### PR TITLE
contracts: merkle: Use hashset instead of ring buffer for root history

### DIFF
--- a/contracts/darkpool/Darkpool.cairo
+++ b/contracts/darkpool/Darkpool.cairo
@@ -80,6 +80,17 @@ func get_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}()
     return (root=root);
 }
 
+// @notice returns whether the given root is in the history
+// @param the root to check the history for
+// @return 1 if the root is in the history, 0 if it is not
+@view
+func root_in_history{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    root: felt
+) -> (res: felt) {
+    let (res) = Darkpool.root_in_history(root=root);
+    return (res=res);
+}
+
 // @dev returns whether a given nullifier has already been used
 // @return a boolean encoded as a felt -- 1 for true, 0 for false
 @view

--- a/contracts/darkpool/library.cairo
+++ b/contracts/darkpool/library.cairo
@@ -137,8 +137,20 @@ namespace Darkpool {
     ) {
         // Get the implementation class
         let (merkle_class) = Darkpool_merkle_class.read();
-        let (root) = IMerkle.library_call_get_root(class_hash=merkle_class, index=0);
+        let (root) = IMerkle.library_call_get_root(class_hash=merkle_class);
         return (root=root);
+    }
+
+    // @dev returns whether the given root is in the root history
+    // @param root the root to check for in the history
+    // @return 1 if the root is in the history, 0 if it is not
+    func root_in_history{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        root: felt
+    ) -> (res: felt) {
+        // Get the implementation class
+        let (merkle_class) = Darkpool_merkle_class.read();
+        let (res) = IMerkle.library_call_root_in_history(class_hash=merkle_class, root=root);
+        return (res=res);
     }
 
     // @dev returns whether a given nullifier has already been used

--- a/contracts/merkle/IMerkle.cairo
+++ b/contracts/merkle/IMerkle.cairo
@@ -7,7 +7,10 @@ namespace IMerkle {
     func initializer(height: felt) {
     }
 
-    func get_root(index: felt) -> (root: felt) {
+    func get_root() -> (root: felt) {
+    }
+
+    func root_in_history(root: felt) -> (res: felt) {
     }
 
     func insert(value: felt) -> (new_root: felt) {

--- a/contracts/merkle/Merkle.cairo
+++ b/contracts/merkle/Merkle.cairo
@@ -20,12 +20,24 @@ func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 // Getters
 //
 
-@external
-func get_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(index: felt) -> (
-    root: felt
-) {
-    let (root) = Merkle.get_root_in_history(index=index);
+// @notice returns the most recent root in the Merkle history
+// @return the current root
+@view
+func get_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (root: felt) {
+    let (root) = Merkle.current_root();
     return (root=root);
+}
+
+// @notice returns whether a given root is in the Merkle tree's root history, result is
+// 1 if the root *is* in the history, 0 if it *is not* in the history
+// @param root the root to check the history for
+// @return res the result (0 or 1) of the check
+@view
+func root_in_history{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    root: felt
+) -> (res: felt) {
+    let (res) = Merkle.root_in_history(root=root);
+    return (res=res);
 }
 
 //

--- a/tests/test_darkpool.py
+++ b/tests/test_darkpool.py
@@ -211,11 +211,29 @@ class TestInitialState:
         empty Merkle tree
         """
         expected_root = MerkleTree(height=MERKLE_TREE_HEIGHT).get_root()
+
+        # Test the `get_root` view
         exec_info = await signer.send_transaction(
             admin_account, proxy_deploy.contract_address, "get_root", []
         )
-
         assert exec_info.call_info.retdata[1] == expected_root
+
+        # Test the `root_in_history` view
+        exec_info = await signer.send_transaction(
+            admin_account,
+            proxy_deploy.contract_address,
+            "root_in_history",
+            [expected_root],
+        )
+        assert exec_info.call_info.retdata[1] == 1  # true
+
+        exec_info = await signer.send_transaction(
+            admin_account,
+            proxy_deploy.contract_address,
+            "root_in_history",
+            [random_felt()],
+        )
+        assert exec_info.call_info.retdata[1] == 0  # false
 
     @pytest.mark.asyncio
     async def test_is_nullifier_used(


### PR DESCRIPTION
### Purpose
This PR changes the way in which we store Merkle root history. Previously we stored the root history in a capacity-limited ring buffer. This was done to force nodes to improve privacy by re-proving `VALID COMMITMENTS` on fresh roots.

However, it simplifies the scheduling and proving logic on the network side if we simply maintain all historical roots and defer re-proving logic to the network actors themselves.

### Testing
- Unit tests