### PR TITLE
renegade_contracts: verifier: separated witness from proof

### DIFF
--- a/src/verifier/types.cairo
+++ b/src/verifier/types.cairo
@@ -316,7 +316,6 @@ struct Proof {
     R: Array<EcPoint>,
     a: Scalar,
     b: Scalar,
-    V: Array<EcPoint>,
 }
 
 // (index, weight) entries in a sparse-reduced vector are expected

--- a/src/verifier/utils.cairo
+++ b/src/verifier/utils.cairo
@@ -47,7 +47,7 @@ fn get_s_elem(u: Span<Scalar>, i: usize) -> Scalar {
 // TODO: Absorb identity points for A_I2, A_O2, S2
 // TODO: Squeeze u challenge scalar for 2-phase circuit (confusing variable naming)
 fn squeeze_challenge_scalars(
-    proof: @Proof, m: usize, n_plus: usize
+    proof: @Proof, witness_commitments: Span<EcPoint>, m: usize, n_plus: usize
 ) -> (Array<Scalar>, Array<Scalar>) {
     let mut challenge_scalars = ArrayTrait::new();
     let mut u = ArrayTrait::new();
@@ -63,7 +63,7 @@ fn squeeze_challenge_scalars(
             break;
         };
 
-        transcript.validate_and_append_point('V', *proof.V.at(i));
+        transcript.validate_and_append_point('V', *witness_commitments.at(i));
 
         i += 1;
     };


### PR DESCRIPTION
This PR separates the witness commitments ($\vec{V}$) from the proof struct - this both more closely matches the Bulletproofs specification and will make witness injection (e.g. adding merkle root to witness) more ergonomic down the line