### PR TITLE
renegade_contracts: darkpool: add verification polling methods

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -28,3 +28,27 @@ struct MatchPayload {
     valid_reblind_proof: Proof,
     valid_reblind_witness_commitments: Array<EcPoint>,
 }
+
+#[derive(Drop, Serde, Copy)]
+struct NewWalletCallbackElems {
+    wallet_blinder_share: Scalar,
+    wallet_share_commitment: Scalar,
+}
+
+#[derive(Drop, Serde, Clone)]
+struct UpdateWalletCallbackElems {
+    wallet_blinder_share: Scalar,
+    wallet_share_commitment: Scalar,
+    old_shares_nullifier: Scalar,
+    external_transfers: Array<ExternalTransfer>,
+}
+
+#[derive(Drop, Serde, Copy)]
+struct ProcessMatchCallbackElems {
+    party_0_wallet_blinder_share: Scalar,
+    party_0_wallet_share_commitment: Scalar,
+    party_0_old_shares_nullifier: Scalar,
+    party_1_wallet_blinder_share: Scalar,
+    party_1_wallet_share_commitment: Scalar,
+    party_1_old_shares_nullifier: Scalar,
+}

--- a/src/testing/tests.cairo
+++ b/src/testing/tests.cairo
@@ -1,4 +1,4 @@
-mod darkpool_tests;
+// mod darkpool_tests;
 mod nullifier_set_tests;
 mod merkle_tests;
 mod utils_tests;


### PR DESCRIPTION
This PR introduces "polling" methods accompanying `new_wallet`, `update_wallet`, and `process_match`, which call out to the underlying `verifier.step_verification` method and, when it completes, handle the merkle / nullifier set updating logic (should the proof verify).

As such, calling `new_wallet` / etc. will simply enqueue the verification jobs, and to drive them forward, one must call `poll_new_wallet` / etc.

A deliberate unknown left here is whether or not enqueueing the 6 verification jobs necessary for `process_match` will be possible within a single transaction. For full size circuits, almost definitely not, but this is something I intend to iterate on, for now optimistically assuming that it will work.

The darkpool Cairo tests are now excluded from the `testing` module since they will all need to be ported over to e2e tests (since they now invoke the verifier, they will need a proof generated from `mpc-bulletproof` as input).

The e2e test updates are coming in a separate PR.