### PR TITLE
renegade_contracts: testing: move verifier utils tests to different file

### DIFF
--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -4,7 +4,7 @@ use option::OptionTrait;
 use traits::Into;
 use ec::{ec_point_from_x, ec_mul};
 
-use renegade_contracts::verifier::types::Proof;
+use renegade_contracts::verifier::types::{Proof, SparseWeightMatrix};
 
 const DUMMY_ROOT_INNER: felt252 = 'DUMMY_ROOT';
 const DUMMY_WALLET_BLINDER_TX: felt252 = 'DUMMY_WALLET_BLINDER_TX';
@@ -49,4 +49,39 @@ fn get_dummy_proof() -> Proof {
         a: 12.into(),
         b: 13.into(),
     }
+}
+
+fn get_test_matrix() -> SparseWeightMatrix {
+    // Matrix (full):
+    // [
+    //   [1, 0, 0, 0], 
+    //   [2, 3, 0, 0], 
+    //   [4, 5, 6, 0], 
+    // ]
+
+    // Matrix (sparse):
+    // [
+    //   [(0, 1)], 
+    //   [(0, 2), (1, 3)], 
+    //   [(0, 4), (1, 5), (2, 6)], 
+    // ]
+
+    let mut matrix = ArrayTrait::new();
+
+    let mut row_0 = ArrayTrait::new();
+    row_0.append((0, 1.into()));
+    matrix.append(row_0);
+
+    let mut row_1 = ArrayTrait::new();
+    row_1.append((0, 2.into()));
+    row_1.append((1, 3.into()));
+    matrix.append(row_1);
+
+    let mut row_2 = ArrayTrait::new();
+    row_2.append((0, 4.into()));
+    row_2.append((1, 5.into()));
+    row_2.append((2, 6.into()));
+    matrix.append(row_2);
+
+    matrix
 }

--- a/src/testing/tests/utils_tests.cairo
+++ b/src/testing/tests/utils_tests.cairo
@@ -3,8 +3,14 @@ use array::ArrayTrait;
 
 use renegade_contracts::{
     utils::{math::{get_consecutive_powers, elt_wise_mul, binary_exp}, eq::ArrayTPartialEq},
-    verifier::scalar::Scalar,
+    verifier::{scalar::Scalar, types::{SparseWeightMatrixTrait, SparseWeightVecTrait}},
 };
+
+use super::super::test_utils::get_test_matrix;
+
+// --------------------
+// | MATH UTILS TESTS |
+// --------------------
 
 #[test]
 #[available_gas(100000000)]
@@ -42,4 +48,75 @@ fn test_elt_wise_mul_basic() {
 #[available_gas(100000000)]
 fn test_binary_exp_basic() {
     assert(binary_exp(3.into(), 5) == 243.into(), 'wrong binary exp')
+}
+
+// ------------------------
+// | VERIFIER UTILS TESTS |
+// ------------------------
+
+#[test]
+#[available_gas(100000000)]
+fn test_flatten_sparse_weight_matrix_basic() {
+    let matrix = get_test_matrix();
+
+    let z = 2.into();
+    let width = 4;
+
+    // For z := [2, 2^2, 2^4, ...] we have expected := zW
+    // ("flattening" W matrix via left-multiplication by z)
+    let mut expected = ArrayTrait::new();
+    // 2*1 + 4*2 + 8*4 = 42
+    expected.append(42.into());
+    // 4*3 + 8*5 = 52
+    expected.append(52.into());
+    // 8*6 = 48
+    expected.append(48.into());
+    expected.append(0.into());
+
+    let flattened = matrix.flatten(z, width);
+
+    assert(flattened == expected, 'wrong flattened matrix');
+}
+
+#[test]
+#[available_gas(100000000)]
+fn test_flatten_column_basic() {
+    let mut column = ArrayTrait::new();
+    column.append((0, 1.into()));
+    column.append((2, 2.into()));
+    column.append((4, 3.into()));
+
+    let z = 2.into();
+
+    let flattened = column.flatten(z);
+
+    // 2*1 + 8*2 + 32*3 = 114
+    assert(flattened == 114.into(), 'wrong flattened column');
+}
+
+#[test]
+#[available_gas(100000000)]
+fn test_get_sparse_weight_column_basic() {
+    let matrix = get_test_matrix();
+
+    let col_0 = matrix.get_sparse_weight_column(0);
+    let col_1 = matrix.get_sparse_weight_column(1);
+    let col_2 = matrix.get_sparse_weight_column(2);
+    let col_3 = matrix.get_sparse_weight_column(3);
+
+    let mut expected_col_0 = ArrayTrait::new();
+    expected_col_0.append((0, 1.into()));
+    expected_col_0.append((1, 2.into()));
+    expected_col_0.append((2, 4.into()));
+    let mut expected_col_1 = ArrayTrait::new();
+    expected_col_1.append((1, 3.into()));
+    expected_col_1.append((2, 5.into()));
+    let mut expected_col_2 = ArrayTrait::new();
+    expected_col_2.append((2, 6.into()));
+    let expected_col_3 = ArrayTrait::new();
+
+    assert(col_0 == expected_col_0, 'wrong column 0');
+    assert(col_1 == expected_col_1, 'wrong column 1');
+    assert(col_2 == expected_col_2, 'wrong column 1');
+    assert(col_3 == expected_col_3, 'wrong column 1');
 }

--- a/src/testing/tests/verifier_tests.cairo
+++ b/src/testing/tests/verifier_tests.cairo
@@ -24,7 +24,7 @@ use renegade_contracts::{
         },
         utils::{get_s_elem, calc_delta, squeeze_challenge_scalars}, scalar::{Scalar, ScalarTrait},
     },
-    testing::test_utils::get_dummy_proof,
+    testing::test_utils::{get_dummy_proof, get_test_matrix},
     utils::{
         eq::{
             OptionTPartialEq, ArrayTPartialEq, SpanTPartialEq, TupleSize2PartialEq, EcPointPartialEq
@@ -40,71 +40,6 @@ use renegade_contracts::{
 // ---------------
 // | UTILS TESTS |
 // ---------------
-
-#[test]
-#[available_gas(100000000)]
-fn test_flatten_sparse_weight_matrix_basic() {
-    let matrix = get_test_matrix_1();
-
-    let z = 2.into();
-    let width = 4;
-
-    let mut expected = ArrayTrait::new();
-    // 2*1 + 4*2 + 8*4 = 42
-    expected.append(42.into());
-    // 4*3 + 8*5 = 52
-    expected.append(52.into());
-    // 8*6 = 48
-    expected.append(48.into());
-    expected.append(0.into());
-
-    let flattened = matrix.flatten(z, width);
-
-    assert(flattened == expected, 'wrong flattened matrix');
-}
-
-#[test]
-#[available_gas(100000000)]
-fn test_flatten_column_basic() {
-    let mut column = ArrayTrait::new();
-    column.append((0, 1.into()));
-    column.append((2, 2.into()));
-    column.append((4, 3.into()));
-
-    let z = 2.into();
-
-    let flattened = column.flatten(z);
-
-    // 2*1 + 8*2 + 32*3 = 114
-    assert(flattened == 114.into(), 'wrong flattened column');
-}
-
-#[test]
-#[available_gas(100000000)]
-fn test_get_sparse_weight_column_basic() {
-    let matrix = get_test_matrix_1();
-
-    let col_0 = matrix.get_sparse_weight_column(0);
-    let col_1 = matrix.get_sparse_weight_column(1);
-    let col_2 = matrix.get_sparse_weight_column(2);
-    let col_3 = matrix.get_sparse_weight_column(3);
-
-    let mut expected_col_0 = ArrayTrait::new();
-    expected_col_0.append((0, 1.into()));
-    expected_col_0.append((1, 2.into()));
-    expected_col_0.append((2, 4.into()));
-    let mut expected_col_1 = ArrayTrait::new();
-    expected_col_1.append((1, 3.into()));
-    expected_col_1.append((2, 5.into()));
-    let mut expected_col_2 = ArrayTrait::new();
-    expected_col_2.append((2, 6.into()));
-    let expected_col_3 = ArrayTrait::new();
-
-    assert(col_0 == expected_col_0, 'wrong column 0');
-    assert(col_1 == expected_col_1, 'wrong column 1');
-    assert(col_2 == expected_col_2, 'wrong column 1');
-    assert(col_3 == expected_col_3, 'wrong column 1');
-}
 
 #[test]
 #[available_gas(1000000000)] // 10x
@@ -177,7 +112,7 @@ fn test_get_s_elem_basic() {
 #[test]
 #[available_gas(100000000)]
 fn test_calc_delta_basic() {
-    let W_L = get_test_matrix_1();
+    let W_L = get_test_matrix();
     let W_R = get_test_matrix_2();
 
     let n = 4;
@@ -254,21 +189,6 @@ fn test_squeeze_challenge_scalars_basic() {
 // W_O = [[], [], [], [], [(0, 1)], [(1, 1)], [], [(2, 1)]]
 // W_V = [[(0, -1)], [(1, -1)], [(2, -1)], [(3, -1)], [], [], [(0, -1)], []]
 // c = [(6, 69), (7, 420)]
-
-#[test]
-#[available_gas(100000000)]
-fn test_initializer_storage_serde() {
-    let mut verifier = Verifier::contract_state_for_testing();
-
-    // Initialize verifier
-    let circuit_params = initialize_verifier(ref verifier);
-
-    'fetching circuit params...'.print();
-    let stored_circuit_params = verifier.get_circuit_params();
-
-    'checking circuit params...'.print();
-    assert(circuit_params == stored_circuit_params, 'circuit params not equal');
-}
 
 #[test]
 #[available_gas(1000000000)] // 10x
@@ -387,41 +307,6 @@ fn test_verification_events() {
 // -----------
 // | HELPERS |
 // -----------
-
-fn get_test_matrix_1() -> SparseWeightMatrix {
-    // Matrix (full):
-    // [
-    //   [1, 0, 0, 0], 
-    //   [2, 3, 0, 0], 
-    //   [4, 5, 6, 0], 
-    // ]
-
-    // Matrix (sparse):
-    // [
-    //   [(0, 1)], 
-    //   [(0, 2), (1, 3)], 
-    //   [(0, 4), (1, 5), (2, 6)], 
-    // ]
-
-    let mut matrix = ArrayTrait::new();
-
-    let mut row_0 = ArrayTrait::new();
-    row_0.append((0, 1.into()));
-    matrix.append(row_0);
-
-    let mut row_1 = ArrayTrait::new();
-    row_1.append((0, 2.into()));
-    row_1.append((1, 3.into()));
-    matrix.append(row_1);
-
-    let mut row_2 = ArrayTrait::new();
-    row_2.append((0, 4.into()));
-    row_2.append((1, 5.into()));
-    row_2.append((2, 6.into()));
-    matrix.append(row_2);
-
-    matrix
-}
 
 fn get_test_matrix_2() -> SparseWeightMatrix {
     // Matrix (full):


### PR DESCRIPTION
This PR splits out some of the verifier utilities unit tests into a separate file (`utils_tests.rs`) in preparation for a larger refactor of the verifier tests into integration tests against the devnet.