### PR TITLE
contracts: proxy: Add UUPS proxy in front of contract logic

### DIFF
--- a/contracts/contract.cairo
+++ b/contracts/contract.cairo
@@ -3,10 +3,43 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
+from openzeppelin.upgrades.library import Proxy
+
+//
+// Storage
+//
+
 // Define a storage variable.
 @storage_var
 func balance() -> (res: felt) {
 }
+
+//
+// Initializer
+//
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    proxy_admin: felt
+) {
+    Proxy.initializer(proxy_admin);
+    return ();
+}
+
+//
+// Upgrades
+//
+@external
+func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    implementation_hash: felt
+) {
+    Proxy.assert_only_admin();
+    Proxy._set_implementation_hash(implementation_hash);
+    return ();
+}
+
+//
+// Setters
+//
 
 // Increases the balance by the given amount.
 @external
@@ -17,6 +50,10 @@ func increase_balance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
     balance.write(res + amount);
     return ();
 }
+
+//
+// Getters
+//
 
 // Returns the current balance.
 @view

--- a/contracts/proxy/Proxy.cairo
+++ b/contracts/proxy/Proxy.cairo
@@ -1,0 +1,5 @@
+%lang starknet
+
+// Import all dependencies from the Proxy template, this will automatically allocate
+// the external methods in the local contract
+from openzeppelin.upgrades.presets.Proxy import constructor, __default__, __l1_default__

--- a/poetry.lock
+++ b/poetry.lock
@@ -1590,6 +1590,24 @@ files = [
 ]
 
 [[package]]
+name = "openzeppelin-cairo-contracts"
+version = "0.5.1"
+description = "Library for secure smart contract development written in Cairo"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "openzeppelin-cairo-contracts-0.5.1.tar.gz", hash = "sha256:886d70a99d43c630cdeeacaa672160d71c34115e2b57efbac02976b5d9791755"},
+    {file = "openzeppelin_cairo_contracts-0.5.1-py3-none-any.whl", hash = "sha256:7510a8b6020d01e6e5c929b341c6befe37a81a546c83c62f6477d0c9d33855ae"},
+]
+
+[package.dependencies]
+importlib-metadata = ">=4.0"
+
+[package.extras]
+testing = ["pytest", "setuptools", "tox"]
+
+[[package]]
 name = "packaging"
 version = "22.0"
 description = "Core utilities for Python packages"
@@ -2374,4 +2392,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.10"
-content-hash = "7252b199951a3676a471222d17ce226b0b17c4f00ef0caea39de902e7ef11424"
+content-hash = "2a7f99eb9ebd752a79d7eee0b2956b19891107069fa107c5180d3700f2c1db01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ openzeppelin-cairo-contracts = "^0.5.1"
 black = "^22.12.0"
 pytest = "^7.2.0"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = ">=3.9,<3.10"
 amarna = "^0.1.5"
 cairo-lang = "^0.10.3"
 cairo-nile = "^0.12.0"
+openzeppelin-cairo-contracts = "^0.5.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+import asyncio
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import asyncio
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def event_loop():
     return asyncio.new_event_loop()

--- a/tests/mocks/Account.cairo
+++ b/tests/mocks/Account.cairo
@@ -1,0 +1,13 @@
+%lang starknet
+
+from openzeppelin.account.presets.Account import (
+    constructor,
+    getPublicKey,
+    supportsInterface,
+    setPublicKey,
+    isValidSignature,
+    __validate__,
+    __validate_declare__,
+    __validate_deploy__,
+    __execute__,
+)

--- a/tests/mocks/ProxyImplementation.cairo
+++ b/tests/mocks/ProxyImplementation.cairo
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin ProxiableImplementation defined here:
+// https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/mocks/ProxiableImplementation.cairo
+// with an additional upgrade method for UUPS proxy implementation
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from openzeppelin.upgrades.library import Proxy
+
+//
+// Storage
+//
+
+@storage_var
+func value() -> (val: felt) {
+}
+
+//
+// Initializer
+//
+
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    proxy_admin: felt
+) {
+    Proxy.initializer(proxy_admin);
+    return ();
+}
+
+//
+// Upgrade
+// 
+
+@external
+func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    implementation_hash: felt
+) {
+    Proxy.assert_only_admin();
+    Proxy._set_implementation_hash(implementation_hash);
+    return ();
+}
+
+
+//
+// Getters
+//
+
+@view
+func getValue{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {
+    return value.read();
+}
+
+@view
+func getAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    admin: felt
+) {
+    return Proxy.get_admin();
+}
+
+//
+// Setters
+//
+
+@external
+func setValue{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    value.write(val);
+    return ();
+}
+
+@external
+func setAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(address: felt) {
+    Proxy.assert_only_admin();
+    Proxy._set_admin(address);
+    return ();
+}

--- a/tests/test_upgades.py
+++ b/tests/test_upgades.py
@@ -1,0 +1,103 @@
+"""
+Tests the upgradeability of the base implementation contracts
+"""
+import os
+
+from typing import Tuple
+
+import asyncio
+import pytest
+
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.contract import StarknetContract
+
+from util import cached_contract, MockSigner
+
+# The path to the mock account contract source code
+ACCOUNT_FILE = os.path.join("tests", "mocks", "Account.cairo")
+# The path to the contract source code
+CONTRACT_FILE = os.path.join("contracts", "contract.cairo")
+# The path to the proxy contract source code
+PROXY_FILE = os.path.join("contracts", "proxy", "Proxy.cairo")
+
+@pytest.fixture(scope='module')
+def private_key() -> int:
+    """
+    A mock public key for the user calling the contracts 
+    """
+    return 12345 # dummy value
+
+@pytest.fixture(scope='module')
+def signer(private_key: int) -> MockSigner:
+    """
+    Constructs a mock transaction signer 
+    """
+    return MockSigner(private_key)
+
+@pytest.fixture(scope='module')
+async def starknet_state() -> Starknet:
+    """
+    Bootstrap the StarkNet mock network
+
+    For now this just creates the network with no special setup
+    """
+    return await Starknet.empty()
+
+@pytest.fixture(scope='module')
+async def admin_account(signer: MockSigner, starknet_state: Starknet) -> StarknetContract:
+    """
+    Deploys an admin account that can be used for proxy admin ops 
+    """
+    # Rebind inputs to their completed futures
+    return await starknet_state.deploy(
+        source = ACCOUNT_FILE,
+        constructor_calldata=[signer.public_key]
+    )
+
+@pytest.fixture(scope='module')
+async def proxy_deploy(admin_account: StarknetContract, starknet_state: Starknet) -> StarknetContract:
+    """
+    Setup the proxy contract with an implementation contract behind it
+    """
+    # Declare the contract class for the implementation contract
+    declare_class = await starknet_state.declare(
+        source=CONTRACT_FILE 
+    )
+
+    initializer_params = [admin_account.contract_address]
+    proxy_calldata = [
+        declare_class.class_hash,
+        get_selector_from_name('initializer'),
+        len(initializer_params),
+        *initializer_params
+    ]
+
+    proxy_contract = await starknet_state.deploy(
+        source=PROXY_FILE,
+        constructor_calldata=proxy_calldata
+    )
+
+    return admin_account, proxy_contract
+
+@pytest.mark.asyncio
+async def test_upgrade(signer: MockSigner, proxy_deploy: Tuple[StarknetContract]):
+    """
+    Tests that upgrading from the base implementation contract and back
+    works properly
+    """
+    # Rebind inputs to their completed futures
+    admin_contract, proxy_contract = proxy_deploy
+
+    print(f"Admin account: {admin_contract.contract_address}\n\n\n")
+    print(f"Proxy account: {proxy_contract.contract_address}\n\n\n")
+
+    # Send a transaction to implementation_v0
+    exec_info = await signer.send_transaction(
+        admin_contract, proxy_contract.contract_address, 'get_balance', []
+    )
+    
+    assert exec_info.call_info.retdata[1] == 0
+ 
+
+        

--- a/tests/test_upgades.py
+++ b/tests/test_upgades.py
@@ -10,32 +10,37 @@ import pytest
 
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.testing.starknet import Starknet
-from starkware.starknet.testing.contract import StarknetContract
+from starkware.starknet.testing.contract import DeclaredClass, StarknetContract
 
 from util import cached_contract, MockSigner
 
 # The path to the mock account contract source code
 ACCOUNT_FILE = os.path.join("tests", "mocks", "Account.cairo")
+# The path to the alternative, proxiable implementation with a dummy interface
+ALTERNATIVE_IMPL_FILE = os.path.join("tests", "mocks", "ProxyImplementation.cairo")
 # The path to the contract source code
 CONTRACT_FILE = os.path.join("contracts", "contract.cairo")
 # The path to the proxy contract source code
 PROXY_FILE = os.path.join("contracts", "proxy", "Proxy.cairo")
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def private_key() -> int:
     """
-    A mock public key for the user calling the contracts 
+    A mock public key for the user calling the contracts
     """
-    return 12345 # dummy value
+    return 12345  # dummy value
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def signer(private_key: int) -> MockSigner:
     """
-    Constructs a mock transaction signer 
+    Constructs a mock transaction signer
     """
     return MockSigner(private_key)
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 async def starknet_state() -> Starknet:
     """
     Bootstrap the StarkNet mock network
@@ -44,60 +49,104 @@ async def starknet_state() -> Starknet:
     """
     return await Starknet.empty()
 
-@pytest.fixture(scope='module')
-async def admin_account(signer: MockSigner, starknet_state: Starknet) -> StarknetContract:
+
+@pytest.fixture(scope="module")
+async def admin_account(
+    signer: MockSigner, starknet_state: Starknet
+) -> StarknetContract:
     """
-    Deploys an admin account that can be used for proxy admin ops 
+    Deploys an admin account that can be used for proxy admin ops
     """
     # Rebind inputs to their completed futures
     return await starknet_state.deploy(
-        source = ACCOUNT_FILE,
-        constructor_calldata=[signer.public_key]
+        source=ACCOUNT_FILE, constructor_calldata=[signer.public_key]
     )
 
-@pytest.fixture(scope='module')
-async def proxy_deploy(admin_account: StarknetContract, starknet_state: Starknet) -> StarknetContract:
+
+@pytest.fixture(scope="module")
+async def alternative_impl_contract_class(starknet_state: Starknet) -> int:
+    """
+    Declares the alternative implementation and returns its class hash
+    """
+    return await starknet_state.declare(source=ALTERNATIVE_IMPL_FILE)
+
+
+@pytest.fixture(scope="module")
+async def proxy_deploy(
+    admin_account: StarknetContract, starknet_state: Starknet
+) -> StarknetContract:
     """
     Setup the proxy contract with an implementation contract behind it
     """
     # Declare the contract class for the implementation contract
-    declare_class = await starknet_state.declare(
-        source=CONTRACT_FILE 
-    )
+    declare_class = await starknet_state.declare(source=CONTRACT_FILE)
 
     initializer_params = [admin_account.contract_address]
     proxy_calldata = [
         declare_class.class_hash,
-        get_selector_from_name('initializer'),
+        get_selector_from_name("initializer"),
         len(initializer_params),
-        *initializer_params
+        *initializer_params,
     ]
 
     proxy_contract = await starknet_state.deploy(
-        source=PROXY_FILE,
-        constructor_calldata=proxy_calldata
+        source=PROXY_FILE, constructor_calldata=proxy_calldata
     )
 
-    return admin_account, proxy_contract
+    return admin_account, proxy_contract, declare_class
+
 
 @pytest.mark.asyncio
-async def test_upgrade(signer: MockSigner, proxy_deploy: Tuple[StarknetContract]):
+async def test_upgrade(
+    signer: MockSigner,
+    proxy_deploy: Tuple[StarknetContract],
+    alternative_impl_contract_class: DeclaredClass,
+):
     """
     Tests that upgrading from the base implementation contract and back
     works properly
     """
     # Rebind inputs to their completed futures
-    admin_contract, proxy_contract = proxy_deploy
+    admin_contract, proxy_contract, impl_class = proxy_deploy
 
-    print(f"Admin account: {admin_contract.contract_address}\n\n\n")
-    print(f"Proxy account: {proxy_contract.contract_address}\n\n\n")
-
-    # Send a transaction to implementation_v0
-    exec_info = await signer.send_transaction(
-        admin_contract, proxy_contract.contract_address, 'get_balance', []
+    # Send a transaction to implementation_v0, increase the balance, fetch the balance, assert
+    # the correctness
+    await signer.send_transaction(
+        admin_contract, proxy_contract.contract_address, "increase_balance", [20]
     )
-    
-    assert exec_info.call_info.retdata[1] == 0
- 
+    exec_info = await signer.send_transaction(
+        admin_contract, proxy_contract.contract_address, "get_balance", []
+    )
 
-        
+    assert exec_info.call_info.retdata[1] == 20
+
+    # Redirect the proxy to the alternative implementation
+    await signer.send_transaction(
+        admin_contract,
+        proxy_contract.contract_address,
+        "upgrade",
+        [alternative_impl_contract_class.class_hash],
+    )
+
+    # Set the value, get the value, assert correctness
+    await signer.send_transaction(
+        admin_contract, proxy_contract.contract_address, "setValue", [30]
+    )
+    exec_info = await signer.send_transaction(
+        admin_contract, proxy_contract.contract_address, "getValue", []
+    )
+
+    assert exec_info.call_info.retdata[1] == 30
+
+    # Redirect the proxy back to the original implementation and check the stored value
+    await signer.send_transaction(
+        admin_contract,
+        proxy_contract.contract_address,
+        "upgrade",
+        [impl_class.class_hash],
+    )
+
+    exec_info = await signer.send_transaction(
+        admin_contract, proxy_contract.contract_address, "get_balance", []
+    )
+    assert exec_info.call_info.retdata[1] == 20

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,7 @@
+"""
+From OpenZeppelin testing utils:
+https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/utils.py
+"""
 import os
 
 from typing import Tuple
@@ -5,20 +9,34 @@ from pathlib import Path
 
 from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
 from starkware.starknet.business_logic.execution.objects import OrderedEvent
-from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
+from starkware.starknet.business_logic.transaction.objects import (
+    InternalTransaction,
+    InternalDeclare,
+    TransactionExecutionInfo,
+)
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starknet.core.os.class_hash import compute_class_hash
-from starkware.starknet.core.os.transaction_hash.transaction_hash import TransactionHashPrefix
+from starkware.starknet.core.os.transaction_hash.transaction_hash import (
+    TransactionHashPrefix,
+)
 from starkware.starknet.core.os.contract_address.contract_address import (
     calculate_contract_address_from_hash,
 )
 from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.public.abi import get_selector_from_name
-from starkware.starknet.services.api.gateway.transaction import InvokeFunction, DeployAccount
+from starkware.starknet.services.api.gateway.transaction import (
+    InvokeFunction,
+    DeployAccount,
+)
 from starkware.starknet.testing.starknet import StarknetContract
 from starkware.starknet.testing.starknet import Starknet
 
-from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
+from nile.signer import (
+    Signer,
+    from_call_to_call_array,
+    get_transaction_hash,
+    TRANSACTION_VERSION,
+)
 from nile.utils import to_uint
 
 """
@@ -30,7 +48,7 @@ INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])
 ZERO_ADDRESS = 0
 TRUE = 1
 FALSE = 0
-IACCOUNT_ID = 0xa66bd575
+IACCOUNT_ID = 0xA66BD575
 
 _root = Path(__file__).parent.parent
 
@@ -39,14 +57,16 @@ Setup Utils from Openzeppelin's test utils:
 https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/utils.py
 """
 
+
 def get_cairo_path():
-    CAIRO_PATH = os.getenv('CAIRO_PATH')
+    CAIRO_PATH = os.getenv("CAIRO_PATH")
     cairo_path = []
 
     if CAIRO_PATH is not None:
         cairo_path = [p for p in CAIRO_PATH.split(":")]
 
     return cairo_path
+
 
 def contract_path(name):
     if name.startswith("tests/"):
@@ -104,9 +124,7 @@ def get_contract_class(contract, is_path=False):
         path = _get_path_from_name(contract)
 
     contract_class = compile_starknet_files(
-        files=[path],
-        debug_info=True,
-        cairo_path=get_cairo_path()
+        files=[path], debug_info=True, cairo_path=get_cairo_path()
     )
     return contract_class
 
@@ -123,7 +141,7 @@ def cached_contract(state, _class, deployed):
         state=state,
         abi=_class.abi,
         contract_address=deployed.contract_address,
-        deploy_call_info=deployed.deploy_call_info
+        deploy_call_info=deployed.deploy_call_info,
     )
     return contract
 
@@ -133,16 +151,17 @@ Signers from Openzeppelin's test util Signers:
 https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/signers.py
 """
 
-class BaseSigner():
-    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
-        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
+
+class BaseSigner:
+    async def send_transaction(
+        self, account, to, selector_name, calldata, nonce=None, max_fee=0
+    ):
+        return await self.send_transactions(
+            account, [(to, selector_name, calldata)], nonce, max_fee
+        )
 
     async def send_transactions(
-        self,
-        account,
-        calls,
-        nonce=None,
-        max_fee=0
+        self, account, calls, nonce=None, max_fee=0
     ) -> TransactionExecutionInfo:
         raw_invocation = get_raw_invoke(account, calls)
         state = raw_invocation.state
@@ -188,7 +207,9 @@ class BaseSigner():
         state = account.state
 
         if nonce is None:
-            nonce = await state.state.get_nonce_at(contract_address=account.contract_address)
+            nonce = await state.state.get_nonce_at(
+                contract_address=account.contract_address
+            )
 
         contract_class = get_contract_class(contract_name)
         class_hash = get_class_hash(contract_name)
@@ -200,7 +221,7 @@ class BaseSigner():
             nonce=nonce,
             version=TRANSACTION_VERSION,
             max_fee=max_fee,
-            chain_id=StarknetChainId.TESTNET.value
+            chain_id=StarknetChainId.TESTNET.value,
         )
 
         signature = self.sign(transaction_hash)
@@ -218,8 +239,7 @@ class BaseSigner():
         execution_info = await state.execute_tx(tx=tx)
 
         await state.state.set_contract_class(
-            class_hash=tx.class_hash,
-            contract_class=contract_class
+            class_hash=tx.class_hash, contract_class=contract_class
         )
         return class_hash, execution_info
 
@@ -235,7 +255,7 @@ class BaseSigner():
             salt=salt,
             class_hash=self.class_hash,
             constructor_calldata=calldata,
-            deployer_address=0
+            deployer_address=0,
         )
 
         transaction_hash = get_transaction_hash(
@@ -245,7 +265,7 @@ class BaseSigner():
             nonce=nonce,
             version=TRANSACTION_VERSION,
             max_fee=max_fee,
-            chain_id=StarknetChainId.TESTNET.value
+            chain_id=StarknetChainId.TESTNET.value,
         )
 
         signature = self.sign(transaction_hash)
@@ -266,6 +286,7 @@ class BaseSigner():
 
         execution_info = await state.execute_tx(tx=tx)
         return execution_info
+
 
 class MockSigner(BaseSigner):
     """
@@ -298,6 +319,7 @@ class MockSigner(BaseSigner):
         )
 
     """
+
     def __init__(self, private_key):
         self.signer = Signer(private_key)
         self.public_key = self.signer.public_key

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,316 @@
+import os
+
+from typing import Tuple
+from pathlib import Path
+
+from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
+from starkware.starknet.business_logic.execution.objects import OrderedEvent
+from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.core.os.class_hash import compute_class_hash
+from starkware.starknet.core.os.transaction_hash.transaction_hash import TransactionHashPrefix
+from starkware.starknet.core.os.contract_address.contract_address import (
+    calculate_contract_address_from_hash,
+)
+from starkware.starknet.definitions.general_config import StarknetChainId
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.services.api.gateway.transaction import InvokeFunction, DeployAccount
+from starkware.starknet.testing.starknet import StarknetContract
+from starkware.starknet.testing.starknet import Starknet
+
+from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
+from nile.utils import to_uint
+
+"""
+Constants
+"""
+
+MAX_UINT256 = (2**128 - 1, 2**128 - 1)
+INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])
+ZERO_ADDRESS = 0
+TRUE = 1
+FALSE = 0
+IACCOUNT_ID = 0xa66bd575
+
+_root = Path(__file__).parent.parent
+
+"""
+Setup Utils from Openzeppelin's test utils:
+https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/utils.py
+"""
+
+def get_cairo_path():
+    CAIRO_PATH = os.getenv('CAIRO_PATH')
+    cairo_path = []
+
+    if CAIRO_PATH is not None:
+        cairo_path = [p for p in CAIRO_PATH.split(":")]
+
+    return cairo_path
+
+def contract_path(name):
+    if name.startswith("tests/"):
+        return str(_root / name)
+    else:
+        return str(_root / "src" / name)
+
+
+def assert_event_emitted(tx_exec_info, from_address, name, data, order=0):
+    """Assert one single event is fired with correct data."""
+    assert_events_emitted(tx_exec_info, [(order, from_address, name, data)])
+
+
+def assert_events_emitted(tx_exec_info, events):
+    """Assert events are fired with correct data."""
+    for event in events:
+        order, from_address, name, data = event
+        event_obj = OrderedEvent(
+            order=order,
+            keys=[get_selector_from_name(name)],
+            data=data,
+        )
+
+        base = tx_exec_info.call_info.internal_calls[0]
+        if event_obj in base.events and from_address == base.contract_address:
+            return
+
+        try:
+            base2 = base.internal_calls[0]
+            if event_obj in base2.events and from_address == base2.contract_address:
+                return
+        except IndexError:
+            pass
+
+        raise BaseException("Event not fired or not fired correctly")
+
+
+def _get_path_from_name(name):
+    """Return the contract path by contract name."""
+    dirs = ["contracts", "tests/mocks"]
+    for dir in dirs:
+        for (dirpath, _, filenames) in os.walk(dir):
+            for file in filenames:
+                if file == f"{name}.cairo":
+                    return os.path.join(dirpath, file)
+
+    raise FileNotFoundError(f"Cannot find '{name}'.")
+
+
+def get_contract_class(contract, is_path=False):
+    """Return the contract class from the contract name or path"""
+    if is_path:
+        path = contract_path(contract)
+    else:
+        path = _get_path_from_name(contract)
+
+    contract_class = compile_starknet_files(
+        files=[path],
+        debug_info=True,
+        cairo_path=get_cairo_path()
+    )
+    return contract_class
+
+
+def get_class_hash(contract_name, is_path=False):
+    """Return the class_hash for a given contract."""
+    contract_class = get_contract_class(contract_name, is_path)
+    return compute_class_hash(contract_class=contract_class, hash_func=pedersen_hash)
+
+
+def cached_contract(state, _class, deployed):
+    """Return the cached contract"""
+    contract = StarknetContract(
+        state=state,
+        abi=_class.abi,
+        contract_address=deployed.contract_address,
+        deploy_call_info=deployed.deploy_call_info
+    )
+    return contract
+
+
+"""
+Signers from Openzeppelin's test util Signers:
+https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/signers.py
+"""
+
+class BaseSigner():
+    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
+        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
+
+    async def send_transactions(
+        self,
+        account,
+        calls,
+        nonce=None,
+        max_fee=0
+    ) -> TransactionExecutionInfo:
+        raw_invocation = get_raw_invoke(account, calls)
+        state = raw_invocation.state
+
+        if nonce is None:
+            nonce = await state.state.get_nonce_at(account.contract_address)
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.INVOKE,
+            account=account.contract_address,
+            calldata=raw_invocation.calldata,
+            version=TRANSACTION_VERSION,
+            chain_id=StarknetChainId.TESTNET.value,
+            nonce=nonce,
+            max_fee=max_fee,
+        )
+
+        signature = self.sign(transaction_hash)
+
+        external_tx = InvokeFunction(
+            contract_address=account.contract_address,
+            calldata=raw_invocation.calldata,
+            entry_point_selector=None,
+            signature=signature,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+        )
+
+        tx = InternalTransaction.from_external(
+            external_tx=external_tx, general_config=state.general_config
+        )
+        execution_info = await state.execute_tx(tx=tx)
+        return execution_info
+
+    async def declare_class(
+        self,
+        account,
+        contract_name,
+        nonce=None,
+        max_fee=0,
+    ) -> Tuple[int, TransactionExecutionInfo]:
+        state = account.state
+
+        if nonce is None:
+            nonce = await state.state.get_nonce_at(contract_address=account.contract_address)
+
+        contract_class = get_contract_class(contract_name)
+        class_hash = get_class_hash(contract_name)
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.DECLARE,
+            account=account.contract_address,
+            calldata=[class_hash],
+            nonce=nonce,
+            version=TRANSACTION_VERSION,
+            max_fee=max_fee,
+            chain_id=StarknetChainId.TESTNET.value
+        )
+
+        signature = self.sign(transaction_hash)
+
+        tx = InternalDeclare.create(
+            sender_address=account.contract_address,
+            contract_class=contract_class,
+            chain_id=StarknetChainId.TESTNET.value,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+            signature=signature,
+        )
+
+        execution_info = await state.execute_tx(tx=tx)
+
+        await state.state.set_contract_class(
+            class_hash=tx.class_hash,
+            contract_class=contract_class
+        )
+        return class_hash, execution_info
+
+    async def deploy_account(
+        self,
+        state,
+        calldata,
+        salt=0,
+        nonce=0,
+        max_fee=0,
+    ) -> TransactionExecutionInfo:
+        account_address = calculate_contract_address_from_hash(
+            salt=salt,
+            class_hash=self.class_hash,
+            constructor_calldata=calldata,
+            deployer_address=0
+        )
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.DEPLOY_ACCOUNT,
+            account=account_address,
+            calldata=[self.class_hash, salt, *calldata],
+            nonce=nonce,
+            version=TRANSACTION_VERSION,
+            max_fee=max_fee,
+            chain_id=StarknetChainId.TESTNET.value
+        )
+
+        signature = self.sign(transaction_hash)
+
+        external_tx = DeployAccount(
+            class_hash=self.class_hash,
+            contract_address_salt=salt,
+            constructor_calldata=calldata,
+            signature=signature,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+        )
+
+        tx = InternalTransaction.from_external(
+            external_tx=external_tx, general_config=state.general_config
+        )
+
+        execution_info = await state.execute_tx(tx=tx)
+        return execution_info
+
+class MockSigner(BaseSigner):
+    """
+    Utility for sending signed transactions to an Account on Starknet.
+
+    Parameters
+    ----------
+
+    private_key : int
+
+    Examples
+    ---------
+    Constructing a MockSigner object
+
+    >>> signer = MockSigner(1234)
+
+    Sending a transaction
+
+    >>> await signer.send_transaction(
+            account, contract_address, 'contract_method', [arg_1]
+        )
+
+    Sending multiple transactions
+
+    >>> await signer.send_transactions(
+            account, [
+                (contract_address, 'contract_method', [arg_1]),
+                (contract_address, 'another_method', [arg_1, arg_2])
+            ]
+        )
+
+    """
+    def __init__(self, private_key):
+        self.signer = Signer(private_key)
+        self.public_key = self.signer.public_key
+        self.class_hash = get_class_hash("Account")
+
+    def sign(self, transaction_hash):
+        sig_r, sig_s = self.signer.sign(transaction_hash)
+        return [sig_r, sig_s]
+
+
+def get_raw_invoke(sender: StarknetContract, calls):
+    """Return raw invoke, remove when test framework supports `invoke`."""
+    print(f"type(sender) = {type(sender)}")
+    call_array, calldata = from_call_to_call_array(calls)
+    raw_invocation = sender.__execute__(call_array, calldata)
+    return raw_invocation


### PR DESCRIPTION
### Purpose
This PR has two purposes:
1. Setup a UUPS proxy in front of the contract to give us upgradability.
2. Setup a unit testing framework for the contracts which allows transactions to be executed behind a proxy. This involves modifying some of the OpenZeppelin testing utils to fit our use case [[their repo](https://github.com/OpenZeppelin/cairo-contracts)]

### Testing
- Unit tests pass