### PR TITLE
tests: darkpool: update existing tests to account for verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", tag
 cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
 cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
 cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1", features = [ "testing" ] }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
 cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
 cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
 cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -18,7 +18,6 @@ use super::ark_merkle::{setup_empty_tree, ScalarMerkleTree};
 pub const TEST_MERKLE_HEIGHT: usize = 5;
 pub const MULTI_INSERT_ROUNDS: usize = 10;
 
-pub const GET_ROOT_FN_NAME: &str = "get_root";
 const INSERT_FN_NAME: &str = "insert";
 
 pub static MERKLE_ADDRESS: OnceCell<FieldElement> = OnceCell::new();

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -11,7 +11,6 @@ use crate::utils::{global_setup, invoke_contract, scalar_to_felt, ARTIFACTS_PATH
 
 pub const FUZZ_ROUNDS: usize = 100;
 
-pub const IS_NULLIFIER_USED_FN_NAME: &str = "is_nullifier_used";
 const MARK_NULLIFIER_USED_FN_NAME: &str = "mark_nullifier_used";
 
 pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -10,7 +10,7 @@ use std::{env, iter};
 use tracing::debug;
 
 use crate::utils::{
-    call_contract, get_dummy_circuit_params, global_setup, invoke_contract, CalldataSerializable,
+    get_dummy_circuit_params, global_setup, invoke_contract, CalldataSerializable,
     ARTIFACTS_PATH_ENV_VAR,
 };
 
@@ -18,9 +18,8 @@ pub const FUZZ_ROUNDS: usize = 1;
 
 const QUEUE_VERIFICATION_JOB_FN_NAME: &str = "queue_verification_job";
 const STEP_VERIFICATION_FN_NAME: &str = "step_verification";
-const CHECK_VERIFICATION_JOB_STATUS_FN_NAME: &str = "check_verification_job_status";
 
-static VERIFIER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
+pub static VERIFIER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
 // ---------------------
 // | META TEST HELPERS |
@@ -96,25 +95,4 @@ pub async fn step_verification(
         vec![verification_job_id],
     )
     .await
-}
-
-pub async fn check_verification_job_status(
-    account: &ScriptAccount,
-    verification_job_id: FieldElement,
-) -> Result<Option<bool>> {
-    call_contract(
-        account,
-        *VERIFIER_ADDRESS.get().unwrap(),
-        CHECK_VERIFICATION_JOB_STATUS_FN_NAME,
-        vec![verification_job_id],
-    )
-    .await
-    .map(|r| {
-        if r[0] == FieldElement::ONE {
-            // This is how Cairo serializes an Option::None
-            None
-        } else {
-            Some(r[1] == FieldElement::ONE)
-        }
-    })
 }

--- a/tests/tests/verifier.rs
+++ b/tests/tests/verifier.rs
@@ -2,10 +2,13 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
-    utils::{global_teardown, random_felt, singleprover_prove_dummy_circuit},
+    utils::{
+        check_verification_job_status, global_teardown, random_felt,
+        singleprover_prove_dummy_circuit,
+    },
     verifier::utils::{
-        check_verification_job_status, queue_verification_job, setup_verifier_test,
-        step_verification, FUZZ_ROUNDS,
+        queue_verification_job, setup_verifier_test, step_verification, FUZZ_ROUNDS,
+        VERIFIER_ADDRESS,
     },
 };
 
@@ -19,16 +22,24 @@ async fn test_full_verification_fuzz() -> Result<()> {
         let verification_job_id = random_felt();
         queue_verification_job(&account, &proof, &witness_commitments, verification_job_id).await?;
 
-        while check_verification_job_status(&account, verification_job_id)
-            .await?
-            .is_none()
+        while check_verification_job_status(
+            &account,
+            *VERIFIER_ADDRESS.get().unwrap(),
+            verification_job_id,
+        )
+        .await?
+        .is_none()
         {
             step_verification(&account, verification_job_id).await?;
         }
 
-        assert!(check_verification_job_status(&account, verification_job_id)
-            .await?
-            .unwrap());
+        assert!(check_verification_job_status(
+            &account,
+            *VERIFIER_ADDRESS.get().unwrap(),
+            verification_job_id
+        )
+        .await?
+        .unwrap());
     }
 
     global_teardown(sequencer);
@@ -46,18 +57,24 @@ async fn test_full_verification_invalid_proof() -> Result<()> {
     let verification_job_id = random_felt();
     queue_verification_job(&account, &proof, &witness_commitments, verification_job_id).await?;
 
-    while check_verification_job_status(&account, verification_job_id)
-        .await?
-        .is_none()
+    while check_verification_job_status(
+        &account,
+        *VERIFIER_ADDRESS.get().unwrap(),
+        verification_job_id,
+    )
+    .await?
+    .is_none()
     {
         step_verification(&account, verification_job_id).await?;
     }
 
-    assert!(
-        !check_verification_job_status(&account, verification_job_id)
-            .await?
-            .unwrap()
-    );
+    assert!(!check_verification_job_status(
+        &account,
+        *VERIFIER_ADDRESS.get().unwrap(),
+        verification_job_id
+    )
+    .await?
+    .unwrap());
 
     global_teardown(sequencer);
     Ok(())


### PR DESCRIPTION
This PR updates the existing darkpool e2e tests (which test that the merkle root is properly updated after `new_wallet`, `update_wallet`, and `process_match`) to account for asynchronous proof verification within these contract functions - i.e., it makes sure to call the `poll_*` methods if necessary.

**Testing**:
Relevant tests (`tests/darkpool.rs`) pass