### PR TITLE
tests: port merkle tests

### DIFF
--- a/starknet_scripts/src/commands/utils.rs
+++ b/starknet_scripts/src/commands/utils.rs
@@ -53,11 +53,13 @@ pub const CASM_FILE_EXTENSION: &str = "casm.json";
 pub const INITIALIZER_FN_NAME: &str = "initializer";
 pub const MERKLE_HEIGHT: usize = 32;
 
+pub type ScriptAccount = SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>;
+
 pub fn setup_account(
     address: FieldElement,
     private_key: String,
     network: Network,
-) -> Result<SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>> {
+) -> Result<ScriptAccount> {
     let provider = match &network {
         // TODO: Use appropriate RPC endpoints
         Network::AlphaMainnet => JsonRpcClient::new(HttpTransport::new(Url::parse(DEVNET_HOST)?)),
@@ -84,7 +86,7 @@ pub async fn get_or_declare(
     class_hash_hex: Option<String>,
     sierra_path: PathBuf,
     casm_path: PathBuf,
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
 ) -> Result<FieldElement> {
     if let Some(class_hash_hex) = class_hash_hex {
         let class_hash = FieldElement::from_hex_be(&class_hash_hex)?;
@@ -101,7 +103,7 @@ pub async fn get_or_declare(
 pub async fn declare(
     sierra_path: PathBuf,
     casm_path: PathBuf,
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
 ) -> Result<DeclareTransactionResult> {
     let sierra_contract: SierraClass = serde_json::from_reader(File::open(sierra_path)?)?;
     let flattened_class = sierra_contract.flatten()?;
@@ -120,7 +122,7 @@ pub async fn declare(
 }
 
 pub async fn deploy(
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
     class_hash: FieldElement,
     calldata: &[FieldElement],
 ) -> Result<InvokeTransactionResult> {
@@ -140,7 +142,7 @@ pub async fn deploy(
 }
 
 pub async fn initialize(
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
     to: FieldElement,
     calldata: Vec<FieldElement>,
 ) -> Result<InvokeTransactionResult> {
@@ -177,7 +179,7 @@ pub async fn deploy_darkpool(
     merkle_class_hash: Option<String>,
     nullifier_set_class_hash: Option<String>,
     artifacts_path: String,
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
 ) -> Result<(
     FieldElement,
     FieldElement,
@@ -246,7 +248,7 @@ pub async fn deploy_darkpool(
 pub async fn deploy_merkle(
     merkle_class_hash: Option<String>,
     artifacts_path: String,
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
 ) -> Result<(FieldElement, FieldElement, FieldElement)> {
     let merkle_class_hash_felt = get_or_declare(
         merkle_class_hash,
@@ -274,7 +276,7 @@ pub async fn deploy_merkle(
 pub async fn deploy_nullifier_set(
     nullifier_set_class_hash: Option<String>,
     artifacts_path: String,
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
 ) -> Result<(FieldElement, FieldElement, FieldElement)> {
     let nullifier_set_class_hash_felt = get_or_declare(
         nullifier_set_class_hash,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod merkle;
 pub mod nullifier_set;
 pub mod utils;

--- a/tests/src/merkle.rs
+++ b/tests/src/merkle.rs
@@ -1,0 +1,2 @@
+pub mod ark_merkle;
+pub mod utils;

--- a/tests/src/merkle/ark_merkle.rs
+++ b/tests/src/merkle/ark_merkle.rs
@@ -85,5 +85,10 @@ pub fn setup_empty_tree(height: usize) -> ScalarMerkleTree {
         .unwrap()
         .to_bytes_be();
     let leaves_digest = vec![empty_leaf; 1 << (height - 1)];
-    ScalarMerkleTree::new_with_leaf_digest(&(), &(), leaves_digest).unwrap()
+    ScalarMerkleTree::new_with_leaf_digest(
+        &(), /* leaf_hash_param */
+        &(), /* two_to_one_hash_param */
+        leaves_digest,
+    )
+    .unwrap()
 }

--- a/tests/src/merkle/ark_merkle.rs
+++ b/tests/src/merkle/ark_merkle.rs
@@ -1,0 +1,89 @@
+//! Merkle tree utilities using arkworks & starknet-rs.
+//! Provides a minimal implementation that calls out to starknet_crypto::pedersen_hash
+
+use ark_crypto_primitives::{
+    crh::{CRHScheme, TwoToOneCRHScheme},
+    merkle_tree::{Config, IdentityDigestConverter, MerkleTree},
+};
+use ark_std::rand::Rng;
+use mpc_stark::algebra::scalar::Scalar;
+use starknet::core::{crypto::pedersen_hash, types::FieldElement};
+
+pub struct FeltCRH {}
+impl CRHScheme for FeltCRH {
+    type Input = [u8; 32];
+    type Output = [u8; 32];
+    type Parameters = ();
+
+    fn setup<R: Rng>(_r: &mut R) -> Result<Self::Parameters, ark_crypto_primitives::Error> {
+        Ok(())
+    }
+
+    fn evaluate<T: std::borrow::Borrow<Self::Input>>(
+        _parameters: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, ark_crypto_primitives::Error> {
+        // We don't hash at the leaf level
+        Ok(*input.borrow())
+    }
+}
+
+pub struct FeltTwoToOneCRH {}
+impl TwoToOneCRHScheme for FeltTwoToOneCRH {
+    type Input = [u8; 32];
+    type Output = [u8; 32];
+    type Parameters = ();
+
+    fn setup<R: Rng>(_r: &mut R) -> Result<Self::Parameters, ark_crypto_primitives::Error> {
+        Ok(())
+    }
+
+    fn evaluate<T: std::borrow::Borrow<Self::Input>>(
+        _parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, ark_crypto_primitives::Error> {
+        let felt_res = pedersen_hash(
+            &FieldElement::from_bytes_be(left_input.borrow()).unwrap(),
+            &FieldElement::from_bytes_be(right_input.borrow()).unwrap(),
+        );
+        let reduced_scalar = Scalar::from_be_bytes_mod_order(&felt_res.to_bytes_be());
+        Ok(reduced_scalar.to_bytes_be().try_into().unwrap())
+    }
+
+    fn compress<T: std::borrow::Borrow<Self::Output>>(
+        parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, ark_crypto_primitives::Error> {
+        Self::evaluate(parameters, left_input, right_input)
+    }
+}
+
+pub struct MerkleConfig {}
+impl Config for MerkleConfig {
+    type Leaf = [u8; 32];
+    type LeafDigest = [u8; 32];
+    type InnerDigest = [u8; 32];
+
+    type LeafHash = FeltCRH;
+    type TwoToOneHash = FeltTwoToOneCRH;
+    type LeafInnerDigestConverter = IdentityDigestConverter<[u8; 32]>;
+}
+
+pub type ScalarMerkleTree = MerkleTree<MerkleConfig>;
+
+/// The value of an empty leaf in the Merkle tree:
+/// 306932273398430716639340090025251550554329269971178413658580639401611971225
+/// This value is computed as the keccak256 hash of the string 'renegade'
+/// taken modulo the STARK curve's scalar field
+pub const EMPTY_LEAF_VAL: &str =
+    "306932273398430716639340090025251550554329269971178413658580639401611971225";
+
+pub fn setup_empty_tree(height: usize) -> ScalarMerkleTree {
+    let empty_leaf = FieldElement::from_dec_str(EMPTY_LEAF_VAL)
+        .unwrap()
+        .to_bytes_be();
+    let leaves_digest = vec![empty_leaf; 1 << (height - 1)];
+    ScalarMerkleTree::new_with_leaf_digest(&(), &(), leaves_digest).unwrap()
+}

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -1,0 +1,160 @@
+use std::env;
+
+use dojo_test_utils::sequencer::TestSequencer;
+use eyre::{eyre, Result};
+use mpc_stark::algebra::scalar::Scalar;
+use once_cell::sync::OnceCell;
+use starknet::{
+    accounts::{Account, Call, ConnectedAccount, SingleOwnerAccount},
+    core::{
+        types::{BlockId, BlockTag, FieldElement, FunctionCall},
+        utils::get_selector_from_name,
+    },
+    providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
+    signers::LocalWallet,
+};
+use starknet_scripts::commands::utils::{deploy_merkle, initialize};
+use tracing::debug;
+
+use crate::{
+    merkle::ark_merkle::setup_empty_tree,
+    utils::{global_setup, random_felt, ARTIFACTS_PATH_ENV_VAR},
+};
+
+use super::ark_merkle::ScalarMerkleTree;
+
+pub const TEST_MERKLE_HEIGHT: usize = 5;
+
+const GET_ROOT_FN_NAME: &str = "get_root";
+const INSERT_FN_NAME: &str = "insert";
+
+pub static MERKLE_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
+// TODO: Shoudl I try to make the Arkworks merkle tree a global static as well?
+
+// ---------------------
+// | META TEST HELPERS |
+// ---------------------
+
+pub async fn setup_merkle_test() -> Result<(TestSequencer, ScalarMerkleTree)> {
+    let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
+
+    let sequencer = global_setup().await;
+    let account = sequencer.account();
+
+    debug!("Declaring & deploying merkle contract...");
+    let (merkle_address, _, _) = deploy_merkle(None, artifacts_path, &account).await?;
+    if MERKLE_ADDRESS.get().is_none() {
+        // When running multiple tests, it's possible for the OnceCell to already be set.
+        // However, we still want to deploy the contract, since each test gets its own sequencer.
+        MERKLE_ADDRESS.set(merkle_address).unwrap();
+    }
+
+    debug!("Initializing merkle contract...");
+    initialize_merkle_contract(&account, merkle_address, TEST_MERKLE_HEIGHT.into()).await?;
+
+    debug!("Initializing arkworks merkle tree...");
+    // arkworks implementation does height inclusive of root,
+    // so "height" here is one more than what's passed to the contract
+    Ok((sequencer, setup_empty_tree(TEST_MERKLE_HEIGHT + 1)))
+}
+
+// --------------------------------
+// | CONTRACT INTERACTION HELPERS |
+// --------------------------------
+
+async fn call_merkle_contract(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    entry_point: &str,
+    calldata: Vec<FieldElement>,
+) -> Result<Vec<FieldElement>> {
+    debug!("Calling {} on merkle contract...", entry_point);
+    account
+        .provider()
+        .call(
+            FunctionCall {
+                contract_address: *MERKLE_ADDRESS.get().unwrap(),
+                entry_point_selector: get_selector_from_name(entry_point)?,
+                calldata,
+            },
+            BlockId::Tag(BlockTag::Latest),
+        )
+        .await
+        .map_err(|e| eyre!("Error calling {}: {}", entry_point, e))
+}
+
+async fn invoke_merkle_contract(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    entry_point: &str,
+    calldata: Vec<FieldElement>,
+) -> Result<()> {
+    debug!("Invoking {} on merkle contract...", entry_point);
+    account
+        .execute(vec![Call {
+            to: *MERKLE_ADDRESS.get().unwrap(),
+            selector: get_selector_from_name(entry_point)?,
+            calldata,
+        }])
+        .send()
+        .await
+        .map(|_| ())
+        .map_err(|e| eyre!("Error invoking {}: {}", entry_point, e))
+}
+
+pub async fn initialize_merkle_contract(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    merkle_address: FieldElement,
+    merkle_height: FieldElement,
+) -> Result<()> {
+    let calldata = vec![merkle_height];
+    initialize(account, merkle_address, calldata).await?;
+
+    Ok(())
+}
+
+pub async fn contract_get_root(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+) -> Result<Scalar> {
+    let result = call_merkle_contract(account, GET_ROOT_FN_NAME, vec![]).await?;
+    Ok(Scalar::from_be_bytes_mod_order(&result[0].to_bytes_be()))
+}
+
+pub async fn contract_insert(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    value: FieldElement,
+) -> Result<()> {
+    invoke_merkle_contract(account, INSERT_FN_NAME, vec![value]).await
+}
+
+// ----------------
+// | MISC HELPERS |
+// ----------------
+
+pub async fn insert_random_val_to_trees(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    ark_merkle_tree: &mut ScalarMerkleTree,
+    index: usize,
+) -> Result<()> {
+    let value = random_felt();
+    contract_insert(account, value).await?;
+    debug!("Inserting into arkworks merkle tree...");
+    ark_merkle_tree
+        .update(index, &value.to_bytes_be())
+        .map_err(|e| eyre!("Error updating arkworks merkle tree: {}", e))
+}
+
+// --------------------------
+// | TEST ASSERTION HELPERS |
+// --------------------------
+
+pub async fn assert_roots_equal(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    ark_merkle_tree: &ScalarMerkleTree,
+) -> Result<()> {
+    let contract_root = contract_get_root(account).await.unwrap();
+    let ark_root = Scalar::from_be_bytes_mod_order(&ark_merkle_tree.root());
+
+    debug!("Checking if roots match...");
+    assert!(contract_root == ark_root);
+
+    Ok(())
+}

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -2,15 +2,14 @@ use dojo_test_utils::sequencer::TestSequencer;
 use eyre::{eyre, Result};
 use once_cell::sync::OnceCell;
 use starknet::{
-    accounts::{Account, Call, ConnectedAccount, SingleOwnerAccount},
+    accounts::{Account, Call, ConnectedAccount},
     core::{
         types::{BlockId, BlockTag, FieldElement, FunctionCall},
         utils::get_selector_from_name,
     },
-    providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
-    signers::LocalWallet,
+    providers::Provider,
 };
-use starknet_scripts::commands::utils::deploy_nullifier_set;
+use starknet_scripts::commands::utils::{deploy_nullifier_set, ScriptAccount};
 use std::env;
 use tracing::debug;
 
@@ -50,7 +49,7 @@ pub async fn setup_nullifier_set_test() -> Result<TestSequencer> {
 // --------------------------------
 
 async fn call_nullifier_set_contract(
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
     entry_point: &str,
     calldata: Vec<FieldElement>,
 ) -> Result<Vec<FieldElement>> {
@@ -70,7 +69,7 @@ async fn call_nullifier_set_contract(
 }
 
 async fn invoke_nullifier_set_contract(
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
     entry_point: &str,
     calldata: Vec<FieldElement>,
 ) -> Result<()> {
@@ -88,7 +87,7 @@ async fn invoke_nullifier_set_contract(
 }
 
 pub async fn contract_is_nullifier_used(
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
     nullifier: FieldElement,
 ) -> Result<bool> {
     let calldata = vec![nullifier];
@@ -97,7 +96,7 @@ pub async fn contract_is_nullifier_used(
 }
 
 pub async fn contract_mark_nullifier_used(
-    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    account: &ScriptAccount,
     nullifier: FieldElement,
 ) -> Result<()> {
     let calldata = vec![nullifier];

--- a/tests/tests/merkle.rs
+++ b/tests/tests/merkle.rs
@@ -1,0 +1,65 @@
+use eyre::Result;
+use tests::{
+    merkle::utils::{
+        assert_roots_equal, contract_insert, insert_random_val_to_trees, setup_merkle_test,
+        TEST_MERKLE_HEIGHT,
+    },
+    utils::{global_teardown, random_felt},
+};
+
+#[tokio::test]
+async fn test_initialization_root() -> Result<()> {
+    let (sequencer, ark_merkle_tree) = setup_merkle_test().await?;
+
+    assert_roots_equal(&sequencer.account(), &ark_merkle_tree).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_single_insert_root() -> Result<()> {
+    let (sequencer, mut ark_merkle_tree) = setup_merkle_test().await?;
+    let account = sequencer.account();
+
+    insert_random_val_to_trees(&account, &mut ark_merkle_tree, 0).await?;
+
+    assert_roots_equal(&account, &ark_merkle_tree).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multi_insert_root() -> Result<()> {
+    let (sequencer, mut ark_merkle_tree) = setup_merkle_test().await?;
+    let account = sequencer.account();
+
+    for i in 0..2_usize.pow(TEST_MERKLE_HEIGHT.try_into()?) {
+        insert_random_val_to_trees(&account, &mut ark_merkle_tree, i).await?;
+    }
+
+    assert_roots_equal(&account, &ark_merkle_tree).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_full_insert() -> Result<()> {
+    let (sequencer, _) = setup_merkle_test().await?;
+    let account = sequencer.account();
+
+    for _ in 0..2_usize.pow(TEST_MERKLE_HEIGHT.try_into()?) {
+        contract_insert(&account, random_felt()).await?;
+    }
+
+    assert!(contract_insert(&account, random_felt()).await.is_err());
+
+    global_teardown(sequencer);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR ports over the merkle contract integration tests, namely those that test against an equivalent implementation of the merkle tree using arkworks.

The arkworks implementation is also ported over, using the reduction into the scalar field described in #35 