### PR TITLE
contracts: nullifier: Add nullifier set implementation and tests

### DIFF
--- a/contracts/merkle/Merkle.cairo
+++ b/contracts/merkle/Merkle.cairo
@@ -1,4 +1,3 @@
-// This contract is implemented as a
 %lang starknet
 
 from openzeppelin.security.initializable.library import Initializable

--- a/contracts/nullifier/NullifierSet.cairo
+++ b/contracts/nullifier/NullifierSet.cairo
@@ -1,0 +1,65 @@
+// Groups logic for the nullifier set which is used to decouple
+// Merkle tree insertion transactions from updates to the Merkle
+// leaves; preseving privacy
+%lang starknet
+
+from openzeppelin.security.initializable.library import Initializable
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_equal
+
+//
+// Storage
+//
+
+// Stores the nullifier set as a mapping from nullifier to
+// a value -- 1 if the nullifier is present, 0 otherwise
+@storage_var
+func Nullifier_spent_set(nullifier: felt) -> (present: felt) {
+}
+
+//
+// Constructor
+//
+
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    // Call the initializable guard; ensures that the tree is only initialized once
+    Initializable.initialize();
+    return ();
+}
+
+//
+// Getters
+//
+
+// @notice returns whether the given nullifier has already be used in a previous transaction
+// @param nullifier the nullifier value to check
+// @return a boolean indicating whether the nullifier is spent already (encoded as felt)
+@view
+func is_nullifier_used{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    nullifier: felt
+) -> (res: felt) {
+    let (res) = Nullifier_spent_set.read(nullifier=nullifier);
+    return (res=res);
+}
+
+//
+// Setters
+//
+
+// @notice marks the given nullifier as used, asserts that it has not already been used
+// @param nullifier the nullifier value to mark as used
+@external
+func mark_nullifier_used{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    nullifier: felt
+) {
+    with_attr error_message("nullifier already used {nullifier}") {
+        let (res) = Nullifier_spent_set.read(nullifier=nullifier);
+        assert_not_equal(res, 1);
+    }
+
+    // Add to set
+    Nullifier_spent_set.write(nullifier=nullifier, value=1);
+    return ();
+}

--- a/tests/test_nullifier.py
+++ b/tests/test_nullifier.py
@@ -1,0 +1,92 @@
+"""
+Groups tests for the nullifier set
+"""
+
+import os
+import pytest
+import random
+
+from nile.utils import assert_revert
+
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.contract import StarknetContract
+
+# The path to the nullifer set contract file
+NULLIFIER_CONTRACT_PATH = os.path.join("contracts", "nullifier", "NullifierSet.cairo")
+# The number of bits that can be stored in a Starkware felt
+STARKWARE_FELT_BITS = 251
+
+
+@pytest.fixture(scope="function")
+async def nullifier_contract(starknet_state: Starknet) -> StarknetContract:
+    """
+    Deploys the nullifier set contract and returns a reference
+    """
+    nullifier_contract = await starknet_state.deploy(source=NULLIFIER_CONTRACT_PATH)
+    await nullifier_contract.initializer().execute()
+
+    return nullifier_contract
+
+
+class TestNullifier:
+    """
+    Groups tests for the nullifier set
+    """
+
+    @pytest.mark.asyncio
+    async def test_double_initialize(self, nullifier_contract: StarknetContract):
+        """
+        Tests that initializing twice fails
+        """
+        # The `merkle_contract` fixture has already initialized the contract,
+        # call the `merkle_contract.intializer` method again and expect an error
+        await assert_revert(
+            nullifier_contract.initializer().execute(),
+            reverted_with="Initializable: contract already initialized",
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_nullifiers(self, nullifier_contract: StarknetContract):
+        """
+        Tests that a series of nullifiers used without conflict are valid
+        """
+        n_nullifiers = 20
+        for _ in range(n_nullifiers):
+            nullifier = random.getrandbits(STARKWARE_FELT_BITS)
+
+            # Check used via call
+            exec_info = await nullifier_contract.is_nullifier_used(
+                nullifier=nullifier
+            ).call()
+            assert exec_info.result == (0,)
+
+            # Spend the nullifier
+            await nullifier_contract.mark_nullifier_used(nullifier=nullifier).execute()
+
+    @pytest.mark.asyncio
+    async def test_invalid_nullifier(self, nullifier_contract: StarknetContract):
+        """
+        Tests that using a nullifier twice will fail
+        """
+        nullifier = random.getrandbits(STARKWARE_FELT_BITS)
+
+        # Check unused
+        exec_info = await nullifier_contract.is_nullifier_used(
+            nullifier=nullifier
+        ).call()
+        assert exec_info.result == (0,)
+
+        # Use the nullifier
+        await nullifier_contract.mark_nullifier_used(nullifier=nullifier).execute()
+
+        # Check used
+        exec_info = await nullifier_contract.is_nullifier_used(
+            nullifier=nullifier
+        ).call()
+        assert exec_info.result == (1,)
+
+        # Attempt to double spend, ensure that the contract errors
+        await assert_revert(
+            nullifier_contract.mark_nullifier_used(nullifier=nullifier).execute(),
+            "nullifier already used",
+        )


### PR DESCRIPTION
### Purpose
The nullifier set is used to decouple Merkle insertion transactions from their subsequent updates, preserving privacy. This is done by assigning a unique nullifier to each Merkle leaf which is proven valid in zero-knowledge upon insertion/update. That way, we can update a Merkle state entry passing only the nullifier (not the leaf value); and the contract will enforce that it is never used twice.

Note that this will not be deployed as a separate contract, but used via library calls. It is written as a separate contract to ease testing.

### Testing
- Unit tests pass
- Tested nullifier functionality