### PR TITLE
tests: darkpool: ported upgrade storage test

### DIFF
--- a/src/testing/tests.cairo
+++ b/src/testing/tests.cairo
@@ -1,4 +1,4 @@
-// mod darkpool_tests;
+mod darkpool_tests;
 mod nullifier_set_tests;
 mod merkle_tests;
 mod utils_tests;

--- a/src/testing/tests/darkpool_tests.cairo
+++ b/src/testing/tests/darkpool_tests.cairo
@@ -1,42 +1,28 @@
-use clone::Clone;
 use option::OptionTrait;
 use result::ResultTrait;
 use traits::{TryInto, Into};
-use box::BoxTrait;
 use array::ArrayTrait;
-use zeroable::Zeroable;
 use starknet::{
-    ContractAddress, contract_address_try_from_felt252, contract_address_to_felt252, deploy_syscall,
-    get_tx_info, testing::set_contract_address, contract_address::ContractAddressZeroable,
+    ContractAddress, contract_address_try_from_felt252, deploy_syscall,
+    testing::set_contract_address,
 };
 
 use renegade_contracts::{
-    darkpool::{
-        Darkpool, Darkpool::ContractState, IDarkpool, IDarkpoolDispatcher, IDarkpoolDispatcherTrait,
-        types::{ExternalTransfer, MatchPayload}
-    },
-    merkle::Merkle, nullifier_set::NullifierSet, verifier::{scalar::Scalar, types::Proof, Verifier},
-    oz::erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
+    darkpool::{Darkpool, IDarkpoolDispatcher, IDarkpoolDispatcherTrait, }, merkle::Merkle,
+    nullifier_set::NullifierSet, verifier::Verifier,
 };
 
 use super::{
     merkle_tests::TEST_MERKLE_HEIGHT,
     super::{
-        test_utils::{
-            get_dummy_proof, get_dummy_circuit_params, DUMMY_ROOT_INNER, DUMMY_WALLET_BLINDER_TX
-        },
-        test_contracts::{dummy_erc20::DummyERC20, dummy_upgrade_target::DummyUpgradeTarget}
+        test_utils::{get_dummy_circuit_params, DUMMY_ROOT_INNER, DUMMY_WALLET_BLINDER_TX},
+        test_contracts::{dummy_upgrade_target::DummyUpgradeTarget}
     }
 };
-
-use debug::PrintTrait;
 
 
 const TEST_CALLER: felt252 = 'TEST_CALLER';
 const DUMMY_CALLER: felt252 = 'DUMMY_CALLER';
-
-const INIT_BALANCE: u256 = 1000;
-const TRANSFER_AMOUNT: u256 = 100;
 
 // ---------
 // | TESTS |
@@ -63,44 +49,6 @@ fn test_upgrade_darkpool() {
 
     darkpool.upgrade(Darkpool::TEST_CLASS_HASH.try_into().unwrap());
     assert(darkpool.get_wallet_blinder_transaction(0.into()) == 0, 'original target wrong result');
-}
-
-#[test]
-#[available_gas(10000000000)] // 100x
-fn test_upgrade_darkpool_storage() {
-    let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
-    set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
-
-    let (
-        wallet_blinder_share,
-        wallet_share_commitment,
-        old_shares_nullifier,
-        public_wallet_shares,
-        external_transfers,
-        proof,
-        witness_commitments
-    ) =
-        get_dummy_update_wallet_args();
-
-    darkpool
-        .update_wallet(
-            wallet_blinder_share,
-            wallet_share_commitment,
-            old_shares_nullifier,
-            public_wallet_shares,
-            external_transfers,
-            proof,
-            witness_commitments
-        );
-
-    let original_root = darkpool.get_root();
-
-    darkpool.upgrade(DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap());
-    darkpool.upgrade(Darkpool::TEST_CLASS_HASH.try_into().unwrap());
-
-    assert(darkpool.get_root() == original_root, 'root not preserved');
-    assert(darkpool.is_nullifier_used(old_shares_nullifier), 'nullifier not preserved');
 }
 
 #[test]
@@ -281,87 +229,4 @@ fn initialize_darkpool(ref darkpool: IDarkpoolDispatcher, verifier_address: Cont
             TEST_MERKLE_HEIGHT,
             get_dummy_circuit_params(),
         );
-}
-
-fn setup_dummy_erc20(darkpool_contract_address: ContractAddress) -> IERC20Dispatcher {
-    let mut calldata = ArrayTrait::new();
-    calldata.append('DummyToken');
-    calldata.append('DUMMY');
-    calldata.append(INIT_BALANCE.low.into());
-    calldata.append(INIT_BALANCE.high.into());
-    calldata.append(2);
-    calldata.append(TEST_CALLER);
-    calldata.append(contract_address_to_felt252(darkpool_contract_address));
-
-    let (dummy_erc20_address, _) = deploy_syscall(
-        DummyERC20::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false, 
-    )
-        .unwrap();
-
-    let mut dummy_erc20 = IERC20Dispatcher { contract_address: dummy_erc20_address };
-    dummy_erc20.approve(darkpool_contract_address, INIT_BALANCE);
-
-    dummy_erc20
-}
-
-fn get_dummy_new_wallet_args() -> (Scalar, Scalar, Array<Scalar>, Proof, Array<EcPoint>) {
-    (0.into(), 0.into(), ArrayTrait::new(), get_dummy_proof(), ArrayTrait::new())
-}
-
-fn get_dummy_update_wallet_args() -> (
-    Scalar, Scalar, Scalar, Array<Scalar>, Array<ExternalTransfer>, Proof, Array<EcPoint>
-) {
-    (
-        0.into(),
-        0.into(),
-        0.into(),
-        ArrayTrait::new(),
-        ArrayTrait::new(),
-        get_dummy_proof(),
-        ArrayTrait::new(),
-    )
-}
-
-fn get_dummy_match_payload(blinder: Scalar, nullifier: Scalar) -> MatchPayload {
-    MatchPayload {
-        wallet_blinder_share: blinder,
-        wallet_share_commitment: 0.into(),
-        old_shares_nullifier: nullifier,
-        public_wallet_shares: ArrayTrait::new(),
-        valid_commitments_proof: get_dummy_proof(),
-        valid_commitments_witness_commitments: ArrayTrait::new(),
-        valid_reblind_proof: get_dummy_proof(),
-        valid_reblind_witness_commitments: ArrayTrait::new(),
-    }
-}
-
-fn get_dummy_process_match_args() -> (
-    MatchPayload, MatchPayload, Proof, Array<EcPoint>, Proof, Array<EcPoint>
-) {
-    (
-        get_dummy_match_payload(0.into(), 0.into()),
-        get_dummy_match_payload(1.into(), 1.into()),
-        get_dummy_proof(),
-        ArrayTrait::new(),
-        get_dummy_proof(),
-        ArrayTrait::new(),
-    )
-}
-
-fn get_dummy_deposit(dummy_erc20_address: ContractAddress) -> ExternalTransfer {
-    ExternalTransfer {
-        account_addr: contract_address_try_from_felt252(TEST_CALLER).unwrap(),
-        mint: dummy_erc20_address,
-        amount: TRANSFER_AMOUNT,
-        is_withdrawal: false,
-    }
-}
-
-fn get_dummy_withdrawal(dummy_erc20_address: ContractAddress) -> ExternalTransfer {
-    ExternalTransfer {
-        account_addr: contract_address_try_from_felt252(TEST_CALLER).unwrap(),
-        mint: dummy_erc20_address,
-        amount: TRANSFER_AMOUNT,
-        is_withdrawal: true,
-    }
 }

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -3,14 +3,14 @@ use starknet::accounts::Account;
 use tests::{
     darkpool::utils::{
         balance_of, get_dummy_new_wallet_args, get_dummy_process_match_args,
-        get_dummy_update_wallet_args, get_wallet_blinder_transaction,
-        poll_new_wallet_to_completion, poll_process_match_to_completion,
-        poll_update_wallet_to_completion, setup_darkpool_test, DARKPOOL_ADDRESS, ERC20_ADDRESS,
-        INIT_BALANCE, TRANSFER_AMOUNT,
+        get_dummy_update_wallet_args, get_wallet_blinder_transaction, new_wallet_and_poll,
+        process_match_and_poll, setup_darkpool_test, update_wallet_and_poll, upgrade,
+        DARKPOOL_ADDRESS, DARKPOOL_CLASS_HASH, ERC20_ADDRESS, INIT_BALANCE, TRANSFER_AMOUNT,
+        UPGRADE_TARGET_CLASS_HASH,
     },
     utils::{
-        assert_roots_equal, global_teardown, insert_scalar_to_ark_merkle_tree, is_nullifier_used,
-        ExternalTransfer, StarknetU256,
+        assert_roots_equal, get_root, global_teardown, insert_scalar_to_ark_merkle_tree,
+        is_nullifier_used, ExternalTransfer, StarknetU256,
     },
 };
 
@@ -20,7 +20,11 @@ use tests::{
 
 #[tokio::test]
 async fn test_initialization_root() -> Result<()> {
-    let (sequencer, ark_merkle_tree) = setup_darkpool_test(false).await?;
+    let (sequencer, ark_merkle_tree) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
 
     assert_roots_equal(
         &sequencer.account(),
@@ -36,7 +40,11 @@ async fn test_initialization_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_new_wallet_root() -> Result<()> {
-    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(false).await?;
+    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_new_wallet_args()?;
@@ -53,7 +61,11 @@ async fn test_new_wallet_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_root() -> Result<()> {
-    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(false).await?;
+    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_update_wallet_args()?;
@@ -70,7 +82,11 @@ async fn test_update_wallet_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_process_match_root() -> Result<()> {
-    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(false).await?;
+    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_process_match_args()?;
@@ -100,7 +116,11 @@ async fn test_process_match_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_new_wallet_last_modified() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(false).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_new_wallet_args()?;
@@ -118,7 +138,11 @@ async fn test_new_wallet_last_modified() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_last_modified() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(false).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_update_wallet_args()?;
@@ -136,7 +160,11 @@ async fn test_update_wallet_last_modified() -> Result<()> {
 
 #[tokio::test]
 async fn test_process_match_last_modified() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(false).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_process_match_args()?;
@@ -163,7 +191,11 @@ async fn test_process_match_last_modified() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_nullifiers() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(false).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_update_wallet_args()?;
@@ -195,7 +227,11 @@ async fn test_update_wallet_nullifiers() -> Result<()> {
 
 #[tokio::test]
 async fn test_process_match_nullifiers() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(false).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        false, /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let args = get_dummy_process_match_args()?;
@@ -247,7 +283,11 @@ async fn test_process_match_nullifiers() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_deposit() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(true).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        true,  /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let mut args = get_dummy_update_wallet_args()?;
@@ -277,7 +317,11 @@ async fn test_update_wallet_deposit() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_withdrawal() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(true).await?;
+    let (sequencer, _) = setup_darkpool_test(
+        true,  /* init_erc20 */
+        false, /* init_upgrade_target */
+    )
+    .await?;
     let account = sequencer.account();
 
     let mut args = get_dummy_update_wallet_args()?;
@@ -299,6 +343,44 @@ async fn test_update_wallet_withdrawal() -> Result<()> {
     // Assumes that INIT_BALANCE +/- TRANSFER_AMOUNT fits within the lower 128 bits of a u256 for simplicity
     assert_eq!(account_balance.low, INIT_BALANCE + TRANSFER_AMOUNT);
     assert_eq!(darkpool_balance.low, INIT_BALANCE - TRANSFER_AMOUNT);
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_upgrade_darkpool_storage() -> Result<()> {
+    let (sequencer, _) = setup_darkpool_test(
+        false, /* init_erc20 */
+        true,  /* init_upgrade_target */
+    )
+    .await?;
+    let account = sequencer.account();
+
+    let args = get_dummy_update_wallet_args()?;
+
+    update_wallet_and_poll(&account, &args).await?;
+
+    // Get pre-upgrade root
+    let pre_upgrade_root = get_root(&account, *DARKPOOL_ADDRESS.get().unwrap()).await?;
+
+    // Upgrade to dummy target
+    upgrade(&account, *UPGRADE_TARGET_CLASS_HASH.get().unwrap()).await?;
+    // Upgrade back to original impl
+    upgrade(&account, *DARKPOOL_CLASS_HASH.get().unwrap()).await?;
+
+    // Get storage elements (root, nullifier_used) after upgrade
+    let post_upgrade_root = get_root(&account, *DARKPOOL_ADDRESS.get().unwrap()).await?;
+    let old_shares_nullifier_used = is_nullifier_used(
+        &account,
+        *DARKPOOL_ADDRESS.get().unwrap(),
+        args.old_shares_nullifier,
+    )
+    .await?;
+
+    assert_eq!(pre_upgrade_root, post_upgrade_root);
+    assert!(old_shares_nullifier_used);
 
     global_teardown(sequencer);
 


### PR DESCRIPTION
This PR ports over the "upgrade storage test" from Cairo to the e2e stack, which asserts that contract storage is preserved appropriately between implementation upgrades. This needs to be on the e2e stack b/c we affect storage in a semantically relevant way by calling `update_wallet`, which requires a valid proof for execution.

The new test passes, and the remaining Cairo darkpool tests pass as well.