### PR TITLE
contracts: darkpool: Add initial `match` implementation

### DIFF
--- a/contracts/darkpool/Darkpool.cairo
+++ b/contracts/darkpool/Darkpool.cairo
@@ -101,3 +101,32 @@ func update_wallet{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
     );
     return (new_root=new_root);
 }
+
+// @notice encumber two wallets by submitting a successfully completed match to the contract
+// @param match_nullifier1 the wallet match nullifier of the first wallet
+// @param match_nullifier2 the wallet match nullifier of the second wallet
+// @param note1_ciphertext_len the number of felts in the first encrypted note
+// @param note1_ciphertext the first note, encrypted under the first party's key
+// @param note2_ciphertext_len the number of felts in the second encrypted note
+// @param note2_ciphertext the second note, encrypted under the second party's key
+// @return the new root after inserting the notes into the commitment tree
+@external
+func match{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    match_nullifier1: felt,
+    match_nullifier2: felt,
+    note1_ciphertext_len: felt,
+    note1_ciphertext: felt*,
+    note2_ciphertext_len: felt,
+    note2_ciphertext: felt*,
+) -> (new_root: felt) {
+    let (new_root) = Darkpool.process_match(
+        match_nullifier1=match_nullifier1,
+        match_nullifier2=match_nullifier2,
+        note1_ciphertext_len=note1_ciphertext_len,
+        note1_ciphertext=note1_ciphertext,
+        note2_ciphertext_len=note2_ciphertext_len,
+        note2_ciphertext=note2_ciphertext,
+    );
+
+    return (new_root=new_root);
+}

--- a/tests/merkle.py
+++ b/tests/merkle.py
@@ -1,0 +1,149 @@
+"""
+An implementation of a merkle tree for testing
+"""
+import pytest
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import DefaultDict, List
+
+from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
+
+#############
+# Constants #
+#############
+
+# The value on an empty leaf in the Merkle tree, defined to be keccak256('renegade')
+# taken modulo the Cairo field
+EMPTY_LEAF_VAL = (
+    306932273398430716639340090025251549301604242969558673011416862133942957551
+)
+
+###############
+# Merkle Tree #
+###############
+
+
+@dataclass(frozen=True, eq=True)
+class MerkleNodeKey:
+    """
+    A key into the default dict
+    """
+
+    # The height in the Merkle tree that this node occurs at
+    # height 0 is the root
+    height: int
+    # The index of the node in the list of nodes at the given height
+    # the leftmost node is at index 0
+    index: int
+
+
+class MerkleTree:
+    """
+    A simple implementation of a Merkle tree for testing using the
+    StarkNet pedersen hash. Implemented sparsely
+    """
+
+    # The height of the tree
+    height: int
+    # A sparse representation of the entires in the tree
+    merkle_entries: DefaultDict[MerkleNodeKey, int]
+    # The next leaf index that is unoccupied
+    next_leaf: int
+    # The current root of the tree
+    root: int
+    # The zero value of each tree
+    zeros: List[int]
+
+    def __init__(self, height: int):
+        """
+        Initializes the Merkle tree
+        """
+        self.height = height
+        self.next_leaf = 0
+        self.zeros = []
+        self.merkle_entries = dict()
+        self.root = self._initailize_zeros()
+
+    def _initailize_zeros(self) -> int:
+        """
+        Setup the zero values at each level of the tree
+
+        :return: The root of the empty tree
+        """
+        current_empty_value = EMPTY_LEAF_VAL
+        for _ in range(self.height):
+            # Append and hash with self to get the empty value for the next level in the tree
+            self.zeros.append(current_empty_value)
+            current_empty_value = pedersen_hash(
+                current_empty_value, current_empty_value
+            )
+
+        # Reverse the zeros list so that index 0 is the root
+        self.zeros.reverse()
+        return current_empty_value
+
+    def from_leaf_data(height: int, leaves: List[int]):
+        """
+        Construct a Merkle tree with a given set of leaves to begin
+        """
+        tree = MerkleTree(height)
+        for leaf in leaves:
+            tree.insert(leaf)
+
+        return tree
+
+    def get_root(self) -> int:
+        """
+        Returns the current root of the Merkle tree
+        """
+        return self.root
+
+    def insert(self, value: int) -> int:
+        """
+        Insert a value into the tree, returns the root
+        """
+        assert self.next_leaf < 2**self.height, "tree full"
+
+        # Compute a new root and update the index
+        new_root = self._insert_impl(value, self.next_leaf, self.height)
+        self.root = new_root
+        self.next_leaf += 1
+
+        return new_root
+
+    def _insert_impl(self, value: int, index: int, height: int) -> int:
+        """
+        Insert a value into the tree recursively
+
+        :param value: The value to insert into the tree
+        :param index: The index in the current height to insert at
+        :param height: The current height of the recursion in the tree
+
+        :return: The new root after insertion
+        """
+        if height == 0:
+            return value
+
+        # Insert the value into the sparse storage
+        self.merkle_entries[MerkleNodeKey(height, index)] = value
+
+        # Select the index of the neighbor to hash with, if the current insertion
+        # index is 0 (mod 2) then it is a left hand node, otherwise it is a right
+        # hand node
+        neighbor_index = index + 1 if index % 2 == 0 else index - 1
+        neighbor = self.merkle_entries.get(
+            MerkleNodeKey(height, neighbor_index),
+            self.zeros[height - 1],
+        )
+
+        next_value = (
+            pedersen_hash(value, neighbor)
+            if index % 2 == 0
+            else pedersen_hash(neighbor, value)
+        )
+
+        # Compute the index of the parent node in the tree
+        parent_index = index // 2
+
+        return self._insert_impl(next_value, parent_index, height - 1)

--- a/tests/test_darkpool.py
+++ b/tests/test_darkpool.py
@@ -11,8 +11,8 @@ from starkware.starknet.testing.contract import DeclaredClass, StarknetContract
 
 from nile.utils import assert_revert, str_to_felt, to_uint
 
+from merkle import MerkleTree
 from util import random_felt, MockSigner
-from test_merkle import empty_merkle_tree_root
 
 #############
 # Constants #
@@ -150,10 +150,10 @@ class TestProxy:
         exec_info = await signer.send_transaction(
             admin_account, proxy_deploy.contract_address, "get_root", []
         )
-        assert exec_info.call_info.retdata[1] == empty_merkle_tree_root(
-            MERKLE_TREE_HEIGHT
+        assert (
+            exec_info.call_info.retdata[1]
+            == MerkleTree(height=MERKLE_TREE_HEIGHT).get_root()
         )
-
         # Redirect the proxy to the alternative implementation
         await signer.send_transaction(
             admin_account,
@@ -183,8 +183,9 @@ class TestProxy:
         exec_info = await signer.send_transaction(
             admin_account, proxy_deploy.contract_address, "get_root", []
         )
-        assert exec_info.call_info.retdata[1] == empty_merkle_tree_root(
-            MERKLE_TREE_HEIGHT
+        assert (
+            exec_info.call_info.retdata[1]
+            == MerkleTree(height=MERKLE_TREE_HEIGHT).get_root()
         )
 
 
@@ -209,7 +210,7 @@ class TestInitialState:
         Tests the get_root method, after deploy it should be equal to the root of an
         empty Merkle tree
         """
-        expected_root = empty_merkle_tree_root(MERKLE_TREE_HEIGHT)
+        expected_root = MerkleTree(height=MERKLE_TREE_HEIGHT).get_root()
         exec_info = await signer.send_transaction(
             admin_account, proxy_deploy.contract_address, "get_root", []
         )


### PR DESCRIPTION
### Purpose
This PR adds the initial implementation of the `match` external function. The current functionality:
- Updates the Merkle tree to include commitments to the encrypted match notes
- Marks the match nullifiers as used so that the user may not withdraw, match again, etc until settlement. I.e. the wallets are encumbered

Left to do includes validating the construction of the notes, nullifiers, etc via ZKP and validating the execution of the matching engine via ZKP. This functionality will come after the general contract structure is written and we have implemented a Bulletproof verifier in Cairo.

### Testing
- Unit tests pass
- Tested the state updates to the Merkle tree from encrypted note commitments
- Tested that wallets are encumbered; i.e. executed a `match` and then verified that a subsequent withdraw request failed.