### PR TITLE
renegade_contracts: darkpool: initialize darkpool w/ single verifier

### DIFF
--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -2,9 +2,11 @@ use array::ArrayTrait;
 use serde::Serde;
 use option::OptionTrait;
 use traits::Into;
-use ec::{ec_point_from_x, ec_mul};
+use ec::{ec_point_from_x, ec_mul, ec_point_new, StarkCurve};
 
-use renegade_contracts::verifier::types::{Proof, SparseWeightMatrix};
+use renegade_contracts::verifier::types::{
+    Proof, SparseWeightMatrix, SparseWeightVec, CircuitParams
+};
 
 const DUMMY_ROOT_INNER: felt252 = 'DUMMY_ROOT';
 const DUMMY_WALLET_BLINDER_TX: felt252 = 'DUMMY_WALLET_BLINDER_TX';
@@ -84,4 +86,106 @@ fn get_test_matrix() -> SparseWeightMatrix {
     matrix.append(row_2);
 
     matrix
+}
+
+fn get_dummy_circuit_weights() -> (
+    SparseWeightMatrix, SparseWeightMatrix, SparseWeightMatrix, SparseWeightMatrix, SparseWeightVec, 
+) {
+    let mut W_L = ArrayTrait::new();
+    let mut W_L_0 = ArrayTrait::new();
+    W_L_0.append((0_usize, -(1.into())));
+    W_L.append(W_L_0);
+    W_L.append(ArrayTrait::new());
+    let mut W_L_2 = ArrayTrait::new();
+    W_L_2.append((1_usize, -(1.into())));
+    W_L.append(W_L_2);
+    W_L.append(ArrayTrait::new());
+    let mut W_L_4 = ArrayTrait::new();
+    W_L_4.append((2_usize, -(1.into())));
+    W_L.append(W_L_4);
+    W_L.append(ArrayTrait::new());
+    W_L.append(ArrayTrait::new());
+    W_L.append(ArrayTrait::new());
+
+    let mut W_R = ArrayTrait::new();
+    W_R.append(ArrayTrait::new());
+    let mut W_R_1 = ArrayTrait::new();
+    W_R_1.append((0_usize, -(1.into())));
+    W_R.append(W_R_1);
+    W_R.append(ArrayTrait::new());
+    let mut W_R_3 = ArrayTrait::new();
+    W_R_3.append((1_usize, -(1.into())));
+    W_R.append(W_R_3);
+    W_R.append(ArrayTrait::new());
+    let mut W_R_5 = ArrayTrait::new();
+    W_R_5.append((2_usize, -(1.into())));
+    W_R.append(W_R_5);
+    W_R.append(ArrayTrait::new());
+    W_R.append(ArrayTrait::new());
+
+    let mut W_O = ArrayTrait::new();
+    W_O.append(ArrayTrait::new());
+    W_O.append(ArrayTrait::new());
+    W_O.append(ArrayTrait::new());
+    W_O.append(ArrayTrait::new());
+    let mut W_O_4 = ArrayTrait::new();
+    W_O_4.append((0_usize, 1.into()));
+    W_O.append(W_O_4);
+    let mut W_O_5 = ArrayTrait::new();
+    W_O_5.append((1_usize, 1.into()));
+    W_O.append(W_O_5);
+    W_O.append(ArrayTrait::new());
+    let mut W_O_7 = ArrayTrait::new();
+    W_O_7.append((2_usize, 1.into()));
+    W_O.append(W_O_7);
+
+    let mut W_V = ArrayTrait::new();
+    let mut W_V_0 = ArrayTrait::new();
+    W_V_0.append((0_usize, -(1.into())));
+    W_V.append(W_V_0);
+    let mut W_V_1 = ArrayTrait::new();
+    W_V_1.append((1_usize, -(1.into())));
+    W_V.append(W_V_1);
+    let mut W_V_2 = ArrayTrait::new();
+    W_V_2.append((2_usize, -(1.into())));
+    W_V.append(W_V_2);
+    let mut W_V_3 = ArrayTrait::new();
+    W_V_3.append((3_usize, -(1.into())));
+    W_V.append(W_V_3);
+    W_V.append(ArrayTrait::new());
+    W_V.append(ArrayTrait::new());
+    let mut W_V_6 = ArrayTrait::new();
+    W_V_6.append((0_usize, -(1.into())));
+    W_V.append(W_V_6);
+    W_V.append(ArrayTrait::new());
+
+    let mut c = ArrayTrait::new();
+    c.append((6_usize, 69.into()));
+    c.append((7_usize, 420.into()));
+
+    (W_L, W_R, W_O, W_V, c)
+}
+
+fn get_dummy_circuit_size_params() -> (usize, usize, usize, usize, usize) {
+    let n = 3;
+    let n_plus = 4;
+    let k = 2;
+    let q = 8;
+    let m = 4;
+
+    (n, n_plus, k, q, m)
+}
+
+fn get_dummy_circuit_pc_gens() -> (EcPoint, EcPoint) {
+    let gen = ec_point_new(StarkCurve::GEN_X, StarkCurve::GEN_Y);
+
+    (gen, gen)
+}
+
+fn get_dummy_circuit_params() -> CircuitParams {
+    let (n, n_plus, k, q, m) = get_dummy_circuit_size_params();
+    let (B, B_blind) = get_dummy_circuit_pc_gens();
+    let (W_L, W_R, W_O, W_V, c) = get_dummy_circuit_weights();
+
+    CircuitParams { n, n_plus, k, q, m, B, B_blind, W_L, W_R, W_O, W_V, c }
 }

--- a/starknet_scripts/src/cli.rs
+++ b/starknet_scripts/src/cli.rs
@@ -32,6 +32,13 @@ pub struct DeployArgs {
     /// the nullifier set contract will be declared.
     pub nullifier_set_class_hash: Option<String>,
 
+    #[arg(long, long_help)]
+    /// The class hash of the verifier contract, in hex form.
+    /// {n}
+    /// If the darkpool or verifier contract is being deployed and this flag is not set,
+    /// the verifier contract will be declared.
+    pub verifier_class_hash: Option<String>,
+
     #[arg(short, long, long_help)]
     /// Whether or not to initialize the contract.
     pub initialize: bool,
@@ -107,6 +114,7 @@ pub enum Contract {
     Darkpool,
     Merkle,
     NullifierSet,
+    // TODO: Add verifier contract
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -2,9 +2,13 @@ use ark_ff::{BigInteger, PrimeField};
 use dojo_test_utils::sequencer::{Environment, StarknetConfig, TestSequencer};
 use eyre::{eyre, Result};
 use katana_core::{constants::DEFAULT_INVOKE_MAX_STEPS, sequencer::SequencerConfig};
+use merlin::HashChainTranscript;
 use mpc_bulletproof::{
-    r1cs::{R1CSProof, SparseReducedMatrix, SparseWeightRow},
-    InnerProductProof,
+    r1cs::{
+        CircuitWeights, ConstraintSystem, Prover, R1CSProof, SparseReducedMatrix, SparseWeightRow,
+        Variable, Verifier,
+    },
+    BulletproofGens, InnerProductProof, PedersenGens,
 };
 use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
 use num_bigint::{BigUint, RandBigInt};
@@ -165,31 +169,6 @@ pub fn insert_scalar_to_ark_merkle_tree(
         .map_err(|e| eyre!("Error updating arkworks merkle tree: {}", e))?;
 
     Ok(Scalar::from_be_bytes_mod_order(&ark_merkle_tree.root()))
-}
-
-pub fn get_dummy_proof() -> R1CSProof {
-    R1CSProof {
-        A_I1: StarkPoint::generator(),
-        A_O1: StarkPoint::generator(),
-        S1: StarkPoint::generator(),
-        A_I2: StarkPoint::generator(),
-        A_O2: StarkPoint::generator(),
-        S2: StarkPoint::generator(),
-        T_1: StarkPoint::generator(),
-        T_3: StarkPoint::generator(),
-        T_4: StarkPoint::generator(),
-        T_5: StarkPoint::generator(),
-        T_6: StarkPoint::generator(),
-        t_x: Scalar::random(&mut thread_rng()),
-        t_x_blinding: Scalar::random(&mut thread_rng()),
-        e_blinding: Scalar::random(&mut thread_rng()),
-        ipp_proof: InnerProductProof {
-            L_vec: vec![],
-            R_vec: vec![],
-            a: Scalar::random(&mut thread_rng()),
-            b: Scalar::random(&mut thread_rng()),
-        },
-    }
 }
 
 // --------------------------
@@ -435,5 +414,173 @@ impl CalldataSerializable for CircuitParams {
             )
             .chain(self.c.to_calldata().into_iter())
             .collect()
+    }
+}
+
+// -------------------------
+// | DUMMY CIRCUIT HELPERS |
+// -------------------------
+
+// The dummy circuit we're using is a very simple circuit with 4 witness elements,
+// 3 multiplication gates, and 2 linear constraints. In total, it is parameterized as follows:
+// n = 3
+// n_plus = 4
+// k = log2(n_plus) = 2
+// m = 4
+// q = 8 (The total number of linear constraints is 8 because there are 3 multiplication gates, and 2 linear constraints per multiplication gate)
+
+// The circuit is defined as follows:
+//
+// Witness:
+// a, b, x, y (all scalars)
+//
+// Circuit:
+// m_1 = multiply(a, b)
+// m_2 = multiply(x, y)
+// m_3 = multiply(m_1, m_2)
+// constrain(a - 69)
+// constrain(m_3 - 420)
+
+// Bearing the following weights:
+// W_L = [[(0, -1)], [], [(1, -1)], [], [(2, -1)], [], [], []]
+// W_R = [[], [(0, -1)], [], [(1, -1)], [], [(2, -1)], [], []]
+// W_O = [[], [], [], [], [(0, 1)], [(1, 1)], [], [(2, 1)]]
+// W_V = [[(0, -1)], [(1, -1)], [(2, -1)], [(3, -1)], [], [], [(0, -1)], []]
+// c = [(6, 69), (7, 420)]
+
+pub const DUMMY_CIRCUIT_N: usize = 3;
+pub const DUMMY_CIRCUIT_N_PLUS: usize = 4;
+pub const DUMMY_CIRCUIT_K: usize = 2;
+pub const DUMMY_CIRCUIT_M: usize = 4;
+pub const DUMMY_CIRCUIT_Q: usize = 8;
+
+pub fn singleprover_prove_dummy_circuit() -> Result<(R1CSProof, Vec<StarkPoint>)> {
+    debug!("Generating proof for dummy circuit...");
+    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
+    let pc_gens = PedersenGens::default();
+    let prover = Prover::new(&pc_gens, &mut transcript);
+
+    let witness = get_dummy_circuit_witness();
+
+    prove(prover, witness)
+}
+
+fn get_dummy_circuit_witness() -> Vec<Scalar> {
+    let a = Scalar::from(69);
+    let b = Scalar::from(420) * a.inverse();
+    let x = Scalar::one();
+    let y = Scalar::one();
+    vec![a, b, x, y]
+}
+
+fn prove(mut prover: Prover, witness: Vec<Scalar>) -> Result<(R1CSProof, Vec<StarkPoint>)> {
+    let mut rng = thread_rng();
+
+    // Commit to the witness
+    let a_blind = Scalar::random(&mut rng);
+    let b_blind = Scalar::random(&mut rng);
+    let x_blind = Scalar::random(&mut rng);
+    let y_blind = Scalar::random(&mut rng);
+
+    let (a_comm, a_var) = prover.commit(witness[0], a_blind);
+    let (b_comm, b_var) = prover.commit(witness[1], b_blind);
+    let (x_comm, x_var) = prover.commit(witness[2], x_blind);
+    let (y_comm, y_var) = prover.commit(witness[3], y_blind);
+
+    // Apply the constraints
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
+
+    // Generate the proof
+    let bp_gens = BulletproofGens::new(8 /* gens_capacity */, 1 /* party_capacity */);
+    let proof = prover
+        .prove(&bp_gens)
+        .map_err(|e| eyre!("error generating proof: {e}"))?;
+
+    Ok((proof, vec![a_comm, b_comm, x_comm, y_comm]))
+}
+
+fn apply_dummy_circuit_constraints<CS: ConstraintSystem>(
+    a: Variable,
+    b: Variable,
+    x: Variable,
+    y: Variable,
+    cs: &mut CS,
+) {
+    let (_, _, m_1) = cs.multiply(a.into(), b.into());
+    let (_, _, m_2) = cs.multiply(x.into(), y.into());
+    let (_, _, m_3) = cs.multiply(m_1.into(), m_2.into());
+    cs.constrain(a - Scalar::from(69));
+    cs.constrain(m_3 - Scalar::from(420));
+}
+
+pub fn prep_dummy_circuit_verifier(verifier: &mut Verifier, witness_commitments: Vec<StarkPoint>) {
+    // Allocate witness commitments into circuit
+    let a_var = verifier.commit(witness_commitments[0]);
+    let b_var = verifier.commit(witness_commitments[1]);
+    let x_var = verifier.commit(witness_commitments[2]);
+    let y_var = verifier.commit(witness_commitments[3]);
+
+    debug!("Applying dummy circuit constraints on verifier...");
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, verifier);
+}
+
+pub fn get_dummy_proof() -> R1CSProof {
+    R1CSProof {
+        A_I1: StarkPoint::generator(),
+        A_O1: StarkPoint::generator(),
+        S1: StarkPoint::generator(),
+        A_I2: StarkPoint::generator(),
+        A_O2: StarkPoint::generator(),
+        S2: StarkPoint::generator(),
+        T_1: StarkPoint::generator(),
+        T_3: StarkPoint::generator(),
+        T_4: StarkPoint::generator(),
+        T_5: StarkPoint::generator(),
+        T_6: StarkPoint::generator(),
+        t_x: Scalar::random(&mut thread_rng()),
+        t_x_blinding: Scalar::random(&mut thread_rng()),
+        e_blinding: Scalar::random(&mut thread_rng()),
+        ipp_proof: InnerProductProof {
+            L_vec: vec![],
+            R_vec: vec![],
+            a: Scalar::random(&mut thread_rng()),
+            b: Scalar::random(&mut thread_rng()),
+        },
+    }
+}
+
+pub fn get_dummy_circuit_weights() -> CircuitWeights {
+    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
+    let pc_gens = PedersenGens::default();
+    let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+    let mut rng = thread_rng();
+
+    let (_, a_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+    let (_, b_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+    let (_, x_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+    let (_, y_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
+
+    prover.get_weights()
+}
+
+pub fn get_dummy_circuit_params() -> CircuitParams {
+    let circuit_weights = get_dummy_circuit_weights();
+    let pc_gens = PedersenGens::default();
+    CircuitParams {
+        n: DUMMY_CIRCUIT_N,
+        n_plus: DUMMY_CIRCUIT_N_PLUS,
+        k: DUMMY_CIRCUIT_K,
+        q: DUMMY_CIRCUIT_Q,
+        m: DUMMY_CIRCUIT_M,
+        b: pc_gens.B,
+        b_blind: pc_gens.B_blinding,
+        w_l: circuit_weights.w_l,
+        w_o: circuit_weights.w_o,
+        w_r: circuit_weights.w_r,
+        w_v: circuit_weights.w_v,
+        c: circuit_weights.c,
     }
 }

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -1,28 +1,20 @@
 use dojo_test_utils::sequencer::TestSequencer;
-use eyre::{eyre, Result};
-use merlin::HashChainTranscript;
-use mpc_bulletproof::{
-    r1cs::{CircuitWeights, ConstraintSystem, Prover, R1CSProof, Variable, Verifier},
-    BulletproofGens, PedersenGens,
-};
-use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use eyre::Result;
+
+use mpc_bulletproof::r1cs::R1CSProof;
+use mpc_stark::algebra::stark_curve::StarkPoint;
 use once_cell::sync::OnceCell;
-use rand::thread_rng;
-use starknet::core::types::{DeclareTransactionResult, FieldElement};
-use starknet_scripts::commands::utils::{
-    calculate_contract_address, declare, deploy, get_artifacts, initialize, ScriptAccount,
-};
+use starknet::core::types::FieldElement;
+use starknet_scripts::commands::utils::{deploy_verifier, initialize, ScriptAccount};
 use std::{env, iter};
 use tracing::debug;
 
 use crate::utils::{
-    call_contract, global_setup, invoke_contract, CalldataSerializable, CircuitParams,
-    ARTIFACTS_PATH_ENV_VAR, TRANSCRIPT_SEED,
+    call_contract, get_dummy_circuit_params, global_setup, invoke_contract, CalldataSerializable,
+    ARTIFACTS_PATH_ENV_VAR,
 };
 
 pub const FUZZ_ROUNDS: usize = 1;
-
-const VERIFIER_CONTRACT_NAME: &str = "renegade_contracts_Verifier";
 
 const QUEUE_VERIFICATION_JOB_FN_NAME: &str = "queue_verification_job";
 const STEP_VERIFICATION_FN_NAME: &str = "step_verification";
@@ -41,7 +33,7 @@ pub async fn setup_verifier_test() -> Result<TestSequencer> {
     let account = sequencer.account();
 
     debug!("Declaring & deploying verifier contract...");
-    let verifier_address = deploy_verifier(artifacts_path, &account).await?;
+    let (verifier_address, _, _) = deploy_verifier(None, artifacts_path, &account).await?;
     if VERIFIER_ADDRESS.get().is_none() {
         // When running multiple tests, it's possible for the OnceCell to already be set.
         // However, we still want to deploy the contract, since each test gets its own sequencer.
@@ -54,19 +46,6 @@ pub async fn setup_verifier_test() -> Result<TestSequencer> {
     Ok(sequencer)
 }
 
-pub async fn deploy_verifier(
-    artifacts_path: String,
-    account: &ScriptAccount,
-) -> Result<FieldElement> {
-    let (verifier_sierra_path, verifier_casm_path) =
-        get_artifacts(&artifacts_path, VERIFIER_CONTRACT_NAME);
-    let DeclareTransactionResult { class_hash, .. } =
-        declare(verifier_sierra_path, verifier_casm_path, account).await?;
-
-    deploy(account, class_hash, &[]).await?;
-    Ok(calculate_contract_address(class_hash, &[]))
-}
-
 // --------------------------------
 // | CONTRACT INTERACTION HELPERS |
 // --------------------------------
@@ -75,27 +54,13 @@ pub async fn initialize_verifier<'t, 'g>(
     account: &ScriptAccount,
     verifier_address: FieldElement,
 ) -> Result<()> {
-    let circuit_weights = get_dummy_circuit_weights();
-    let pc_gens = PedersenGens::default();
-    let circuit_params = CircuitParams {
-        n: DUMMY_CIRCUIT_N,
-        n_plus: DUMMY_CIRCUIT_N_PLUS,
-        k: DUMMY_CIRCUIT_K,
-        q: DUMMY_CIRCUIT_Q,
-        m: DUMMY_CIRCUIT_M,
-        b: pc_gens.B,
-        b_blind: pc_gens.B_blinding,
-        w_l: circuit_weights.w_l,
-        w_o: circuit_weights.w_o,
-        w_r: circuit_weights.w_r,
-        w_v: circuit_weights.w_v,
-        c: circuit_weights.c,
-    };
-    let calldata = circuit_params.to_calldata();
-
-    initialize(account, verifier_address, calldata)
-        .await
-        .map(|_| ())
+    initialize(
+        account,
+        verifier_address,
+        get_dummy_circuit_params().to_calldata(),
+    )
+    .await
+    .map(|_| ())
 }
 
 pub async fn queue_verification_job(
@@ -152,128 +117,4 @@ pub async fn check_verification_job_status(
             Some(r[1] == FieldElement::ONE)
         }
     })
-}
-
-// -------------------------
-// | DUMMY CIRCUIT HELPERS |
-// -------------------------
-
-// The dummy circuit we're using is a very simple circuit with 4 witness elements,
-// 3 multiplication gates, and 2 linear constraints. In total, it is parameterized as follows:
-// n = 3
-// n_plus = 4
-// k = log2(n_plus) = 2
-// m = 4
-// q = 8 (The total number of linear constraints is 8 because there are 3 multiplication gates, and 2 linear constraints per multiplication gate)
-
-// The circuit is defined as follows:
-//
-// Witness:
-// a, b, x, y (all scalars)
-//
-// Circuit:
-// m_1 = multiply(a, b)
-// m_2 = multiply(x, y)
-// m_3 = multiply(m_1, m_2)
-// constrain(a - 69)
-// constrain(m_3 - 420)
-
-// Bearing the following weights:
-// W_L = [[(0, -1)], [], [(1, -1)], [], [(2, -1)], [], [], []]
-// W_R = [[], [(0, -1)], [], [(1, -1)], [], [(2, -1)], [], []]
-// W_O = [[], [], [], [], [(0, 1)], [(1, 1)], [], [(2, 1)]]
-// W_V = [[(0, -1)], [(1, -1)], [(2, -1)], [(3, -1)], [], [], [(0, -1)], []]
-// c = [(6, 69), (7, 420)]
-
-pub const DUMMY_CIRCUIT_N: usize = 3;
-pub const DUMMY_CIRCUIT_N_PLUS: usize = 4;
-pub const DUMMY_CIRCUIT_K: usize = 2;
-pub const DUMMY_CIRCUIT_M: usize = 4;
-pub const DUMMY_CIRCUIT_Q: usize = 8;
-
-pub fn singleprover_prove_dummy_circuit() -> Result<(R1CSProof, Vec<StarkPoint>)> {
-    debug!("Generating proof for dummy circuit...");
-    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
-    let pc_gens = PedersenGens::default();
-    let prover = Prover::new(&pc_gens, &mut transcript);
-
-    let witness = get_dummy_circuit_witness();
-
-    prove(prover, witness)
-}
-
-fn get_dummy_circuit_witness() -> Vec<Scalar> {
-    let a = Scalar::from(69);
-    let b = Scalar::from(420) * a.inverse();
-    let x = Scalar::one();
-    let y = Scalar::one();
-    vec![a, b, x, y]
-}
-
-fn prove(mut prover: Prover, witness: Vec<Scalar>) -> Result<(R1CSProof, Vec<StarkPoint>)> {
-    let mut rng = thread_rng();
-
-    // Commit to the witness
-    let a_blind = Scalar::random(&mut rng);
-    let b_blind = Scalar::random(&mut rng);
-    let x_blind = Scalar::random(&mut rng);
-    let y_blind = Scalar::random(&mut rng);
-
-    let (a_comm, a_var) = prover.commit(witness[0], a_blind);
-    let (b_comm, b_var) = prover.commit(witness[1], b_blind);
-    let (x_comm, x_var) = prover.commit(witness[2], x_blind);
-    let (y_comm, y_var) = prover.commit(witness[3], y_blind);
-
-    // Apply the constraints
-    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
-
-    // Generate the proof
-    let bp_gens = BulletproofGens::new(8 /* gens_capacity */, 1 /* party_capacity */);
-    let proof = prover
-        .prove(&bp_gens)
-        .map_err(|e| eyre!("error generating proof: {e}"))?;
-
-    Ok((proof, vec![a_comm, b_comm, x_comm, y_comm]))
-}
-
-fn apply_dummy_circuit_constraints<CS: ConstraintSystem>(
-    a: Variable,
-    b: Variable,
-    x: Variable,
-    y: Variable,
-    cs: &mut CS,
-) {
-    let (_, _, m_1) = cs.multiply(a.into(), b.into());
-    let (_, _, m_2) = cs.multiply(x.into(), y.into());
-    let (_, _, m_3) = cs.multiply(m_1.into(), m_2.into());
-    cs.constrain(a - Scalar::from(69));
-    cs.constrain(m_3 - Scalar::from(420));
-}
-
-pub fn prep_dummy_circuit_verifier(verifier: &mut Verifier, witness_commitments: Vec<StarkPoint>) {
-    // Allocate witness commitments into circuit
-    let a_var = verifier.commit(witness_commitments[0]);
-    let b_var = verifier.commit(witness_commitments[1]);
-    let x_var = verifier.commit(witness_commitments[2]);
-    let y_var = verifier.commit(witness_commitments[3]);
-
-    debug!("Applying dummy circuit constraints on verifier...");
-    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, verifier);
-}
-
-pub fn get_dummy_circuit_weights() -> CircuitWeights {
-    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
-    let pc_gens = PedersenGens::default();
-    let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-    let mut rng = thread_rng();
-
-    let (_, a_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
-    let (_, b_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
-    let (_, x_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
-    let (_, y_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
-
-    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
-
-    prover.get_weights()
 }

--- a/tests/src/verifier_utils/utils.rs
+++ b/tests/src/verifier_utils/utils.rs
@@ -16,15 +16,10 @@ use starknet_scripts::commands::utils::{
 use std::{env, io::Cursor, iter};
 use tracing::debug;
 
-use crate::{
-    utils::{
-        call_contract, felt_to_scalar, global_setup, scalar_to_felt, CalldataSerializable,
-        ARTIFACTS_PATH_ENV_VAR,
-    },
-    verifier::utils::{
-        prep_dummy_circuit_verifier, singleprover_prove_dummy_circuit, DUMMY_CIRCUIT_K,
-        DUMMY_CIRCUIT_M, DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS,
-    },
+use crate::utils::{
+    call_contract, felt_to_scalar, global_setup, prep_dummy_circuit_verifier, scalar_to_felt,
+    singleprover_prove_dummy_circuit, CalldataSerializable, ARTIFACTS_PATH_ENV_VAR,
+    DUMMY_CIRCUIT_K, DUMMY_CIRCUIT_M, DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS,
 };
 
 const VERIFIER_UTILS_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_VerifierUtilsWrapper";

--- a/tests/tests/verifier.rs
+++ b/tests/tests/verifier.rs
@@ -2,10 +2,10 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
-    utils::{global_teardown, random_felt},
+    utils::{global_teardown, random_felt, singleprover_prove_dummy_circuit},
     verifier::utils::{
         check_verification_job_status, queue_verification_job, setup_verifier_test,
-        singleprover_prove_dummy_circuit, step_verification, FUZZ_ROUNDS,
+        step_verification, FUZZ_ROUNDS,
     },
 };
 

--- a/tests/tests/verifier_utils.rs
+++ b/tests/tests/verifier_utils.rs
@@ -6,8 +6,7 @@ use mpc_bulletproof::{
     PedersenGens,
 };
 use tests::{
-    utils::{global_teardown, TRANSCRIPT_SEED},
-    verifier::utils::DUMMY_CIRCUIT_N,
+    utils::{global_teardown, DUMMY_CIRCUIT_N, TRANSCRIPT_SEED},
     verifier_utils::utils::{
         calc_delta, get_expected_dummy_circuit_delta, get_expected_dummy_circuit_s, get_s_elem,
         setup_verifier_utils_test, squeeze_challenge_scalars,


### PR DESCRIPTION
This PR is the beginning of the gradual integration of the verifier into the darkpool.

Here, we add the verifier to the darkpool initialization process, for now initializing just a single verifier contract (in the future, there will be multiple verifier contracts for each of the circuits).

We do not yet actually invoke the verifier contract (other than initializing it). Implementing access controls for the verifier contract is also saved for a future PR.

This PR also makes the relevant changes to the integration testing code to ensure that the darkpool is initialized with a verifier.

Since there are a lot of shared utilities between the integration testing code and the deploy/upgrade scripts, the minimal reasonable changes are made to the latter, as well.

However, updating the deploy / upgrade scripts to properly include the verifier contract is left for a future PR.

**Testing:**
Cairo tests pass, and integration tests that are affected by these changes (`darkpool`, `verifier`, `verifier_utils`) pass.