### PR TITLE
meta: remove test badges while CI is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@
 
 <div>
   <img
-    src="https://github.com/renegade-fi/renegade-contracts/actions/workflows/test_cairo.yml/badge.svg"
-  />
-  <img
-    src="https://github.com/renegade-fi/renegade-contracts/actions/workflows/test_devnet.yml/badge.svg"
-  />
-  <img
     src="https://github.com/renegade-fi/renegade-contracts/actions/workflows/format.yml/badge.svg"
   />
   <a href="https://twitter.com/renegade_fi" target="_blank">


### PR DESCRIPTION
Since cairo/devnet tests have started OOMing the actions runner, we disabled them in CI (I'm the only one working on these contracts anyway) - so there's no point in keeping the badges for these actions in our readme