### PR TITLE
contracts: darkpool: Implement internal transfers

### DIFF
--- a/contracts/darkpool/Darkpool.cairo
+++ b/contracts/darkpool/Darkpool.cairo
@@ -89,6 +89,8 @@ func update_wallet{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
     commitment: felt,
     match_nullifier: felt,
     spend_nullifier: felt,
+    internal_transfer_ciphertext_len: felt,
+    internal_transfer_ciphertext: felt*,
     external_transfers_len: felt,
     external_transfers: ExternalTransfer*,
 ) -> (new_root: felt) {
@@ -96,6 +98,8 @@ func update_wallet{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
         commitment=commitment,
         match_nullifier=match_nullifier,
         spend_nullifier=spend_nullifier,
+        internal_transfer_ciphertext_len=internal_transfer_ciphertext_len,
+        internal_transfer_ciphertext=internal_transfer_ciphertext,
         external_transfers_len=external_transfers_len,
         external_transfers=external_transfers,
     );

--- a/contracts/darkpool/library.cairo
+++ b/contracts/darkpool/library.cairo
@@ -146,6 +146,8 @@ namespace Darkpool {
         commitment: felt,
         match_nullifier: felt,
         spend_nullifier: felt,
+        internal_transfer_ciphertext_len: felt,
+        internal_transfer_ciphertext: felt*,
         external_transfers_len: felt,
         external_transfers: ExternalTransfer*,
     ) -> (new_root: felt) {
@@ -177,6 +179,17 @@ namespace Darkpool {
             transfers=external_transfers,
         );
 
+        // Process the internal transfer if one exists
+        if (internal_transfer_ciphertext_len == 0) {
+            return (new_root=new_root);
+        }
+
+        let (transfer_commitment) = _hash_array(
+            internal_transfer_ciphertext_len, internal_transfer_ciphertext
+        );
+        let (new_root) = IMerkle.library_call_insert(
+            class_hash=merkle_class, value=transfer_commitment
+        );
         return (new_root=new_root);
     }
 


### PR DESCRIPTION
### Purpose
This PR makes a small modification to `wallet_update` to implement commitments to encrypted internal transfers.

### Testing
- Unit tests pass
- Tested the internal transfer commitment state update