### PR TITLE
renegade_contracts: verifier: impl initialize fn

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,7 +3,7 @@
 // mod darkpool;
 mod verifier;
 mod utils;
-// mod testing;
+mod testing;
 // mod oz;
 
 

--- a/src/testing.cairo
+++ b/src/testing.cairo
@@ -1,4 +1,4 @@
 mod test_utils;
-mod test_contracts;
+// mod test_contracts;
 #[cfg(test)]
 mod tests;

--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -1,12 +1,15 @@
-use option::OptionTrait;
 use array::ArrayTrait;
+use serde::Serde;
+use option::OptionTrait;
 
-fn serialized_element<T, impl TSerde: serde::Serde::<T>>(value: T) -> Span::<felt252> {
-    let mut arr = ArrayTrait::new();
-    serde::Serde::serialize(ref arr, value);
+fn serialized_element<T, impl TSerde: Serde<T>, impl TDestruct: Destruct<T>>(
+    value: T
+) -> Span<felt252> {
+    let mut arr = Default::default();
+    value.serialize(ref arr);
     arr.span()
 }
 
-fn single_deserialize<T, impl TSerde: serde::Serde::<T>>(ref data: Span::<felt252>) -> T {
-    serde::Serde::deserialize(ref data).expect('missing data')
+fn single_deserialize<T, impl TSerde: Serde<T>>(ref data: Span<felt252>) -> T {
+    Serde::deserialize(ref data).expect('missing data')
 }

--- a/src/testing/tests.cairo
+++ b/src/testing/tests.cairo
@@ -1,1 +1,2 @@
-mod nullifier_set_tests;
+// mod nullifier_set_tests;
+mod verifier_tests;

--- a/src/testing/tests/verifier_tests.cairo
+++ b/src/testing/tests/verifier_tests.cairo
@@ -1,0 +1,167 @@
+use option::OptionTrait;
+use serde::Serde;
+use array::{ArrayTrait, SpanTrait};
+use ec::{ec_point_from_x, ec_mul};
+
+use debug::PrintTrait;
+
+use renegade_contracts::{
+    verifier::{Verifier, types::{SparseWeightMatrix, SparseWeightVec, CircuitParams}},
+    testing::test_utils,
+};
+
+// ----------------------------
+// | DUMMY CIRCUIT DEFINITION |
+// ----------------------------
+
+// The dummy circuit we're using is a very simple circuit with 4 witness elements,
+// 2 multiplication gates, and 2 linear constraints. In total, it is parameterized as follows:
+// n = 2
+// n_plus = 2
+// k = log2(n_plus) = 1
+// m = 4
+// q = 6 (The total number of linear constraints is 6 because there are 2 multiplication gates, and 2 linear constraints per multiplication gate)
+
+// The circuit is defined as follows:
+//
+// Witness:
+// a, b, x, y (all scalars)
+//
+// Circuit:
+// m_1 = multiply(a, b)
+// m_2 = multiply(x, y)
+// constrain(m_1 - 69)
+// constrain(m_2 - 420)
+
+// Bearing the following weights:
+// W_L = [[(0, -1)], [], [(1, -1)], [], [], []]
+// W_R = [[], [(0, -1)], [], [(1, -1)], [], []]
+// W_O = [[], [], [], [], [(0, 1)], [(1, 1)]]
+// W_V = [[(0, -1)], [(1, -1)], [(2, -1)], [(3, -1)], [], []]
+// c = [(4, 69), (5, 420)]
+
+// ---------
+// | TESTS |
+// ---------
+
+#[test]
+#[available_gas(100000000)]
+fn test_initializer_storage_serde() {
+    'getting dummy circuit params...'.print();
+    let circuit_params = get_dummy_circuit_params();
+
+    'serializing...'.print();
+    let mut calldata = ArrayTrait::new();
+    circuit_params.serialize(ref calldata);
+    let calldata_span = calldata.span();
+
+    'initializing...'.print();
+    Verifier::__external::initialize(calldata_span);
+
+    'fetching circuit params...'.print();
+    let mut retdata = Verifier::__external::get_circuit_params(ArrayTrait::new().span());
+    let stored_circuit_params: CircuitParams = test_utils::single_deserialize(ref retdata);
+
+    'checking circuit params...'.print();
+    assert(circuit_params == stored_circuit_params, 'circuit params not equal');
+}
+
+// -----------
+// | HELPERS |
+// -----------
+
+fn get_dummy_circuit_weights() -> (
+    SparseWeightMatrix, SparseWeightMatrix, SparseWeightMatrix, SparseWeightMatrix, SparseWeightVec, 
+) {
+    let mut W_L = ArrayTrait::new();
+    let mut W_L_0 = ArrayTrait::new();
+    W_L_0.append((0_usize, -1));
+    W_L.append(W_L_0);
+    W_L.append(ArrayTrait::new());
+    let mut W_L_2 = ArrayTrait::new();
+    W_L_2.append((1_usize, -1));
+    W_L.append(W_L_2);
+    W_L.append(ArrayTrait::new());
+    W_L.append(ArrayTrait::new());
+    W_L.append(ArrayTrait::new());
+
+    let mut W_R = ArrayTrait::new();
+    W_R.append(ArrayTrait::new());
+    let mut W_R_1 = ArrayTrait::new();
+    W_R_1.append((0_usize, -1));
+    W_R.append(W_R_1);
+    W_R.append(ArrayTrait::new());
+    let mut W_R_3 = ArrayTrait::new();
+    W_R_3.append((1_usize, -1));
+    W_R.append(W_R_3);
+    W_R.append(ArrayTrait::new());
+    W_R.append(ArrayTrait::new());
+
+    let mut W_O = ArrayTrait::new();
+    W_O.append(ArrayTrait::new());
+    W_O.append(ArrayTrait::new());
+    W_O.append(ArrayTrait::new());
+    W_O.append(ArrayTrait::new());
+    let mut W_O_4 = ArrayTrait::new();
+    W_O_4.append((0_usize, 1));
+    W_O.append(W_O_4);
+    let mut W_O_5 = ArrayTrait::new();
+    W_O_5.append((1_usize, 1));
+    W_O.append(W_O_5);
+
+    let mut W_V = ArrayTrait::new();
+    let mut W_V_0 = ArrayTrait::new();
+    W_V_0.append((0_usize, -1));
+    W_V.append(W_V_0);
+    let mut W_V_1 = ArrayTrait::new();
+    W_V_1.append((1_usize, -1));
+    W_V.append(W_V_1);
+    let mut W_V_2 = ArrayTrait::new();
+    W_V_2.append((2_usize, -1));
+    W_V.append(W_V_2);
+    let mut W_V_3 = ArrayTrait::new();
+    W_V_3.append((3_usize, -1));
+    W_V.append(W_V_3);
+    W_V.append(ArrayTrait::new());
+    W_V.append(ArrayTrait::new());
+
+    let mut c = ArrayTrait::new();
+    c.append((4_usize, 69));
+    c.append((5_usize, 420));
+
+    (W_L, W_R, W_O, W_V, c)
+}
+
+fn get_dummy_circuit_size_params() -> (usize, usize, usize, usize, usize) {
+    let n = 2;
+    let n_plus = 2;
+    let k = 1;
+    let q = 6;
+    let m = 4;
+
+    (n, n_plus, k, q, m)
+}
+
+fn get_dummy_circuit_generator_labels() -> (felt252, felt252) {
+    let G_label = 'GeneratorsChainG0000';
+    let H_label = 'GeneratorsChainH0000';
+
+    (G_label, H_label)
+}
+
+fn get_dummy_circuit_pc_gens() -> (EcPoint, EcPoint) {
+    let basepoint = ec_point_from_x(1).unwrap();
+    let B = ec_mul(basepoint, 1);
+    let B_blind = ec_mul(basepoint, 2);
+
+    (B, B_blind)
+}
+
+fn get_dummy_circuit_params() -> CircuitParams {
+    let (n, n_plus, k, q, m) = get_dummy_circuit_size_params();
+    let (G_label, H_label) = get_dummy_circuit_generator_labels();
+    let (B, B_blind) = get_dummy_circuit_pc_gens();
+    let (W_L, W_R, W_O, W_V, c) = get_dummy_circuit_weights();
+
+    CircuitParams { n, n_plus, k, q, m, G_label, H_label, B, B_blind, W_L, W_R, W_O, W_V, c }
+}

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -1,2 +1,136 @@
 mod types;
 mod utils;
+
+// -------------
+// | INTERFACE |
+// -------------
+// TODO: Move to separate file / module?
+
+use types::CircuitParams;
+
+#[starknet::interface]
+trait IVerifier<TContractState> {
+    fn initialize(ref self: TContractState, circuit_params: CircuitParams);
+    fn get_circuit_params(self: @TContractState) -> CircuitParams;
+}
+
+#[starknet::contract]
+mod Verifier {
+    use traits::Into;
+    use ec::EcPoint;
+
+    use renegade_contracts::utils::{math::fast_power, storage::StorageAccessSerdeWrapper};
+
+    use super::{types::{VerificationJob, SparseWeightVec, SparseWeightMatrix, CircuitParams}, };
+
+    // -------------
+    // | CONSTANTS |
+    // -------------
+
+    // 2^32 - 1
+    const MAX_USIZE: usize = 4294967295;
+
+    // -----------
+    // | STORAGE |
+    // -----------
+
+    #[storage]
+    struct Storage {
+        /// Queue of in-progress verification jobs
+        verification_queue: LegacyMap<felt252, StorageAccessSerdeWrapper<VerificationJob>>,
+        /// Domain separator for hash chain from which G generators are drawn
+        G_label: felt252,
+        /// Domain separator for hash chain from which H generators are drawn
+        H_label: felt252,
+        /// Generator used for Pedersen commitments
+        B: StorageAccessSerdeWrapper<EcPoint>,
+        /// Generator used for blinding in Pedersen commitments
+        B_blind: StorageAccessSerdeWrapper<EcPoint>,
+        /// Number of multiplication gates in the circuit
+        n: usize,
+        /// Number of multiplication gates in the circuit,
+        /// padded to the next power of 2
+        n_plus: usize,
+        /// log_2(n_plus), cached for efficiency
+        k: usize,
+        /// The number of linear constraints in the circuit
+        q: usize,
+        /// The witness size
+        m: usize,
+        // TODO: The circuit weights *definitely* won't fit in a single storage address...
+        /// Sparse-reduced matrix of left input weights for the circuit
+        W_L: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        /// Sparse-reduced matrix of right input weights for the circuit
+        W_R: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        /// Sparse-reduced matrix of output weights for the circuit
+        W_O: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        /// Sparse-reduced matrix of witness weights for the circuit
+        W_V: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        /// Sparse-reduced vector of constants for the circuit
+        c: StorageAccessSerdeWrapper<SparseWeightVec>,
+    }
+
+    // ----------
+    // | EVENTS |
+    // ----------
+
+    // TODO
+
+    // ----------------------------
+    // | INTERFACE IMPLEMENTATION |
+    // ----------------------------
+
+    #[external(v0)]
+    impl IVerifierImpl of super::IVerifier<ContractState> {
+        /// Initializes the verifier for the given public parameters
+        /// Parameters:
+        /// - `circuit_params`: The public parameters of the circuit
+        fn initialize(ref self: ContractState, circuit_params: CircuitParams) {
+            // Assert that n_plus = 2^k
+            assert(
+                fast_power(2, circuit_params.k.into(), MAX_USIZE.into() + 1) == circuit_params
+                    .n_plus
+                    .into(),
+                'n_plus != 2^k'
+            );
+
+            self.n.write(circuit_params.n);
+            self.n_plus.write(circuit_params.n_plus);
+            self.k.write(circuit_params.k);
+            self.q.write(circuit_params.q);
+            self.m.write(circuit_params.m);
+            self.G_label.write(circuit_params.G_label);
+            self.H_label.write(circuit_params.H_label);
+            self.B.write(StorageAccessSerdeWrapper { inner: circuit_params.B });
+            self.B_blind.write(StorageAccessSerdeWrapper { inner: circuit_params.B_blind });
+            self.W_L.write(StorageAccessSerdeWrapper { inner: circuit_params.W_L });
+            self.W_R.write(StorageAccessSerdeWrapper { inner: circuit_params.W_R });
+            self.W_O.write(StorageAccessSerdeWrapper { inner: circuit_params.W_O });
+            self.W_V.write(StorageAccessSerdeWrapper { inner: circuit_params.W_V });
+            self.c.write(StorageAccessSerdeWrapper { inner: circuit_params.c });
+        }
+
+        // -----------
+        // | GETTERS |
+        // -----------
+
+        fn get_circuit_params(self: @ContractState) -> CircuitParams {
+            CircuitParams {
+                n: self.n.read(),
+                n_plus: self.n_plus.read(),
+                k: self.k.read(),
+                q: self.q.read(),
+                m: self.m.read(),
+                G_label: self.G_label.read(),
+                H_label: self.H_label.read(),
+                B: self.B.read().inner,
+                B_blind: self.B_blind.read().inner,
+                W_L: self.W_L.read().inner,
+                W_R: self.W_R.read().inner,
+                W_O: self.W_O.read().inner,
+                W_V: self.W_V.read().inner,
+                c: self.c.read().inner,
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR stubs out the contract structure using Cairo `v2.0.0-rc2` syntax, and implements the `initialize` function on the verifier contract.

For now, we assume that all types can be stored in a single storage address (which can hold 256 slots / felts).

CI is red, but the `test_initializer_storage_serde` test passes, asserting that circuit params are written to contract storage correctly.