### PR TITLE
tests: verifier_utils: integration test scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,7 @@ dependencies = [
  "ark-crypto-primitives",
  "ark-ff",
  "ark-std 0.4.0",
+ "byteorder",
  "dojo-test-utils",
  "eyre",
  "katana-core",

--- a/src/testing/test_contracts.cairo
+++ b/src/testing/test_contracts.cairo
@@ -2,3 +2,4 @@ mod dummy_erc20;
 mod dummy_upgrade_target;
 mod poseidon_wrapper;
 mod transcript_wrapper;
+mod verifier_utils_wrapper;

--- a/src/testing/test_contracts/verifier_utils_wrapper.cairo
+++ b/src/testing/test_contracts/verifier_utils_wrapper.cairo
@@ -1,0 +1,54 @@
+use renegade_contracts::{
+    verifier::{scalar::Scalar, types::{Proof, SparseWeightMatrix}}, utils::serde::EcPointSerde
+};
+
+
+#[starknet::interface]
+trait IVerifierUtils<TContractState> {
+    fn calc_delta(
+        self: @TContractState,
+        n: usize,
+        y_inv_powers_to_n: Array<Scalar>,
+        z: Scalar,
+        W_L: SparseWeightMatrix,
+        W_R: SparseWeightMatrix
+    ) -> Scalar;
+    fn get_s_elem(self: @TContractState, u: Array<Scalar>, i: usize) -> Scalar;
+    fn squeeze_challenge_scalars(
+        self: @TContractState, proof: Proof, witness: Array<EcPoint>, m: usize, n_plus: usize
+    ) -> (Array<Scalar>, Array<Scalar>);
+}
+
+#[starknet::contract]
+mod VerifierUtilsWrapper {
+    use array::ArrayTrait;
+    use renegade_contracts::{
+        verifier::{scalar::Scalar, types::{Proof, SparseWeightMatrix}, utils},
+        utils::serde::EcPointSerde
+    };
+
+    #[storage]
+    struct Storage {}
+
+
+    fn calc_delta(
+        self: @ContractState,
+        n: usize,
+        y_inv_powers_to_n: Array<Scalar>,
+        z: Scalar,
+        W_L: SparseWeightMatrix,
+        W_R: SparseWeightMatrix
+    ) -> Scalar {
+        utils::calc_delta(n, y_inv_powers_to_n.span(), z, @W_L, @W_R)
+    }
+
+    fn get_s_elem(self: @ContractState, u: Array<Scalar>, i: usize) -> Scalar {
+        utils::get_s_elem(u.span(), i)
+    }
+
+    fn squeeze_challenge_scalars(
+        self: @ContractState, proof: Proof, witness: Array<EcPoint>, m: usize, n_plus: usize
+    ) -> (Array<Scalar>, Array<Scalar>) {
+        utils::squeeze_challenge_scalars(@proof, witness.span(), m, n_plus)
+    }
+}

--- a/src/testing/tests/utils_tests.cairo
+++ b/src/testing/tests/utils_tests.cairo
@@ -62,6 +62,8 @@ fn test_flatten_sparse_weight_matrix_basic() {
     let z = 2.into();
     let width = 4;
 
+    // For z := [2, 2^2, 2^4, ...] we have expected := zW
+    // ("flattening" W matrix via left-multiplication by z)
     let mut expected = ArrayTrait::new();
     // 2*1 + 4*2 + 8*4 = 42
     expected.append(42.into());

--- a/src/testing/tests/utils_tests.cairo
+++ b/src/testing/tests/utils_tests.cairo
@@ -62,8 +62,6 @@ fn test_flatten_sparse_weight_matrix_basic() {
     let z = 2.into();
     let width = 4;
 
-    // For z := [2, 2^2, 2^4, ...] we have expected := zW
-    // ("flattening" W matrix via left-multiplication by z)
     let mut expected = ArrayTrait::new();
     // 2*1 + 4*2 + 8*4 = 42
     expected.append(42.into());

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,6 +20,7 @@ ark-std = "0.4"
 ark-ff = "0.4"
 rand = "0.8"
 num-bigint = { version = "0.4.3", features = ["rand"] }
+byteorder = "1.4.3"
 
 starknet = { workspace = true }
 katana-core = { git = "https://github.com/dojoengine/dojo.git", rev = "e305d4d" }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,3 +5,4 @@ pub mod poseidon;
 pub mod transcript;
 pub mod utils;
 pub mod verifier;
+pub mod verifier_utils;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,3 +4,4 @@ pub mod nullifier_set;
 pub mod poseidon;
 pub mod transcript;
 pub mod utils;
+pub mod verifier;

--- a/tests/src/poseidon/utils.rs
+++ b/tests/src/poseidon/utils.rs
@@ -14,7 +14,9 @@ use starknet_scripts::commands::utils::{
 use std::{env, iter};
 use tracing::debug;
 
-use crate::utils::{call_contract, global_setup, invoke_contract, ARTIFACTS_PATH_ENV_VAR};
+use crate::utils::{
+    call_contract, felt_to_scalar, global_setup, invoke_contract, ARTIFACTS_PATH_ENV_VAR,
+};
 
 pub const FUZZ_ROUNDS: usize = 10;
 const MAX_INPUT_SIZE: usize = 16;
@@ -105,10 +107,10 @@ pub async fn get_hash(account: &ScriptAccount) -> Result<Vec<Scalar>> {
     )
     .await
     .map(|r| {
-        r.into_iter()
+        r.iter()
             // First element is the length of the output
             .skip(1)
-            .map(|felt| Scalar::from_be_bytes_mod_order(&felt.to_bytes_be()))
+            .map(felt_to_scalar)
             .collect()
     })
 }

--- a/tests/src/transcript/utils.rs
+++ b/tests/src/transcript/utils.rs
@@ -19,12 +19,10 @@ use tracing::debug;
 
 use crate::utils::{
     call_contract, global_setup, invoke_contract, scalar_to_felt, CalldataSerializable,
-    ARTIFACTS_PATH_ENV_VAR,
+    ARTIFACTS_PATH_ENV_VAR, TRANSCRIPT_SEED,
 };
 
 pub const FUZZ_ROUNDS: usize = 10;
-
-const TRANSCRIPT_SEED: &str = "merlin seed";
 
 const TRANSCRIPT_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_TranscriptWrapper";
 

--- a/tests/src/verifier.rs
+++ b/tests/src/verifier.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -1,0 +1,182 @@
+use eyre::{eyre, Result};
+use merlin::HashChainTranscript;
+use mpc_bulletproof::{
+    r1cs::{ConstraintSystem, Prover, R1CSProof, Variable, Verifier},
+    BulletproofGens, PedersenGens, TranscriptProtocol,
+};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use rand::thread_rng;
+use tracing::debug;
+
+use crate::utils::TRANSCRIPT_SEED;
+
+// -------------------------
+// | DUMMY CIRCUIT HELPERS |
+// -------------------------
+
+// The dummy circuit we're using is a very simple circuit with 4 witness elements,
+// 3 multiplication gates, and 2 linear constraints. In total, it is parameterized as follows:
+// n = 3
+// n_plus = 4
+// k = log2(n_plus) = 2
+// m = 4
+// q = 8 (The total number of linear constraints is 8 because there are 3 multiplication gates, and 2 linear constraints per multiplication gate)
+
+// The circuit is defined as follows:
+//
+// Witness:
+// a, b, x, y (all scalars)
+//
+// Circuit:
+// m_1 = multiply(a, b)
+// m_2 = multiply(x, y)
+// m_3 = multiply(m_1, m_2)
+// constrain(a - 69)
+// constrain(m_3 - 420)
+
+// Bearing the following weights:
+// W_L = [[(0, -1)], [], [(1, -1)], [], [(2, -1)], [], [], []]
+// W_R = [[], [(0, -1)], [], [(1, -1)], [], [(2, -1)], [], []]
+// W_O = [[], [], [], [], [(0, 1)], [(1, 1)], [], [(2, 1)]]
+// W_V = [[(0, -1)], [(1, -1)], [(2, -1)], [(3, -1)], [], [], [(0, -1)], []]
+// c = [(6, 69), (7, 420)]
+
+pub const DUMMY_CIRCUIT_N: usize = 3;
+pub const DUMMY_CIRCUIT_N_PLUS: usize = 4;
+pub const DUMMY_CIRCUIT_K: usize = 2;
+pub const DUMMY_CIRCUIT_M: usize = 4;
+pub const DUMMY_CIRCUIT_Q: usize = 8;
+
+pub fn singleprover_prove_dummy_circuit() -> Result<(R1CSProof, Vec<StarkPoint>)> {
+    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
+    let pc_gens = PedersenGens::default();
+    let prover = Prover::new(&pc_gens, &mut transcript);
+
+    let witness = get_dummy_circuit_witness();
+
+    prove(prover, witness)
+}
+
+fn get_dummy_circuit_witness() -> Vec<Scalar> {
+    let a = Scalar::from(69);
+    let b = Scalar::from(420) * a.inverse();
+    let x = Scalar::one();
+    let y = Scalar::one();
+    vec![a, b, x, y]
+}
+
+fn prove(mut prover: Prover, witness: Vec<Scalar>) -> Result<(R1CSProof, Vec<StarkPoint>)> {
+    let mut rng = thread_rng();
+
+    // Commit to the witness
+    let a_blind = Scalar::random(&mut rng);
+    let b_blind = Scalar::random(&mut rng);
+    let x_blind = Scalar::random(&mut rng);
+    let y_blind = Scalar::random(&mut rng);
+
+    let (a_comm, a_var) = prover.commit(witness[0], a_blind);
+    let (b_comm, b_var) = prover.commit(witness[1], b_blind);
+    let (x_comm, x_var) = prover.commit(witness[2], x_blind);
+    let (y_comm, y_var) = prover.commit(witness[3], y_blind);
+
+    // Apply the constraints
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
+
+    // Generate the proof
+    let bp_gens = BulletproofGens::new(8 /* gens_capacity */, 1 /* party_capacity */);
+    let proof = prover
+        .prove(&bp_gens)
+        .map_err(|e| eyre!("error generating proof: {e}"))?;
+
+    Ok((proof, vec![a_comm, b_comm, x_comm, y_comm]))
+}
+
+fn apply_dummy_circuit_constraints<CS: ConstraintSystem>(
+    a: Variable,
+    b: Variable,
+    x: Variable,
+    y: Variable,
+    cs: &mut CS,
+) {
+    let (_, _, m_1) = cs.multiply(a.into(), b.into());
+    let (_, _, m_2) = cs.multiply(x.into(), y.into());
+    let (_, _, m_3) = cs.multiply(m_1.into(), m_2.into());
+    cs.constrain(a - Scalar::from(69));
+    cs.constrain(m_3 - Scalar::from(420));
+}
+
+pub fn prep_dummy_circuit_verifier(verifier: &mut Verifier, witness_commitments: Vec<StarkPoint>) {
+    // Allocate witness commitments into circuit
+    let a_var = verifier.commit(witness_commitments[0]);
+    let b_var = verifier.commit(witness_commitments[1]);
+    let x_var = verifier.commit(witness_commitments[2]);
+    let y_var = verifier.commit(witness_commitments[3]);
+
+    debug!("Applying dummy circuit constraints on verifier...");
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, verifier);
+}
+
+/// Squeezes the expected challenge scalars for a given proof and witness commitments,
+/// copying the implementation in `mpc-bulletproof`.
+/// Assumes the transcript has absorbed nothing other than the seed it was initialized with.
+pub fn squeeze_expected_challenge_scalars(
+    transcript: &mut HashChainTranscript,
+    proof: &R1CSProof,
+    witness_commitments: &[StarkPoint],
+) -> Result<(Vec<Scalar>, Vec<Scalar>)> {
+    let mut challenge_scalars = Vec::with_capacity(5);
+    let mut u = Vec::with_capacity(DUMMY_CIRCUIT_K);
+
+    transcript.r1cs_domain_sep();
+
+    witness_commitments
+        .iter()
+        .try_for_each(|w| transcript.validate_and_append_point(b"V", w))?;
+
+    transcript.append_u64(b"m", DUMMY_CIRCUIT_M as u64);
+
+    transcript.validate_and_append_point(b"A_I1", &proof.A_I1)?;
+    transcript.validate_and_append_point(b"A_O1", &proof.A_O1)?;
+    transcript.validate_and_append_point(b"S1", &proof.S1)?;
+
+    let identity = StarkPoint::identity();
+
+    transcript.append_point(b"A_I2", &identity);
+    transcript.append_point(b"A_O2", &identity);
+    transcript.append_point(b"S2", &identity);
+
+    challenge_scalars.push(transcript.challenge_scalar(b"y"));
+    challenge_scalars.push(transcript.challenge_scalar(b"z"));
+
+    transcript.validate_and_append_point(b"T_1", &proof.T_1)?;
+    transcript.validate_and_append_point(b"T_3", &proof.T_3)?;
+    transcript.validate_and_append_point(b"T_4", &proof.T_4)?;
+    transcript.validate_and_append_point(b"T_5", &proof.T_5)?;
+    transcript.validate_and_append_point(b"T_6", &proof.T_6)?;
+
+    challenge_scalars.push(transcript.challenge_scalar(b"u"));
+    challenge_scalars.push(transcript.challenge_scalar(b"x"));
+
+    transcript.append_scalar(b"t_x", &proof.t_x);
+    transcript.append_scalar(b"t_x_blinding", &proof.t_x_blinding);
+    transcript.append_scalar(b"e_blinding", &proof.e_blinding);
+
+    challenge_scalars.push(transcript.challenge_scalar(b"w"));
+
+    transcript.innerproduct_domain_sep(DUMMY_CIRCUIT_N_PLUS as u64);
+
+    for (l, r) in proof
+        .ipp_proof
+        .L_vec
+        .iter()
+        .zip(proof.ipp_proof.R_vec.iter())
+    {
+        transcript.validate_and_append_point(b"L", l)?;
+        transcript.validate_and_append_point(b"R", r)?;
+        u.push(transcript.challenge_scalar(b"u"));
+    }
+
+    challenge_scalars.push(transcript.challenge_scalar(b"r"));
+
+    Ok((challenge_scalars, u))
+}

--- a/tests/src/verifier_utils.rs
+++ b/tests/src/verifier_utils.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/tests/src/verifier_utils/utils.rs
+++ b/tests/src/verifier_utils/utils.rs
@@ -1,0 +1,178 @@
+use byteorder::{BigEndian, ReadBytesExt};
+use dojo_test_utils::sequencer::TestSequencer;
+use eyre::Result;
+use mpc_bulletproof::r1cs::{R1CSProof, SparseReducedMatrix, Verifier};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use once_cell::sync::OnceCell;
+use starknet::core::types::{DeclareTransactionResult, FieldElement};
+use starknet_scripts::commands::utils::{
+    calculate_contract_address, declare, deploy, get_artifacts, ScriptAccount,
+};
+use std::{env, iter};
+use tracing::debug;
+
+use crate::{
+    utils::{
+        call_contract, felt_to_scalar, global_setup, scalar_to_felt, CalldataSerializable,
+        ARTIFACTS_PATH_ENV_VAR,
+    },
+    verifier::utils::{
+        prep_dummy_circuit_verifier, singleprover_prove_dummy_circuit, DUMMY_CIRCUIT_M,
+        DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS,
+    },
+};
+
+const VERIFIER_UTILS_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_VerifierUtilsWrapper";
+
+const CALC_DELTA_FN_NAME: &str = "calc_delta";
+const GET_S_ELEM_FN_NAME: &str = "get_s_elem";
+const SQUEEZE_CHALLENGE_SCALARS_FN_NAME: &str = "squeeze_challenge_scalars";
+
+static VERIFIER_UTILS_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
+
+// ---------------------
+// | META TEST HELPERS |
+// ---------------------
+
+pub async fn setup_verifier_utils_test(
+    verifier: &mut Verifier<'static, 'static>,
+) -> Result<(TestSequencer, R1CSProof, Vec<StarkPoint>)> {
+    let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
+
+    let sequencer = global_setup().await;
+    let account = sequencer.account();
+
+    debug!("Declaring & deploying verifier utils wrapper contract...");
+    let verifier_utils_wrapper_address =
+        deploy_verifier_utils_wrapper(artifacts_path, &account).await?;
+    if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
+        // When running multiple tests, it's possible for the OnceCell to already be set.
+        // However, we still want to deploy the contract, since each test gets its own sequencer.
+        VERIFIER_UTILS_WRAPPER_ADDRESS
+            .set(verifier_utils_wrapper_address)
+            .unwrap();
+    }
+
+    debug!("Getting example proof & witness commitments...");
+    let (proof, witness_commitments) = singleprover_prove_dummy_circuit().unwrap();
+
+    debug!("Getting reference verifier...");
+    prep_dummy_circuit_verifier(verifier, witness_commitments.clone());
+
+    Ok((sequencer, proof, witness_commitments))
+}
+
+pub async fn deploy_verifier_utils_wrapper(
+    artifacts_path: String,
+    account: &ScriptAccount,
+) -> Result<FieldElement> {
+    let (verifier_utils_sierra_path, verifier_utils_casm_path) =
+        get_artifacts(&artifacts_path, VERIFIER_UTILS_WRAPPER_CONTRACT_NAME);
+    let DeclareTransactionResult { class_hash, .. } = declare(
+        verifier_utils_sierra_path,
+        verifier_utils_casm_path,
+        account,
+    )
+    .await?;
+
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
+}
+
+// --------------------------------
+// | CONTRACT INTERACTION HELPERS |
+// --------------------------------
+
+pub async fn calc_delta(
+    account: &ScriptAccount,
+    y_inv_powers_to_n: Vec<Scalar>,
+    z: Scalar,
+    w_l: SparseReducedMatrix,
+    w_r: SparseReducedMatrix,
+) -> Result<Scalar> {
+    let calldata = iter::once(FieldElement::from(DUMMY_CIRCUIT_N))
+        .chain(y_inv_powers_to_n.to_calldata().into_iter())
+        .chain(iter::once(scalar_to_felt(&z)))
+        .chain(w_l.to_calldata().into_iter())
+        .chain(w_r.to_calldata().into_iter())
+        .collect();
+
+    call_contract(
+        account,
+        *VERIFIER_UTILS_WRAPPER_ADDRESS.get().unwrap(),
+        CALC_DELTA_FN_NAME,
+        calldata,
+    )
+    .await
+    .map(|r| felt_to_scalar(&r[0]))
+}
+
+pub async fn get_s_elem(account: &ScriptAccount, u: Vec<Scalar>, i: usize) -> Result<Scalar> {
+    let calldata = u
+        .to_calldata()
+        .into_iter()
+        .chain(iter::once(FieldElement::from(i)))
+        .collect();
+
+    call_contract(
+        account,
+        *VERIFIER_UTILS_WRAPPER_ADDRESS.get().unwrap(),
+        GET_S_ELEM_FN_NAME,
+        calldata,
+    )
+    .await
+    .map(|r| felt_to_scalar(&r[0]))
+}
+
+pub async fn squeeze_challenge_scalars(
+    account: &ScriptAccount,
+    proof: &R1CSProof,
+    witness_commitments: &Vec<StarkPoint>,
+) -> Result<(Vec<Scalar>, Vec<Scalar>)> {
+    let calldata = proof
+        .to_calldata()
+        .into_iter()
+        .chain(witness_commitments.to_calldata().into_iter())
+        .chain(iter::once(FieldElement::from(DUMMY_CIRCUIT_M)))
+        .chain(iter::once(FieldElement::from(DUMMY_CIRCUIT_N_PLUS)))
+        .collect();
+
+    call_contract(
+        account,
+        *VERIFIER_UTILS_WRAPPER_ADDRESS.get().unwrap(),
+        SQUEEZE_CHALLENGE_SCALARS_FN_NAME,
+        calldata,
+    )
+    .await
+    .map(|r| {
+        // TODO: Implement intelligent deserialization when it is more heavily relied upon
+
+        let mut r_iter = r.iter();
+
+        let challenge_scalars_len = r_iter
+            .next()
+            .unwrap()
+            .to_bytes_be()
+            .as_slice()
+            .read_u32::<BigEndian>()
+            .unwrap() as usize;
+
+        let challenge_scalars = r_iter
+            .by_ref()
+            .take(challenge_scalars_len)
+            .map(felt_to_scalar)
+            .collect();
+
+        let u_len = r_iter
+            .next()
+            .unwrap()
+            .to_bytes_be()
+            .as_slice()
+            .read_u32::<BigEndian>()
+            .unwrap() as usize;
+
+        let u = r_iter.take(u_len).map(felt_to_scalar).collect();
+
+        (challenge_scalars, u)
+    })
+}


### PR DESCRIPTION
This PR introduces scaffolding and utilities to be used in integration tests of the verifier utilities, namely the `calc_delta`, `get_s_elem`, and `squeeze_challenge_scalars` Cairo functions which will be tested against their counterparts in `mpc-bulletproof`.

This includes a wrapper contract that exposes these utility functions, and helpers for getting their exact inputs from the `mpc-bulletproof` implementation (e.g., no single method that "gets challenge scalars for given proof").

This also includes an implementation of the dummy circuit used in the native Cairo tests.