### PR TITLE
renegade_contracts: verifier: pack verifier utils into sep. files / traits

### DIFF
--- a/src/testing/tests/verifier_tests.cairo
+++ b/src/testing/tests/verifier_tests.cairo
@@ -168,11 +168,14 @@ fn test_calc_delta_basic() {
         .append(3350465545061232605275298873236176023725099273455182129604714866792474093038);
 
     let delta = calc_delta(n, y_inv_powers_to_n.span(), z, @W_L, @W_R);
-    delta.print();
-    assert(
-        delta == 1206167596222043737899107594365023368541035738443865566657697352045290674603,
-        'wrong delta'
-    );
+
+    // delta = <y^{n+}[0:n] * w_R_flat, w_L_flat>
+    // The expected result was calculated by hand using the powers of y^{-1} above
+    // and the result of flattening the matrices W_L and W_R above using z = 2
+    let expected_delta =
+        1206167596222043737899107594365023368541035738443865566657697352045290674603;
+
+    assert(delta == expected_delta, 'wrong delta');
 }
 
 // ------------------
@@ -525,6 +528,9 @@ fn get_expected_verification_job() -> VerificationJob {
     }
 }
 
+// The `scalar` fields in these terms were calculated by hand using the following values,
+// given from the placeholder `squeeze_challenge_scalars` implementation & the `get_dummy_proof` helper:
+// y = 2, z = 3, x = 4, w = 5, u = [6], r = 8, t_hat = 9, t_blind = 10, e_blind = 11, a = 12, b = 13
 fn get_expected_scalars_rem() -> Array<VecPoly3> {
     let mut scalars_rem = ArrayTrait::new();
 

--- a/src/verifier/utils.cairo
+++ b/src/verifier/utils.cairo
@@ -1,90 +1,65 @@
-use traits::Into;
+use traits::{Into, TryInto};
 use option::OptionTrait;
 use array::{ArrayTrait, SpanTrait};
-use dict::Felt252DictTrait;
 
-use renegade_contracts::utils::{math::{dot_product, binary_exp}};
+use renegade_contracts::utils::{math::{dot_product, elt_wise_mul}, collections::{tile_felt_arr}};
 
-use super::types::{VerificationJob, SparseWeightMatrixSpan, SparseWeightVec, SparseWeightVecSpan};
+use super::types::{SparseWeightMatrix, SparseWeightMatrixTrait, Proof};
 
-// --------
-// | MATH |
-// --------
-
-/// Given a sparse-reduced circuit weight matrix (W_{L, R, O, V}) with (actual)
-/// width `width`, "flattens" the matrix into a `width`-length vector by computing
-/// [z, z^2, ..., z^q] * W_{L, R, O, V} (vector-matrix multiplication)
-fn flatten_sparse_weight_matrix(
-    matrix: SparseWeightMatrixSpan, z: felt252, width: usize, 
-) -> Array<felt252> {
-    // Can't set an item at a given index in an array, can only append,
-    // so we use a dict here
-    let mut flattened_dict: Felt252Dict<felt252> = Default::default();
-
-    // Loop over rows first, then entries
-    // Since matrices are sparse and in row-major form, this ensure that we only loop
-    // once per non-zero entry
-    let mut row_index: usize = 0;
+/// This computes the `i`th element of the `s` vector using the `u` challenge scalars.
+/// The explanation for this calculation can be found [here](https://doc-internal.dalek.rs/bulletproofs/inner_product_proof/index.html#verifiers-algorithm)
+fn get_s_elem(u: Span<felt252>, i: usize) -> felt252 {
+    let mut res = 1;
+    let mut j = 0;
+    let mut two_to_j: u128 = 1;
     loop {
-        if row_index == matrix.len() {
+        if j == u.len() {
             break;
+        }
+
+        if i.into() & two_to_j == two_to_j {
+            // If jth bit of i is 1, then we multiply by u[j]
+            res *= *u.at(j);
+        } else {
+            // If jth bit of i is 0, then we multiply by u[j]^-1
+            // Unwrapping is safe here b/c u scalars are never 0
+            res *= felt252_div(1, (*u.at(j)).try_into().unwrap());
         };
 
-        let mut row = *matrix.at(row_index);
-        let mut entry_index = 0;
-        loop {
-            if entry_index == row.len() {
-                break;
-            };
-
-            let (col_index, weight) = *row.at(entry_index);
-            let col_index_felt = col_index.into();
-            // Default value for an unset key is 0
-            let mut value = flattened_dict.get(col_index_felt);
-            // z vector starts at z^1, i.e. is [z, z^2, ..., z^q]
-            let z_i = binary_exp(z, row_index + 1);
-            value += z_i * weight;
-            flattened_dict.insert(col_index_felt, value);
-
-            entry_index += 1;
-        };
-
-        row_index += 1;
-    };
-
-    let mut flattened_vec = ArrayTrait::new();
-    let mut col_index = 0;
-    loop {
-        if col_index == width {
-            break;
-        };
-
-        flattened_vec.append(flattened_dict.get(col_index.into()));
-        col_index += 1;
-    };
-
-    flattened_vec
-}
-
-/// Given a sparse-reduced column vector `col`, "flattens" the vector into a
-/// single scalar by computing sum(z^i * col[i]) for all indices i with non-zero
-/// weights in the column. This is effectively a dot product [z, z^2, ..., z^len(col)] * col,
-/// but omitting multiplications by zero.
-fn flatten_column(mut col: SparseWeightVecSpan, z: felt252) -> felt252 {
-    let mut res = 0;
-    let mut entry_num = 0;
-    loop {
-        if entry_num == col.len() {
-            break;
-        };
-
-        let (i, weight) = *col.at(entry_num);
-        // z vector starts at z^1, i.e. is [z, z^2, ..., z^q]
-        let z_i = binary_exp(z, i + 1);
-        res += z_i * weight;
-
-        entry_num += 1;
+        j += 1;
+        two_to_j *= 2;
     };
 
     res
+}
+
+// "Squeezes" the challenge scalars from the proof
+// This is a placeholder for now, in the future we will have a MerlinTranscript module
+fn squeeze_challenge_scalars(
+    k: usize, _proof: @Proof
+) -> (felt252, felt252, felt252, felt252, Array<felt252>, felt252) {
+    let mut u = ArrayTrait::new();
+    tile_felt_arr(ref u, 6, k);
+
+    (2, 3, 4, 5, u, 8)
+}
+
+/// Calculates the value delta = <y^{n+}[0:n] * w_R_flat, w_L_flat> used in verification
+// TODO: Because this requires flattening the matrices, it may need to be split across multiple EC points
+// TODO: Can make this more efficient by pre-computing all powers of z & selectively using in dot products
+// (will need all powers of z across both of W_L, W_R)
+// TODO: Technically, only need powers of y for which the corresponding column of W_R & W_L is non-zero
+fn calc_delta(
+    n: usize,
+    y_inv_powers_to_n: Span<felt252>,
+    z: felt252,
+    W_L: @SparseWeightMatrix,
+    W_R: @SparseWeightMatrix
+) -> felt252 {
+    // Flatten W_L, W_R using z
+    let w_L_flat = W_L.flatten(z, n);
+    let w_R_flat = W_R.flatten(z, n);
+
+    // \delta = <y^n * w_R_flat, w_L_flat>
+    dot_product(elt_wise_mul(y_inv_powers_to_n, w_R_flat.span()).span(), w_L_flat.span())
 }

--- a/src/verifier/utils.cairo
+++ b/src/verifier/utils.cairo
@@ -41,6 +41,7 @@ fn squeeze_challenge_scalars(
     let mut u = ArrayTrait::new();
     tile_felt_arr(ref u, 6, k);
 
+    // y, z, x, w, u, r
     (2, 3, 4, 5, u, 8)
 }
 


### PR DESCRIPTION
This PR moves the `calc_delta` and `squeeze_challenge_scalars` helper functions into the `verifier/utils.cairo` folder, and moves some sparse weight matrix / vector utilities (i.e. flattening) into a trait, allowing relevant methods to be called directly on the types.