### PR TITLE
renegade_contracts: darkpool: use initial tx hash for last_modified

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -33,6 +33,7 @@ struct MatchPayload {
 struct NewWalletCallbackElems {
     wallet_blinder_share: Scalar,
     wallet_share_commitment: Scalar,
+    tx_hash: felt252,
 }
 
 #[derive(Drop, Serde, Clone)]
@@ -41,6 +42,7 @@ struct UpdateWalletCallbackElems {
     wallet_share_commitment: Scalar,
     old_shares_nullifier: Scalar,
     external_transfers: Array<ExternalTransfer>,
+    tx_hash: felt252,
 }
 
 #[derive(Drop, Serde, Copy)]
@@ -51,4 +53,5 @@ struct ProcessMatchCallbackElems {
     party_1_wallet_blinder_share: Scalar,
     party_1_wallet_share_commitment: Scalar,
     party_1_old_shares_nullifier: Scalar,
+    tx_hash: felt252,
 }

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -246,7 +246,7 @@ pub async fn new_wallet(account: &ScriptAccount, args: &NewWalletArgs) -> Result
 pub async fn poll_new_wallet(
     account: &ScriptAccount,
     verification_job_id: FieldElement,
-) -> Result<FieldElement> {
+) -> Result<()> {
     invoke_contract(
         account,
         *DARKPOOL_ADDRESS.get().unwrap(),
@@ -254,14 +254,14 @@ pub async fn poll_new_wallet(
         vec![verification_job_id],
     )
     .await
-    .map(|r| r.transaction_hash)
+    .map(|_| ())
 }
 
 pub async fn poll_new_wallet_to_completion(
     account: &ScriptAccount,
     args: &NewWalletArgs,
 ) -> Result<FieldElement> {
-    let mut tx_hash = new_wallet(account, args).await?;
+    let tx_hash = new_wallet(account, args).await?;
     while check_verification_job_status(
         account,
         *DARKPOOL_ADDRESS.get().unwrap(),
@@ -270,7 +270,7 @@ pub async fn poll_new_wallet_to_completion(
     .await?
     .is_none()
     {
-        tx_hash = poll_new_wallet(account, args.verification_job_id).await?;
+        poll_new_wallet(account, args.verification_job_id).await?;
     }
 
     Ok(tx_hash)
@@ -295,7 +295,7 @@ pub async fn update_wallet(
 pub async fn poll_update_wallet(
     account: &ScriptAccount,
     verification_job_id: FieldElement,
-) -> Result<FieldElement> {
+) -> Result<()> {
     invoke_contract(
         account,
         *DARKPOOL_ADDRESS.get().unwrap(),
@@ -303,14 +303,14 @@ pub async fn poll_update_wallet(
         vec![verification_job_id],
     )
     .await
-    .map(|r| r.transaction_hash)
+    .map(|_| ())
 }
 
 pub async fn poll_update_wallet_to_completion(
     account: &ScriptAccount,
     args: &UpdateWalletArgs,
 ) -> Result<FieldElement> {
-    let mut tx_hash = update_wallet(account, args).await?;
+    let tx_hash = update_wallet(account, args).await?;
     while check_verification_job_status(
         account,
         *DARKPOOL_ADDRESS.get().unwrap(),
@@ -319,7 +319,7 @@ pub async fn poll_update_wallet_to_completion(
     .await?
     .is_none()
     {
-        tx_hash = poll_update_wallet(account, args.verification_job_id).await?;
+        poll_update_wallet(account, args.verification_job_id).await?;
     }
 
     Ok(tx_hash)
@@ -344,7 +344,7 @@ pub async fn process_match(
 pub async fn poll_process_match(
     account: &ScriptAccount,
     verification_job_ids: Vec<FieldElement>,
-) -> Result<FieldElement> {
+) -> Result<()> {
     invoke_contract(
         account,
         *DARKPOOL_ADDRESS.get().unwrap(),
@@ -352,7 +352,7 @@ pub async fn poll_process_match(
         verification_job_ids,
     )
     .await
-    .map(|r| r.transaction_hash)
+    .map(|_| ())
 }
 
 pub async fn process_match_verification_jobs_are_done(
@@ -379,10 +379,10 @@ pub async fn poll_process_match_to_completion(
     account: &ScriptAccount,
     args: &ProcessMatchArgs,
 ) -> Result<FieldElement> {
-    let mut tx_hash = process_match(account, args).await?;
+    let tx_hash = process_match(account, args).await?;
 
     while !process_match_verification_jobs_are_done(account, &args.verification_job_ids).await? {
-        tx_hash = poll_process_match(account, args.verification_job_ids.clone()).await?;
+        poll_process_match(account, args.verification_job_ids.clone()).await?;
     }
 
     Ok(tx_hash)

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -3,9 +3,10 @@ use starknet::accounts::Account;
 use tests::{
     darkpool::utils::{
         balance_of, get_dummy_new_wallet_args, get_dummy_process_match_args,
-        get_dummy_update_wallet_args, get_wallet_blinder_transaction, new_wallet_and_poll,
-        process_match_and_poll, setup_darkpool_test, update_wallet_and_poll, upgrade,
-        DARKPOOL_ADDRESS, DARKPOOL_CLASS_HASH, ERC20_ADDRESS, INIT_BALANCE, TRANSFER_AMOUNT,
+        get_dummy_update_wallet_args, get_wallet_blinder_transaction,
+        poll_new_wallet_to_completion, poll_process_match_to_completion,
+        poll_update_wallet_to_completion, setup_darkpool_test, upgrade, DARKPOOL_ADDRESS,
+        DARKPOOL_CLASS_HASH, ERC20_ADDRESS, INIT_BALANCE, TRANSFER_AMOUNT,
         UPGRADE_TARGET_CLASS_HASH,
     },
     utils::{
@@ -360,7 +361,7 @@ async fn test_upgrade_darkpool_storage() -> Result<()> {
 
     let args = get_dummy_update_wallet_args()?;
 
-    update_wallet_and_poll(&account, &args).await?;
+    poll_update_wallet_to_completion(&account, &args).await?;
 
     // Get pre-upgrade root
     let pre_upgrade_root = get_root(&account, *DARKPOOL_ADDRESS.get().unwrap()).await?;


### PR DESCRIPTION
This PR tweaks the logic of `new_wallet`, `update_wallet`, and `process_match` so that the transaction hash of the first (enqueueing) transaction, as opposed to the last (polling) transaction is stored in the `last_modified` mapping in contract storage.

The `*_last_modified` tests have been updated and pass.