### PR TITLE
tests: verifier: scaffolding for verifier integration tests

### DIFF
--- a/src/testing/tests/verifier_tests.cairo
+++ b/src/testing/tests/verifier_tests.cairo
@@ -92,8 +92,8 @@ fn test_full_verification_ex_proof() {
     'executing verification job'.print();
     verifier.step_verification(11);
 
-    let verification_job = verifier.get_verification_job(11);
-    assert(verification_job.verified == Option::Some(true), 'verification failed');
+    let verified = verifier.check_verification_job_status(11);
+    assert(verified == Option::Some(true), 'verification failed');
     'proof verified!'.print();
 }
 
@@ -119,8 +119,8 @@ fn test_full_verification_modified_proof() {
     'executing verification job'.print();
     verifier.step_verification(11);
 
-    let verification_job = verifier.get_verification_job(11);
-    assert(verification_job.verified == Option::Some(true), 'verification failed');
+    let verified = verifier.check_verification_job_status(11);
+    assert(verified == Option::Some(true), 'verification failed');
 }
 
 // 10x more gas for this test so that verification definitely completes,

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -22,7 +22,9 @@ trait IVerifier<TContractState> {
     );
     fn step_verification(ref self: TContractState, verification_job_id: felt252);
     fn get_circuit_params(self: @TContractState) -> CircuitParams;
-    fn get_verification_job(self: @TContractState, verification_job_id: felt252) -> VerificationJob;
+    fn check_verification_job_status(
+        self: @TContractState, verification_job_id: felt252
+    ) -> Option<bool>;
 }
 
 #[starknet::contract]
@@ -295,10 +297,10 @@ mod Verifier {
             }
         }
 
-        fn get_verification_job(
+        fn check_verification_job_status(
             self: @ContractState, verification_job_id: felt252
-        ) -> VerificationJob {
-            self.verification_queue.read(verification_job_id).inner
+        ) -> Option<bool> {
+            self.verification_queue.read(verification_job_id).inner.verified
         }
     }
 

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -260,17 +260,29 @@ impl MatchPayload {
 }
 
 pub struct CircuitParams {
+    /// Number of multiplication gates in the circuit
     pub n: usize,
+    /// Number of multiplication gates in the circuit, padded to the next power of 2
     pub n_plus: usize,
+    /// log2(n_plus)
     pub k: usize,
+    /// Number of linear constraints in the circuit
     pub q: usize,
+    /// Number of witness elements for the circuit
     pub m: usize,
+    /// Generator for Pedersen commitments
     pub b: StarkPoint,
+    /// Generator for blinding in Pedersen commitments
     pub b_blind: StarkPoint,
+    /// Sparse-reduced matrix of left input weights in the circuit
     pub w_l: SparseReducedMatrix,
+    /// Sparse-reduced matrix of right input weights in the circuit
     pub w_r: SparseReducedMatrix,
+    /// Sparse-reduced matrix of output weights in the circuit
     pub w_o: SparseReducedMatrix,
+    /// Sparse-reduced matrix of witness weights in the circuit
     pub w_v: SparseReducedMatrix,
+    /// Sparse-reduced vector of constants in the circuit
     pub c: SparseWeightRow,
 }
 


### PR DESCRIPTION
This PR introduces scaffolding & utilities for running verifier integration tests (attempting verification of valid & invalid proofs), as well as slightly tweaking the verifier contract interface to only return the `verified` field of the `VerificationJob`, as this is all that is relevant.