### PR TITLE
renegade_contracts: verifier: impl queue_verification_job fn

### DIFF
--- a/src/testing/tests/verifier_tests.cairo
+++ b/src/testing/tests/verifier_tests.cairo
@@ -1,13 +1,20 @@
 use option::OptionTrait;
 use serde::Serde;
+use clone::Clone;
 use array::{ArrayTrait, SpanTrait};
 use ec::{ec_point_from_x, ec_mul};
 
 use debug::PrintTrait;
 
 use renegade_contracts::{
-    verifier::{Verifier, types::{SparseWeightMatrix, SparseWeightVec, CircuitParams}},
-    testing::test_utils,
+    verifier::{
+        Verifier,
+        types::{
+            SparseWeightMatrix, SparseWeightVec, CircuitParams, Proof, VerificationJob,
+            RemainingScalarPowers, RemainingGenerators, VecPoly3Term, VecPoly3, VecElem
+        }
+    },
+    testing::test_utils, utils::eq::{OptionTPartialEq, ArrayTPartialEq, SpanTPartialEq}
 };
 
 // ----------------------------
@@ -64,6 +71,83 @@ fn test_initializer_storage_serde() {
 
     'checking circuit params...'.print();
     assert(circuit_params == stored_circuit_params, 'circuit params not equal');
+}
+
+#[test]
+#[available_gas(100000000)]
+fn test_queue_verification() {
+    'getting dummy circuit params...'.print();
+    let circuit_params = get_dummy_circuit_params();
+
+    'serializing...'.print();
+    let mut calldata = ArrayTrait::new();
+    circuit_params.serialize(ref calldata);
+    let calldata_span = calldata.span();
+
+    'initializing...'.print();
+    Verifier::__external::initialize(calldata_span);
+
+    'getting dummy proof...'.print();
+    let proof = get_dummy_proof();
+
+    'queueing verification job...'.print();
+    let mut calldata = ArrayTrait::new();
+    proof.serialize(ref calldata);
+    // Add verification job ID to calldata
+    11.serialize(ref calldata);
+    let calldata_span = calldata.span();
+    Verifier::__external::queue_verification_job(calldata_span);
+
+    'fetching verification job...'.print();
+    let mut calldata = ArrayTrait::new();
+    calldata.append(11);
+    let mut retdata = Verifier::__external::get_verification_job(calldata.span());
+    let stored_verification_job: VerificationJob = test_utils::single_deserialize(ref retdata);
+    let expected_verification_job = get_expected_verification_job();
+
+    'checking y_powers_rem...'.print();
+    assert(
+        stored_verification_job.y_powers_rem == expected_verification_job.y_powers_rem,
+        'y_powers_rem not equal'
+    );
+
+    'checking z_powers_rem...'.print();
+    assert(
+        stored_verification_job.z_powers_rem == expected_verification_job.z_powers_rem,
+        'z_powers_rem not equal'
+    );
+
+    'checking G_rem...'.print();
+    assert(stored_verification_job.G_rem == expected_verification_job.G_rem, 'G_rem not equal');
+
+    'checking H_rem...'.print();
+    assert(stored_verification_job.H_rem == expected_verification_job.H_rem, 'H_rem not equal');
+
+    'checking msm_result...'.print();
+    assert(
+        stored_verification_job.msm_result == expected_verification_job.msm_result,
+        'msm_result not equal'
+    );
+
+    'checking verified...'.print();
+    assert(
+        stored_verification_job.verified == expected_verification_job.verified, 'verified not equal'
+    );
+
+    'checking scalars_rem...'.print();
+    assert(
+        stored_verification_job.scalars_rem == expected_verification_job.scalars_rem,
+        'scalars_rem not equal'
+    );
+
+    'checking commitments_rem...'.print();
+    assert(
+        stored_verification_job.commitments_rem == expected_verification_job.commitments_rem,
+        'commitments_rem not equal'
+    );
+
+    'final sanity check'.print();
+    assert(stored_verification_job == expected_verification_job, 'verification job not equal');
 }
 
 // -----------
@@ -164,4 +248,323 @@ fn get_dummy_circuit_params() -> CircuitParams {
     let (W_L, W_R, W_O, W_V, c) = get_dummy_circuit_weights();
 
     CircuitParams { n, n_plus, k, q, m, G_label, H_label, B, B_blind, W_L, W_R, W_O, W_V, c }
+}
+
+fn get_dummy_proof() -> Proof {
+    let basepoint = ec_point_from_x(1).unwrap();
+
+    let mut L = ArrayTrait::new();
+    L.append(ec_mul(basepoint, 11));
+
+    let mut R = ArrayTrait::new();
+    R.append(ec_mul(basepoint, 12));
+
+    let mut V = ArrayTrait::new();
+    V.append(ec_mul(basepoint, 13));
+    V.append(ec_mul(basepoint, 14));
+    V.append(ec_mul(basepoint, 15));
+    V.append(ec_mul(basepoint, 16));
+
+    Proof {
+        A_I: ec_mul(basepoint, 3),
+        A_O: ec_mul(basepoint, 4),
+        S: ec_mul(basepoint, 5),
+        T_1: ec_mul(basepoint, 6),
+        T_3: ec_mul(basepoint, 7),
+        T_4: ec_mul(basepoint, 8),
+        T_5: ec_mul(basepoint, 9),
+        T_6: ec_mul(basepoint, 10),
+        t_hat: 9,
+        t_blind: 10,
+        e_blind: 11,
+        L,
+        R,
+        a: 12,
+        b: 13,
+        V,
+    }
+}
+
+fn get_expected_verification_job() -> VerificationJob {
+    VerificationJob {
+        scalars_rem: get_expected_scalars_rem(), y_powers_rem: RemainingScalarPowers {
+            base: 2, power: 1, num_exp_rem: 1, 
+            }, z_powers_rem: RemainingScalarPowers {
+            base: 3, power: 3, num_exp_rem: 5, 
+            }, G_rem: RemainingGenerators {
+            hash_state: 'GeneratorsChainG0000', num_gens_rem: 2, 
+            }, H_rem: RemainingGenerators {
+            hash_state: 'GeneratorsChainH0000', num_gens_rem: 2, 
+        },
+        commitments_rem: get_expected_commitments_rem(),
+        msm_result: Option::None(()),
+        verified: false,
+    }
+}
+
+fn get_expected_scalars_rem() -> Array<VecPoly3> {
+    let mut scalars_rem = ArrayTrait::new();
+
+    // x
+    let mut scalars_rem_0 = ArrayTrait::new();
+    scalars_rem_0
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(4), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_0);
+
+    // x^2
+    let mut scalars_rem_1 = ArrayTrait::new();
+    scalars_rem_1
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(16), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_1);
+
+    // x^3
+    let mut scalars_rem_2 = ArrayTrait::new();
+    scalars_rem_2
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(64), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_2);
+
+    // r*x^2*w_V
+    let mut scalars_rem_3 = ArrayTrait::new();
+    scalars_rem_3
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(128),
+                uses_y_power: false,
+                vec_elem: Option::Some(VecElem::w_V_flat(0))
+            }
+        );
+    scalars_rem.append(scalars_rem_3);
+
+    // r*x
+    let mut scalars_rem_4 = ArrayTrait::new();
+    scalars_rem_4
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(32), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_4);
+
+    // r*x^3
+    let mut scalars_rem_5 = ArrayTrait::new();
+    scalars_rem_5
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(512), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_5);
+
+    // r*x^4
+    let mut scalars_rem_6 = ArrayTrait::new();
+    scalars_rem_6
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(2048), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_6);
+
+    // r*x^5
+    let mut scalars_rem_7 = ArrayTrait::new();
+    scalars_rem_7
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(8192), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_7);
+
+    // r*x^6
+    let mut scalars_rem_8 = ArrayTrait::new();
+    scalars_rem_8
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(32768), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_8);
+
+    // w(t_hat - a * b) + r(x^2*(w_c + delta) - t_hat)
+    // w = 5, t_hat = 9, a = 12, b = 13, r = 8, x^2 = 16, w_c = 322947,
+    // delta = 1809251394333065606848661391547535052811553607665798349986546028067936011361
+    // total = 41479833
+    let mut scalars_rem_9 = ArrayTrait::new();
+    scalars_rem_9
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(41479833), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_9);
+
+    // -e_blind - r*t_blind
+    let mut scalars_rem_10 = ArrayTrait::new();
+    scalars_rem_10
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-91), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_10);
+
+    // u_sq (length k = 1)
+    let mut scalars_rem_11 = ArrayTrait::new();
+    scalars_rem_11
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(6), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_11);
+
+    // u_sq_inv (length k = 1)
+    let mut scalars_rem_12 = ArrayTrait::new();
+    scalars_rem_12
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(
+                    603083798111021868949553797182511684270517869221932783328848676022645336747
+                ),
+                uses_y_power: false,
+                vec_elem: Option::None(())
+            }
+        );
+    scalars_rem.append(scalars_rem_12);
+
+    // xy^{-n+}_[0:n] * w_R_flat - as_[0:n]
+    let mut scalars_rem_13 = ArrayTrait::new();
+    scalars_rem_13
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(4),
+                uses_y_power: true,
+                vec_elem: Option::Some(VecElem::w_R_flat(0))
+            }
+        );
+    scalars_rem_13
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-12),
+                uses_y_power: false,
+                vec_elem: Option::Some(VecElem::s((0, 2)))
+            }
+        );
+    scalars_rem.append(scalars_rem_13);
+
+    // -as_[n:n+]
+    let mut scalars_rem_14 = ArrayTrait::new();
+    scalars_rem_14
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-12),
+                uses_y_power: false,
+                vec_elem: Option::Some(VecElem::s((2, 2)))
+            }
+        );
+    scalars_rem.append(scalars_rem_14);
+
+    // -1 + y^{-n+}_[0:n] * (x*w_L_flat + w_O_flat - b*s^-1_[0:n])
+    let mut scalars_rem_15 = ArrayTrait::new();
+    scalars_rem_15
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-1), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem_15
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(4),
+                uses_y_power: true,
+                vec_elem: Option::Some(VecElem::w_L_flat(0)),
+            }
+        );
+    scalars_rem_15
+        .append(
+            VecPoly3Term {
+                scalar: Option::None(()),
+                uses_y_power: true,
+                vec_elem: Option::Some(VecElem::w_O_flat(0)),
+            }
+        );
+    scalars_rem_15
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-13),
+                uses_y_power: true,
+                vec_elem: Option::Some(VecElem::s_inv((0, 2))),
+            }
+        );
+    scalars_rem.append(scalars_rem_15);
+
+    // -1 + y^{-n+}_[n:n+] * (-b*s^-1_[n:n+])
+    let mut scalars_rem_16 = ArrayTrait::new();
+    scalars_rem_16
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-1), uses_y_power: false, vec_elem: Option::None(())
+            }
+        );
+    scalars_rem_16
+        .append(
+            VecPoly3Term {
+                scalar: Option::Some(-13),
+                uses_y_power: true,
+                vec_elem: Option::Some(VecElem::s_inv((2, 2))),
+            }
+        );
+    scalars_rem.append(scalars_rem_16);
+
+    scalars_rem
+}
+
+fn get_expected_commitments_rem() -> Array<EcPoint> {
+    let mut commitments_rem = ArrayTrait::new();
+
+    let basepoint = ec_point_from_x(1).unwrap();
+
+    // A_I
+    commitments_rem.append(ec_mul(basepoint, 3));
+    // A_O
+    commitments_rem.append(ec_mul(basepoint, 4));
+    // S
+    commitments_rem.append(ec_mul(basepoint, 5));
+    // V
+    commitments_rem.append(ec_mul(basepoint, 13));
+    commitments_rem.append(ec_mul(basepoint, 14));
+    commitments_rem.append(ec_mul(basepoint, 15));
+    commitments_rem.append(ec_mul(basepoint, 16));
+    // T_1
+    commitments_rem.append(ec_mul(basepoint, 6));
+    // T_3
+    commitments_rem.append(ec_mul(basepoint, 7));
+    // T_4
+    commitments_rem.append(ec_mul(basepoint, 8));
+    // T_5
+    commitments_rem.append(ec_mul(basepoint, 9));
+    // T_6
+    commitments_rem.append(ec_mul(basepoint, 10));
+    // B
+    commitments_rem.append(ec_mul(basepoint, 1));
+    // B_blind
+    commitments_rem.append(ec_mul(basepoint, 2));
+    // L
+    commitments_rem.append(ec_mul(basepoint, 11));
+    // R
+    commitments_rem.append(ec_mul(basepoint, 12));
+
+    commitments_rem
 }

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -6,22 +6,39 @@ mod utils;
 // -------------
 // TODO: Move to separate file / module?
 
-use types::CircuitParams;
+use types::{CircuitParams, Proof, VerificationJob};
 
 #[starknet::interface]
 trait IVerifier<TContractState> {
     fn initialize(ref self: TContractState, circuit_params: CircuitParams);
+    fn queue_verification_job(ref self: TContractState, proof: Proof, verification_job_id: felt252);
     fn get_circuit_params(self: @TContractState) -> CircuitParams;
+    fn get_verification_job(self: @TContractState, verification_job_id: felt252) -> VerificationJob;
 }
 
 #[starknet::contract]
 mod Verifier {
-    use traits::Into;
+    use option::OptionTrait;
+    use clone::Clone;
+    use traits::{Into, TryInto};
+    use array::{ArrayTrait, SpanTrait};
     use ec::EcPoint;
+    use math::inv_mod;
 
-    use renegade_contracts::utils::{math::fast_power, storage::StorageAccessSerdeWrapper};
+    use renegade_contracts::utils::{
+        math::{get_consecutive_powers, dot_product, elt_wise_mul, fast_power},
+        collections::{extend, tile_felt_arr, DeepSpan, ArrayTraitExt},
+        storage::{StorageAccessSerdeWrapper}
+    };
 
-    use super::{types::{VerificationJob, SparseWeightVec, SparseWeightMatrix, CircuitParams}, };
+    use super::{
+        types::{
+            VerificationJob, RemainingScalarPowers, RemainingGenerators, VecPoly3Trait,
+            SparseWeightVec, SparseWeightMatrix, SparseWeightMatrixSpan, VecElem, Proof,
+            CircuitParams
+        },
+        utils::{flatten_sparse_weight_matrix, flatten_column}
+    };
 
     // -------------
     // | CONSTANTS |
@@ -110,6 +127,234 @@ mod Verifier {
             self.c.write(StorageAccessSerdeWrapper { inner: circuit_params.c });
         }
 
+        /// Enqueues a verification job for the given proof, squeezing out challenge scalars
+        /// as necessary.
+        /// Parameters:
+        /// - `proof`: The proof to verify
+        /// - `verification_job_id`: The ID of the verification job
+        fn queue_verification_job(
+            ref self: ContractState, mut proof: Proof, verification_job_id: felt252
+        ) {
+            // Assert that the verification job ID is not already in use
+            // assert(verification_queue::read(verification_job_id) == ... what is the default value?);
+            // TODO: can just have a separate hashmap attesting to whether or not a job ID is in use
+
+            let n = self.n.read();
+            let n_plus = self.n_plus.read();
+            let k = self.k.read();
+            let q = self.q.read();
+            let G_label = self.G_label.read();
+            let H_label = self.H_label.read();
+            let B = self.B.read().inner;
+            let B_blind = self.B_blind.read().inner;
+            let W_L = self.W_L.read().inner;
+            let W_R = self.W_R.read().inner;
+            let W_O = self.W_O.read().inner;
+            let W_V = self.W_V.read().inner;
+            let c = self.c.read().inner;
+
+            // Prep `RemainingGenerators` structs for G and H generators
+
+            let G_rem = RemainingGenerators { hash_state: G_label, num_gens_rem: n_plus };
+            let H_rem = RemainingGenerators { hash_state: H_label, num_gens_rem: n_plus };
+
+            // Squeeze out challenge scalars from proof
+            let (y, z, x, w, u_sq, u_sq_inv, r) = _squeeze_challenge_scalars(k, @proof);
+
+            // Prep `RemainingScalarPowers` structs for y & z
+
+            let y_powers_rem = RemainingScalarPowers {
+                base: y, power: 1, num_exp_rem: n_plus - 1, 
+            };
+
+            let z_powers_rem = RemainingScalarPowers { base: z, power: z, num_exp_rem: q - 1,  };
+
+            // Construct scalar polynomials & EC points in the appropriate order
+            // TODO(andrew): DOCUMENT THIS ORDER (AND THE ENTIRE FINAL MSM)
+
+            // Begin with MSM terms that do not use G, H generators
+
+            let mut scalars_rem = ArrayTrait::new();
+            let mut commitments_rem = ArrayTrait::new();
+
+            let x_2 = x * x;
+            let x_3 = x_2 * x;
+
+            // x
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(x));
+            commitments_rem.append(proof.A_I);
+
+            // x^2
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(x_2));
+            commitments_rem.append(proof.A_O);
+
+            // x^3
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(x_3));
+            commitments_rem.append(proof.S);
+
+            // r*x^2*w_V_flat
+            scalars_rem
+                .append(
+                    VecPoly3Trait::new()
+                        .add_term(
+                            Option::Some(r * x_2), false, Option::Some(VecElem::w_V_flat(0)), 
+                        )
+                );
+            commitments_rem.append_all(ref proof.V);
+
+            let x_4 = x_3 * x;
+            let x_5 = x_4 * x;
+            let x_6 = x_5 * x;
+
+            // r*x
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(r * x));
+            commitments_rem.append(proof.T_1);
+
+            // r*x^3
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(r * x_3));
+            commitments_rem.append(proof.T_3);
+
+            // r*x^4
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(r * x_4));
+            commitments_rem.append(proof.T_4);
+
+            // r*x^5
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(r * x_5));
+            commitments_rem.append(proof.T_5);
+
+            // r*x^6
+            scalars_rem.append(VecPoly3Trait::single_scalar_poly(r * x_6));
+            commitments_rem.append(proof.T_6);
+
+            // Calculate delta
+
+            // No point in using the precomputed powers of y & z since we need consecutive powers
+            // (would only save us from doing log n, log q multiplications)
+
+            // TODO: Technically, only need powers of y & z for which
+            // the corresponding column of W_R & W_L is non-zero
+
+            // Need powers [0, n) of y^-1
+            let mut y_inv_powers_to_n = ArrayTrait::new();
+            y_inv_powers_to_n.append(1);
+            // Calculate mod inv of y
+            // Unwrapping is safe here since y is guaranteed not to be 0
+            let y_inv = felt252_div(1, y.try_into().unwrap());
+            let mut computed_y_powers = get_consecutive_powers(y_inv, n - 1);
+            y_inv_powers_to_n.append_all(ref computed_y_powers);
+
+            let delta = _calc_delta(
+                n, y_inv_powers_to_n.span(), z, W_L.deep_span(), W_R.deep_span()
+            );
+
+            let mut c_span = c.span();
+            let w_c = flatten_column(c_span, z);
+
+            // w(t_hat - a * b) + r(x^2*(w_c + delta) - t_hat)
+            scalars_rem
+                .append(
+                    VecPoly3Trait::single_scalar_poly(
+                        w * (proof.t_hat - proof.a * proof.b)
+                            + r * (x_2 * (w_c + delta) - proof.t_hat)
+                    )
+                );
+            commitments_rem.append(B);
+
+            // -e_blind - r*t_blind
+            scalars_rem
+                .append(VecPoly3Trait::single_scalar_poly(0 - proof.e_blind - r * proof.t_blind));
+            commitments_rem.append(B_blind);
+
+            let mut u_sq_span = u_sq.span();
+            let mut u_sq_inv_span = u_sq_inv.span();
+
+            // u_sq
+            extend(ref scalars_rem, VecPoly3Trait::map_to_single_scalar_polys(ref u_sq_span));
+            commitments_rem.append_all(ref proof.L);
+
+            // u_sq_inv
+            extend(ref scalars_rem, VecPoly3Trait::map_to_single_scalar_polys(ref u_sq_inv_span));
+            commitments_rem.append_all(ref proof.R);
+
+            // Now, construct scalar polynomials in MSM terms that use G, H generators
+
+            // xy^{-n+}_[0:n] * w_R_flat - as_[0:n]
+            let g_n_poly = VecPoly3Trait::new()
+                .add_term(
+                    scalar: Option::Some(x),
+                    uses_y_power: true,
+                    vec_elem: Option::Some(VecElem::w_R_flat(0)),
+                )
+                .add_term(
+                    scalar: Option::Some(0 - proof.a),
+                    uses_y_power: false,
+                    vec_elem: Option::Some(VecElem::s((0, n))),
+                );
+            scalars_rem.append(g_n_poly);
+
+            // -as_[n:n+]
+            let g_n_plus_poly = VecPoly3Trait::new()
+                .add_term(
+                    scalar: Option::Some(0 - proof.a),
+                    uses_y_power: false,
+                    vec_elem: Option::Some(VecElem::s((n, n_plus))),
+                );
+            scalars_rem.append(g_n_plus_poly);
+
+            // -1 + y^{-n+}_[0:n] * (x*w_L_flat + w_O_flat - b*s^-1_[0:n])
+            let h_n_poly = VecPoly3Trait::new()
+                .add_term(
+                    scalar: Option::Some(0 - 1), uses_y_power: false, vec_elem: Option::None(()), 
+                )
+                .add_term(
+                    scalar: Option::Some(x),
+                    uses_y_power: true,
+                    vec_elem: Option::Some(VecElem::w_L_flat(0)),
+                )
+                .add_term(
+                    scalar: Option::None(()),
+                    uses_y_power: true,
+                    vec_elem: Option::Some(VecElem::w_O_flat(0)),
+                )
+                .add_term(
+                    scalar: Option::Some(0 - proof.b),
+                    uses_y_power: true,
+                    vec_elem: Option::Some(VecElem::s_inv((0, n))),
+                );
+            scalars_rem.append(h_n_poly);
+
+            // -1 + y^{-n+}_[n:n+] * (-b*s^-1_[n:n+])
+            let h_n_plus_poly = VecPoly3Trait::new()
+                .add_term(
+                    scalar: Option::Some(0 - 1), uses_y_power: false, vec_elem: Option::None(()), 
+                )
+                .add_term(
+                    scalar: Option::Some(0 - proof.b),
+                    uses_y_power: true,
+                    vec_elem: Option::Some(VecElem::s_inv((n, n_plus))),
+                );
+            scalars_rem.append(h_n_plus_poly);
+
+            // Pack `VerificationJob` struct
+
+            let verification_job = VerificationJob {
+                scalars_rem,
+                y_powers_rem,
+                z_powers_rem,
+                G_rem,
+                H_rem,
+                commitments_rem,
+                msm_result: Option::None(()),
+                verified: false,
+            };
+
+            // Enqueue verification job
+
+            self
+                .verification_queue
+                .write(verification_job_id, StorageAccessSerdeWrapper { inner: verification_job });
+        }
+
         // -----------
         // | GETTERS |
         // -----------
@@ -132,5 +377,48 @@ mod Verifier {
                 c: self.c.read().inner,
             }
         }
+
+        fn get_verification_job(
+            self: @ContractState, verification_job_id: felt252
+        ) -> VerificationJob {
+            self.verification_queue.read(verification_job_id).inner
+        }
+    }
+
+    // -----------
+    // | HELPERS |
+    // -----------
+
+    // TODO: This is a placeholder for now, in the future we will have a MerlinTranscript module
+    fn _squeeze_challenge_scalars(
+        k: usize, _proof: @Proof
+    ) -> (felt252, felt252, felt252, felt252, Array<felt252>, Array<felt252>, felt252) {
+        let mut u_sq = ArrayTrait::new();
+        tile_felt_arr(ref u_sq, 6, k);
+
+        let mut u_sq_inv = ArrayTrait::new();
+        tile_felt_arr(
+            ref u_sq_inv,
+            603083798111021868949553797182511684270517869221932783328848676022645336747,
+            k
+        );
+
+        (2, 3, 4, 5, u_sq, u_sq_inv, 8)
+    }
+
+    // TODO: Because this requires flattening the matrices, it may need to be split across multiple EC points
+    fn _calc_delta(
+        n: usize,
+        y_inv_powers_to_n: Span<felt252>,
+        z: felt252,
+        W_L: SparseWeightMatrixSpan,
+        W_R: SparseWeightMatrixSpan
+    ) -> felt252 {
+        // Flatten W_L, W_R using z
+        let w_L_flat = flatten_sparse_weight_matrix(W_L, z, n);
+        let w_R_flat = flatten_sparse_weight_matrix(W_R, z, n);
+
+        // \delta = <y^n * w_R_flat, w_L_flat>
+        dot_product(elt_wise_mul(y_inv_powers_to_n, w_R_flat.span()).span(), w_L_flat.span())
     }
 }


### PR DESCRIPTION
This PR introduces the `queue_verification_job` function, which preps a verification job so that the underlying MSM can later be processed.

For now, we make the optimistic assumption that all of the required scalar/felt computation fits within a transaction - this is relevant in the context of calculating delta, a scalar term in the MSM which requires flattening 2 weight matrices and the constants vector - this takes a lot of work (asymptotically).

The `test_queue_verification_job` test passes, for which I evaluated the structure & scalar computation for the given circuit by hand, this is what's hardcoded in the test case.