### PR TITLE
renegade_contracts: merkle: use poseidon hash

### DIFF
--- a/src/merkle.cairo
+++ b/src/merkle.cairo
@@ -191,7 +191,8 @@ mod Merkle {
         hash_input.append(current_leaf);
         hash_input.append(current_leaf);
 
-        let next_leaf = *poseidon_hash(hash_input.span(), 1)[0];
+        let next_leaf = *poseidon_hash(hash_input.span(), 1, // num_elements
+         )[0];
         setup_empty_tree(ref self, height - 1, next_leaf)
     }
 
@@ -265,7 +266,8 @@ mod Merkle {
             hash_input.append(value);
             new_subtree_filled = subtree_filled;
         }
-        next_value = *poseidon_hash(hash_input.span(), 1)[0];
+        next_value = *poseidon_hash(hash_input.span(), 1, // num_elements
+         )[0];
 
         // Emit an event indicating that the internal node has changed
         self

--- a/src/merkle/poseidon.cairo
+++ b/src/merkle/poseidon.cairo
@@ -43,6 +43,12 @@ struct PoseidonSponge {
     mds: Array<Array<Scalar>>,
 }
 
+fn poseidon_hash(input: Span<Scalar>, num_elements: usize) -> Array<Scalar> {
+    let mut sponge = PoseidonTrait::new();
+    sponge.absorb(input);
+    sponge.squeeze(num_elements)
+}
+
 #[generate_trait]
 impl PoseidonImpl of PoseidonTrait {
     /// Instantiate a new sponge with the hardcoded round constants & MDS matrix,

--- a/src/testing/tests/merkle_tests.cairo
+++ b/src/testing/tests/merkle_tests.cairo
@@ -8,7 +8,7 @@ const TEST_MERKLE_HEIGHT: u8 = 5;
 const TEST_MERKLE_CAPACITY: u8 = 32;
 
 #[test]
-#[available_gas(100000000)]
+#[available_gas(1000000000)] // 10x
 fn test_initialization_root_history() {
     let merkle = setup_merkle();
     let root = merkle.get_root();
@@ -16,7 +16,7 @@ fn test_initialization_root_history() {
 }
 
 #[test]
-#[available_gas(100000000)]
+#[available_gas(1000000000)] // 10x
 fn test_single_insert_root_history() {
     let mut merkle = setup_merkle();
     merkle.insert(0.into());
@@ -25,7 +25,7 @@ fn test_single_insert_root_history() {
 }
 
 #[test]
-#[available_gas(100000000)]
+#[available_gas(10000000000)] // 100x
 fn test_multi_insert_root_history() {
     let mut merkle = setup_merkle();
 

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -8,12 +8,11 @@ use starknet::core::types::FieldElement;
 use starknet_scripts::commands::utils::{deploy_merkle, initialize, ScriptAccount};
 use tracing::debug;
 
-use crate::{
-    merkle::ark_merkle::setup_empty_tree,
-    utils::{call_contract, global_setup, invoke_contract, random_felt, ARTIFACTS_PATH_ENV_VAR},
+use crate::utils::{
+    call_contract, global_setup, invoke_contract, random_felt, ARTIFACTS_PATH_ENV_VAR,
 };
 
-use super::ark_merkle::ScalarMerkleTree;
+use super::ark_merkle::{setup_empty_tree, ScalarMerkleTree};
 
 pub const TEST_MERKLE_HEIGHT: usize = 5;
 


### PR DESCRIPTION
This PR integrates the Poseidon hash over the scalar field into the Merkle tree contract.

Integration tests are updated to use the Poseidon hash in the Arkworks merkle tree implementation, as well.