### PR TITLE
renegade_contracts: utils: add generic utils needed in verification

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,6 +1,8 @@
 // mod nullifier_set;
 // mod merkle;
 // mod darkpool;
+mod utils;
 // mod testing;
 // mod oz;
+
 

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -1,0 +1,8 @@
+//! Common, contract-agnostic utilities
+
+mod math;
+mod storage;
+mod serde;
+mod collections;
+mod eq;
+

--- a/src/utils/collections.cairo
+++ b/src/utils/collections.cairo
@@ -1,0 +1,65 @@
+use option::OptionTrait;
+use array::ArrayTrait;
+use array::SpanTrait;
+
+
+trait DeepSpan<T, TSpan> {
+    fn deep_span(self: @Array<T>) -> Span<TSpan>;
+}
+
+impl ArrayDeepSpanImpl<T> of DeepSpan<T, T> {
+    fn deep_span(self: @Array<T>) -> Span<T> {
+        self.span()
+    }
+}
+
+impl NestedArrayDeepSpanImpl<T> of DeepSpan<Array<T>, Span<T>> {
+    fn deep_span(self: @Array<Array<T>>) -> Span<Span<T>> {
+        let mut spans = ArrayTrait::new();
+        let mut top_span = self.span();
+        loop {
+            match top_span.pop_front() {
+                Option::Some(span) => spans.append(span.deep_span()),
+                Option::None(()) => {
+                    break;
+                },
+            };
+        };
+        spans.span()
+    }
+}
+
+fn fill_felt_arr(ref arr: Array::<felt252>, val: felt252, mut len: usize) {
+    loop {
+        if len == 0 {
+            break;
+        } else {
+            arr.append(val);
+            len -= 1;
+        };
+    }
+}
+
+fn extend<T, impl TDrop: Drop<T>>(ref arr1: Array::<T>, mut arr2: Array::<T>) {
+    match arr2.pop_front() {
+        Option::Some(v) => {
+            arr1.append(v);
+            extend(ref arr1, arr2);
+        },
+        Option::None(()) => (),
+    }
+}
+
+// FORKED FROM ALEXANDRIA, MADE COMPATIBLE W/ V2.0.0-RC2:
+#[generate_trait]
+impl ArrayImpl<T, impl TDrop: Drop<T>> of ArrayTraitExt<T> {
+    fn append_all(ref self: Array<T>, ref arr: Array<T>) {
+        match arr.pop_front() {
+            Option::Some(v) => {
+                self.append(v);
+                self.append_all(ref arr);
+            },
+            Option::None(()) => (),
+        }
+    }
+}

--- a/src/utils/collections.cairo
+++ b/src/utils/collections.cairo
@@ -29,7 +29,7 @@ impl NestedArrayDeepSpanImpl<T> of DeepSpan<Array<T>, Span<T>> {
     }
 }
 
-fn fill_felt_arr(ref arr: Array::<felt252>, val: felt252, mut len: usize) {
+fn tile_felt_arr(ref arr: Array::<felt252>, val: felt252, mut len: usize) {
     loop {
         if len == 0 {
             break;

--- a/src/utils/eq.cairo
+++ b/src/utils/eq.cairo
@@ -1,0 +1,97 @@
+use option::OptionTrait;
+use array::{ArrayTrait, SpanTrait};
+use serde::Serde;
+use ec::EcPoint;
+
+use super::serde::EcPointSerde;
+
+
+impl TupleSize2PartialEq<
+    E0, E1, impl E0PartialEq: PartialEq<E0>, impl E1PartialEq: PartialEq<E1>
+> of PartialEq<(E0, E1)> {
+    fn eq(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
+        let (lhs1, lhs2) = lhs;
+        let (rhs1, rhs2) = rhs;
+        lhs1 == rhs1 && lhs2 == rhs2
+    }
+    fn ne(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
+        !(rhs == lhs)
+    }
+}
+
+impl ArrayTPartialEq<T, impl TPartialEq: PartialEq<T>, impl TDrop: Drop<T>> of PartialEq<Array<T>> {
+    fn eq(lhs: @Array<T>, rhs: @Array<T>) -> bool {
+        let mut lhs_span = Span { snapshot: lhs };
+        let mut rhs_span = Span { snapshot: rhs };
+        @lhs_span == @rhs_span
+    }
+    fn ne(lhs: @Array<T>, rhs: @Array<T>) -> bool {
+        !(lhs == rhs)
+    }
+}
+
+impl SpanTPartialEq<T, impl TPartialEq: PartialEq<T>, impl TDrop: Drop<T>> of PartialEq<Span<T>> {
+    fn eq(lhs: @Span<T>, rhs: @Span<T>) -> bool {
+        let mut lhs_span = *lhs;
+        let mut rhs_span = *rhs;
+        if lhs_span.len() != rhs_span.len() {
+            return false;
+        }
+
+        let mut arr_eq = true;
+        loop {
+            match lhs_span.pop_front() {
+                Option::Some(lhs_i) => {
+                    let rhs_i = rhs_span.pop_front().unwrap();
+                    if lhs_i != rhs_i {
+                        arr_eq = false;
+                        break;
+                    }
+                },
+                Option::None(_) => {
+                    break;
+                }
+            };
+        };
+
+        arr_eq
+    }
+    fn ne(lhs: @Span<T>, rhs: @Span<T>) -> bool {
+        !(lhs == rhs)
+    }
+}
+
+impl EcPointPartialEq of PartialEq<EcPoint> {
+    fn eq(lhs: @EcPoint, rhs: @EcPoint) -> bool {
+        // Serializing EcPoint => obtaining x, y coords (felt252s)
+        // Comparing equality of felt coords is an appropriate notion of equality for EcPoints
+        let mut lhs_ser = ArrayTrait::new();
+        lhs.serialize(ref lhs_ser);
+        let mut rhs_ser = ArrayTrait::new();
+        rhs.serialize(ref rhs_ser);
+
+        lhs_ser == rhs_ser
+    }
+    fn ne(lhs: @EcPoint, rhs: @EcPoint) -> bool {
+        !(lhs == rhs)
+    }
+}
+impl OptionTPartialEq<
+    T, impl TPartialEq: PartialEq<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>
+> of PartialEq<Option<T>> {
+    fn eq(lhs: @Option<T>, rhs: @Option<T>) -> bool {
+        if lhs.is_none() && rhs.is_none() {
+            return true;
+        }
+
+        if lhs.is_some() && rhs.is_some() {
+            return (*lhs).unwrap() == (*rhs).unwrap();
+        }
+
+        return false;
+    }
+    fn ne(lhs: @Option<T>, rhs: @Option<T>) -> bool {
+        !(lhs == rhs)
+    }
+}
+

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -89,3 +89,13 @@ fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
 
     return low;
 }
+
+fn binary_exp(base: felt252, exp: usize) -> felt252 {
+    if exp == 0 {
+        1
+    } else if exp % 2 == 0 {
+        binary_exp(base * base, exp / 2)
+    } else {
+        base * binary_exp(base * base, (exp - 1) / 2)
+    }
+}

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,0 +1,91 @@
+use option::OptionTrait;
+use array::{ArrayTrait, SpanTrait};
+
+
+fn get_consecutive_powers(val: felt252, mut num_powers: usize) -> Array<felt252> {
+    let mut val_powers = ArrayTrait::new();
+    let mut prev_power = 1;
+    loop {
+        if num_powers == 0 {
+            break;
+        }
+
+        let curr_power = prev_power * val;
+        val_powers.append(curr_power);
+        prev_power = curr_power;
+
+        num_powers -= 1;
+    };
+    val_powers
+}
+
+fn dot_product(mut a: Span<felt252>, mut b: Span<felt252>) -> felt252 {
+    assert(a.len() == b.len(), 'vectors must be of equal length');
+    let mut result = 0;
+    loop {
+        match a.pop_front() {
+            Option::Some(a_i) => {
+                let b_i = b.pop_front().unwrap();
+                result += *a_i * *b_i;
+            },
+            Option::None(_) => {
+                break;
+            },
+        };
+    };
+    result
+}
+
+fn elt_wise_mul(mut a: Span<felt252>, mut b: Span<felt252>) -> Array<felt252> {
+    assert(a.len() == b.len(), 'vectors must be of equal length');
+    let mut result = ArrayTrait::new();
+    loop {
+        match a.pop_front() {
+            Option::Some(a_i) => {
+                let b_i = b.pop_front().unwrap();
+                result.append(*a_i * *b_i);
+            },
+            Option::None(_) => {
+                break;
+            },
+        };
+    };
+    result
+}
+
+// FORKED FROM ALEXANDRIA, MADE COMPATIBLE W/ V2.0.0-RC2:
+fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
+    // Return invalid input error
+    if base == 0 {
+        panic_with_felt252('II')
+    }
+
+    if modulus == 1 {
+        return 0;
+    }
+
+    let mut base: u256 = u256 { low: base, high: 0 };
+    let modulus: u256 = u256 { low: modulus, high: 0 };
+    let mut result: u256 = u256 { low: 1, high: 0 };
+
+    let res = loop {
+        if power == 0 {
+            break result;
+        }
+
+        if power % 2 != 0 {
+            result = (result * base) % modulus;
+        }
+
+        base = (base * base) % modulus;
+        power = power / 2;
+    };
+
+    let u256{low: low, high: high } = res;
+
+    if high != 0 {
+        panic_with_felt252('value cant be larger than u128')
+    }
+
+    return low;
+}

--- a/src/utils/serde.cairo
+++ b/src/utils/serde.cairo
@@ -1,0 +1,19 @@
+use serde::Serde;
+use ec::ec_point_new;
+use ec::ec_point_unwrap;
+use ec::ec_point_non_zero;
+
+
+impl EcPointSerde of Serde<EcPoint> {
+    fn serialize(self: @EcPoint, ref output: Array<felt252>) {
+        let (x, y) = ec_point_unwrap(ec_point_non_zero(*self));
+        x.serialize(ref output);
+        y.serialize(ref output);
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<EcPoint> {
+        let x: felt252 = Serde::deserialize(ref serialized)?;
+        let y: felt252 = Serde::deserialize(ref serialized)?;
+        Option::Some(ec_point_new(x, y))
+    }
+}

--- a/src/utils/serde.cairo
+++ b/src/utils/serde.cairo
@@ -1,19 +1,31 @@
 use serde::Serde;
-use ec::ec_point_new;
-use ec::ec_point_unwrap;
-use ec::ec_point_non_zero;
+use zeroable::{IsZeroResult, Zeroable};
+use ec::{ec_point_new, ec_point_unwrap, ec_point_is_zero, ec_point_non_zero, ec_point_zero};
 
 
 impl EcPointSerde of Serde<EcPoint> {
     fn serialize(self: @EcPoint, ref output: Array<felt252>) {
-        let (x, y) = ec_point_unwrap(ec_point_non_zero(*self));
-        x.serialize(ref output);
-        y.serialize(ref output);
+        match ec_point_is_zero(*self) {
+            IsZeroResult::Zero(()) => {
+                // (0, 0) is not an actual point on the STARK curve,
+                // so this is safe
+                0.serialize(ref output);
+                0.serialize(ref output);
+            },
+            IsZeroResult::NonZero(point) => {
+                let (x, y) = ec_point_unwrap(ec_point_non_zero(*self));
+                x.serialize(ref output);
+                y.serialize(ref output);
+            }
+        }
     }
 
     fn deserialize(ref serialized: Span<felt252>) -> Option<EcPoint> {
         let x: felt252 = Serde::deserialize(ref serialized)?;
         let y: felt252 = Serde::deserialize(ref serialized)?;
+        if x.is_zero() && y.is_zero() {
+            return Option::Some(ec_point_zero());
+        }
         Option::Some(ec_point_new(x, y))
     }
 }

--- a/src/utils/storage.cairo
+++ b/src/utils/storage.cairo
@@ -1,0 +1,146 @@
+use traits::{Into, TryInto};
+use option::{OptionTrait, OptionSerde};
+use result::ResultTrait;
+use clone::Clone;
+use array::{ArrayTrait, ArrayTCloneImpl, SpanTrait};
+use serde::Serde;
+use ec::EcPoint;
+use starknet::{
+    StorageAccess, SyscallResult, SyscallResultTrait,
+    storage_access::{
+        StorageBaseAddress, storage_address_from_base, storage_address_from_base_and_offset,
+    },
+    syscalls::{storage_read_syscall, storage_write_syscall}
+};
+
+use super::{collections::{ArrayTraitExt}, serde::EcPointSerde};
+
+
+impl TStorageAccess<
+    T, impl TStorageSerde: StorageSerde<T>, impl TDrop: Drop<T>
+> of StorageAccess<T> {
+    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<T> {
+        TStorageAccess::<T>::read_at_offset_internal(address_domain, base, 0)
+    }
+
+    fn read_at_offset_internal(
+        address_domain: u32, base: StorageBaseAddress, offset: u8
+    ) -> SyscallResult<T> {
+        // Read serialization len, add 1 to account for the len slot
+        let num_slots: u8 = storage_read_syscall(address_domain, storage_address_from_base(base))?
+            .try_into()
+            .expect('Storage - value too large')
+            + 1_u8;
+
+        let mut serialized = ArrayTrait::new();
+        let mut slots_read: u8 = 0;
+        loop {
+            if slots_read == num_slots {
+                break;
+            }
+
+            let address = storage_address_from_base_and_offset(base, offset + slots_read);
+            // Unwrapping here for now since you can't return / use `?` in a loop
+            let felt = storage_read_syscall(address_domain, address).unwrap_syscall();
+            serialized.append(felt);
+            slots_read += 1;
+        };
+        let mut serialized_span = serialized.span();
+
+        // This deserialize expects to pop off the len slot
+        match StorageSerde::<T>::deserialize_storage(ref serialized_span) {
+            Option::Some(val) => Result::Ok(val),
+            Option::None(_) => {
+                let mut data = ArrayTrait::new();
+                data.append('Storage - deser failed');
+                Result::Err(data)
+            },
+        }
+    }
+
+    fn write(address_domain: u32, base: StorageBaseAddress, value: T) -> SyscallResult<()> {
+        TStorageAccess::<T>::write_at_offset_internal(address_domain, base, 0, value)
+    }
+
+    fn write_at_offset_internal(
+        address_domain: u32, base: StorageBaseAddress, offset: u8, value: T
+    ) -> SyscallResult<()> {
+        // Acts as an assertion that serialization len <= 255
+        let mut serialized = ArrayTrait::new();
+        value.serialize_storage(ref serialized);
+        let _len: u8 = (*(@serialized).at(0_usize)).try_into().expect('Storage - value too large');
+
+        let mut slots_written: u8 = 0;
+        loop {
+            match serialized.pop_front() {
+                Option::Some(felt) => {
+                    let address = storage_address_from_base_and_offset(
+                        base, offset + slots_written
+                    );
+                    // Unwrapping here for now since you can't return / use `?` in a loop
+                    storage_write_syscall(address_domain, address, felt).unwrap_syscall();
+                    slots_written += 1;
+                },
+                Option::None(_) => {
+                    break;
+                }
+            };
+        };
+
+        Result::Ok(())
+    }
+
+    fn size_internal(value: T) -> u8 {
+        // TODO: Kinda sucks to do full serialization for this...
+        // should I push a "size" method down to the StorageSerde trait?
+
+        // Acts as an assertion that serialization len <= 255
+        let mut serialized = ArrayTrait::new();
+        value.serialize_storage(ref serialized);
+        (*(@serialized).at(0_usize)).try_into().expect('Storage - value too large')
+    }
+}
+
+// We use this wrapper trait around Serde (which prepends a length to the serialized data)
+// so that we can do a blanket implementation of StorageAccess for types that impl StorageSerde.
+// If we were to do a blanket implementation for types that impl Serde, we'd have conflicting
+// StorageAccess implementations for some types.
+trait StorageSerde<T> {
+    fn serialize_storage(self: @T, ref output: Array<felt252>);
+    fn deserialize_storage(ref serialized: Span<felt252>) -> Option<T>;
+}
+
+fn serialize_storage_generic<T, impl TSerde: Serde<T>>(t: @T, ref output: Array<felt252>) {
+    let mut native_output = ArrayTrait::new();
+    t.serialize(ref native_output);
+    output.append(native_output.len().into());
+    output.append_all(ref native_output);
+}
+
+fn deserialize_storage_generic<T, impl TSerde: Serde<T>>(
+    ref serialized: Span<felt252>
+) -> Option<T> {
+    serialized.pop_front()?;
+    Serde::<T>::deserialize(ref serialized)
+}
+
+impl ArrayStorageSerde<T, impl TSerde: Serde<Array<T>>> of StorageSerde<Array<T>> {
+    fn serialize_storage(self: @Array<T>, ref output: Array<felt252>) {
+        serialize_storage_generic(self, ref output)
+    }
+
+    fn deserialize_storage(ref serialized: Span<felt252>) -> Option<Array<T>> {
+        deserialize_storage_generic(ref serialized)
+    }
+}
+
+impl EcPointStorageSerde of StorageSerde<EcPoint> {
+    fn serialize_storage(self: @EcPoint, ref output: Array<felt252>) {
+        serialize_storage_generic(self, ref output)
+    }
+
+    fn deserialize_storage(ref serialized: Span<felt252>) -> Option<EcPoint> {
+        deserialize_storage_generic(ref serialized)
+    }
+}
+


### PR DESCRIPTION
This PR introduces some of the utilities needed in queueing a verification job.

I decided to put these in a top-level `utils` module since they are generic/agnostic of any verifier types, and I will later refactor the existing contracts to use them where necessary.

Expect CI to be red as it has not been upgraded to target `v2.0.0-rc2` of the Cairo compiler.

Although it's not in this PR for brevity, these utils have seen basic testing in the `initialize` and `queue_verification_job` tests for the verifier (coming soon to a PR near you).