### PR TITLE
renegade_contracts, tests: align `process_match` statement types

### DIFF
--- a/src/darkpool/statements.cairo
+++ b/src/darkpool/statements.cairo
@@ -37,3 +37,48 @@ struct ValidWalletUpdateStatement {
     /// The timestamp this update is at
     timestamp: u64,
 }
+
+/// Statement for the VALID_REBLIND proof
+#[derive(Drop, Serde, Copy)]
+struct ValidReblindStatement {
+    /// The nullifier of the original wallet's secret shares
+    original_shares_nullifier: Scalar,
+    /// A commitment to the private secret shares of the reblinded wallet
+    reblinded_private_shares_commitment: Scalar,
+    /// The global merkle root to prove inclusion into
+    merkle_root: Scalar,
+}
+
+/// Statememt for the VALID_COMMITMENTS proof
+#[derive(Drop, Serde, Copy)]
+struct ValidCommitmentsStatement {
+    /// The index of the balance that holds the mint that the wallet will
+    /// send if a successful match occurs
+    balance_send_index: u64,
+    /// The index of the balance that holds the mint that the wallet will
+    /// receive if a successful match occurs
+    balance_receive_index: u64,
+    /// The index of the order that is to be matched
+    order_index: u64,
+}
+
+/// Statement for the VALID_SETTLE proof
+#[derive(Drop, Serde, Clone)]
+struct ValidSettleStatement {
+    /// The modified public secret shares of the first party
+    party0_modified_shares: Array<Scalar>,
+    /// The modified public secret shares of the second party
+    party1_modified_shares: Array<Scalar>,
+    /// The index of the balance that the first party sent in the settlement
+    party0_send_balance_index: u64,
+    /// The index of teh balance that the first party received in the settlement
+    party0_receive_balance_index: u64,
+    /// The index of the first party's order that was matched
+    party0_order_index: u64,
+    /// The index of the balance that the second party sent in the settlement
+    party1_send_balance_index: u64,
+    /// The index of teh balance that the second party received in the settlement
+    party1_receive_balance_index: u64,
+    /// The index of the second party's order that was matched
+    party1_order_index: u64,
+}

--- a/src/darkpool/statements.cairo
+++ b/src/darkpool/statements.cairo
@@ -1,6 +1,6 @@
 use clone::Clone;
 
-use renegade_contracts::verifier::scalar::Scalar;
+use renegade_contracts::{verifier::scalar::Scalar, utils::eq::ArrayTPartialEq};
 
 use super::types::ExternalTransfer;
 
@@ -11,7 +11,7 @@ use super::types::ExternalTransfer;
 /// to/from Scalars as the relayer-side implementation.
 
 /// Statement for the VALID_WALLET_CREATE proof
-#[derive(Drop, Serde, Clone)]
+#[derive(Drop, Serde, Clone, PartialEq)]
 struct ValidWalletCreateStatement {
     /// The commitment to the private secret shares of the wallet
     private_shares_commitment: Scalar,
@@ -20,7 +20,7 @@ struct ValidWalletCreateStatement {
 }
 
 /// Statement for the VALID_WALLET_UPDATE proof
-#[derive(Drop, Serde, Clone)]
+#[derive(Drop, Serde, Clone, PartialEq)]
 struct ValidWalletUpdateStatement {
     /// The nullifier of the old wallet's secret shares
     old_shares_nullifier: Scalar,
@@ -28,57 +28,57 @@ struct ValidWalletUpdateStatement {
     new_private_shares_commitment: Scalar,
     /// The public secret shares of the new wallet
     new_public_shares: Array<Scalar>,
-    /// The global Merkle root that the wallet share proofs open to
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the old wallet's private secret shares
     merkle_root: Scalar,
-    /// The external transfer tuple
+    /// The external transfer associated with this update
     external_transfer: ExternalTransfer,
-    /// The public root key of the old wallet, rotated out after update
+    /// The public root key of the old wallet, rotated out after this update
     old_pk_root: Array<Scalar>,
-    /// The timestamp this update is at
+    /// The timestamp this update was applied at
     timestamp: u64,
 }
 
 /// Statement for the VALID_REBLIND proof
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Copy, PartialEq)]
 struct ValidReblindStatement {
     /// The nullifier of the original wallet's secret shares
     original_shares_nullifier: Scalar,
     /// A commitment to the private secret shares of the reblinded wallet
     reblinded_private_shares_commitment: Scalar,
-    /// The global merkle root to prove inclusion into
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the original wallet's private secret shares
     merkle_root: Scalar,
 }
 
 /// Statememt for the VALID_COMMITMENTS proof
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Copy, PartialEq)]
 struct ValidCommitmentsStatement {
-    /// The index of the balance that holds the mint that the wallet will
-    /// send if a successful match occurs
+    /// The index of the balance sent by the party if a successful match occurs
     balance_send_index: u64,
-    /// The index of the balance that holds the mint that the wallet will
-    /// receive if a successful match occurs
+    /// The index of the balance received by the party if a successful match occurs
     balance_receive_index: u64,
-    /// The index of the order that is to be matched
+    /// The index of the order being matched
     order_index: u64,
 }
 
 /// Statement for the VALID_SETTLE proof
-#[derive(Drop, Serde, Clone)]
+#[derive(Drop, Serde, Clone, PartialEq)]
 struct ValidSettleStatement {
     /// The modified public secret shares of the first party
     party0_modified_shares: Array<Scalar>,
     /// The modified public secret shares of the second party
     party1_modified_shares: Array<Scalar>,
-    /// The index of the balance that the first party sent in the settlement
+    /// The index of the balance sent by the first party in the settlement
     party0_send_balance_index: u64,
-    /// The index of teh balance that the first party received in the settlement
+    /// The index of the balance received by the first party in the settlement
     party0_receive_balance_index: u64,
-    /// The index of the first party's order that was matched
+    /// The index of the first party's matched order
     party0_order_index: u64,
-    /// The index of the balance that the second party sent in the settlement
+    /// The index of the balance sent by the second party in the settlement
     party1_send_balance_index: u64,
-    /// The index of teh balance that the second party received in the settlement
+    /// The index of the balance received by the second party in the settlement
     party1_receive_balance_index: u64,
-    /// The index of the second party's order that was matched
+    /// The index of the second party's matched order
     party1_order_index: u64,
 }

--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -5,6 +5,8 @@ use starknet::ContractAddress;
 
 use renegade_contracts::{verifier::{scalar::Scalar, types::Proof}, utils::serde::EcPointSerde};
 
+use super::statements::{ValidReblindStatement, ValidCommitmentsStatement};
+
 // --------------
 // | MISC TYPES |
 // --------------
@@ -37,13 +39,12 @@ impl ExternalTransferDefault of Default<ExternalTransfer> {
 #[derive(Drop, Serde, Clone)]
 struct MatchPayload {
     wallet_blinder_share: Scalar,
-    old_shares_nullifier: Scalar,
-    wallet_share_commitment: Scalar,
-    public_wallet_shares: Array<Scalar>,
-    valid_commitments_proof: Proof,
+    valid_commitments_statement: ValidCommitmentsStatement,
     valid_commitments_witness_commitments: Array<EcPoint>,
-    valid_reblind_proof: Proof,
+    valid_commitments_proof: Proof,
+    valid_reblind_statement: ValidReblindStatement,
     valid_reblind_witness_commitments: Array<EcPoint>,
+    valid_reblind_proof: Proof,
 }
 
 // --------------------------
@@ -69,10 +70,10 @@ struct UpdateWalletCallbackElems {
 #[derive(Drop, Serde, Copy)]
 struct ProcessMatchCallbackElems {
     party_0_wallet_blinder_share: Scalar,
-    party_0_wallet_share_commitment: Scalar,
-    party_0_old_shares_nullifier: Scalar,
+    party_0_reblinded_private_shares_commitment: Scalar,
+    party_0_original_shares_nullifier: Scalar,
     party_1_wallet_blinder_share: Scalar,
-    party_1_wallet_share_commitment: Scalar,
-    party_1_old_shares_nullifier: Scalar,
+    party_1_reblinded_private_shares_commitment: Scalar,
+    party_1_original_shares_nullifier: Scalar,
     tx_hash: felt252,
 }

--- a/src/testing/test_contracts.cairo
+++ b/src/testing/test_contracts.cairo
@@ -4,3 +4,4 @@ mod poseidon_wrapper;
 mod transcript_wrapper;
 mod verifier_utils_wrapper;
 mod storage_serde_wrapper;
+mod statement_serde_wrapper;

--- a/src/testing/test_contracts/statement_serde_wrapper.cairo
+++ b/src/testing/test_contracts/statement_serde_wrapper.cairo
@@ -1,0 +1,170 @@
+use traits::Into;
+use array::ArrayTrait;
+
+use renegade_contracts::{
+    darkpool::statements::{
+        ValidWalletCreateStatement, ValidWalletUpdateStatement, ValidReblindStatement,
+        ValidCommitmentsStatement, ValidSettleStatement
+    },
+    verifier::scalar::Scalar
+};
+
+
+const MAX_BALANCES: usize = 2;
+const MAX_ORDERS: usize = 2;
+const MAX_FEES: usize = 1;
+
+const DUMMY_VALUE: u64 = 42;
+
+
+#[starknet::interface]
+trait IStatementSerde<TContractState> {
+    fn assert_valid_wallet_create_statement(
+        self: @TContractState, statement: ValidWalletCreateStatement
+    );
+    fn assert_valid_wallet_update_statement(
+        self: @TContractState, statement: ValidWalletUpdateStatement
+    );
+    fn assert_valid_reblind_statement(self: @TContractState, statement: ValidReblindStatement);
+    fn assert_valid_commitments_statement(
+        self: @TContractState, statement: ValidCommitmentsStatement
+    );
+    fn assert_valid_settle_statement(self: @TContractState, statement: ValidSettleStatement);
+}
+
+#[starknet::contract]
+mod StatementSerdeWrapper {
+    use renegade_contracts::darkpool::statements::{
+        ValidWalletCreateStatement, ValidWalletUpdateStatement, ValidReblindStatement,
+        ValidCommitmentsStatement, ValidSettleStatement
+    };
+
+    use super::{
+        dummy_valid_wallet_create_statement, dummy_valid_wallet_update_statement,
+        dummy_valid_reblind_statement, dummy_valid_commitments_statement,
+        dummy_valid_settle_statement,
+    };
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    impl StatementSerdeWrapperImpl of super::IStatementSerde<ContractState> {
+        fn assert_valid_wallet_create_statement(
+            self: @ContractState, statement: ValidWalletCreateStatement
+        ) {
+            assert(
+                statement == dummy_valid_wallet_create_statement(), 'VALID_WALLET_CREATE: bad stmt'
+            )
+        }
+
+        fn assert_valid_wallet_update_statement(
+            self: @ContractState, statement: ValidWalletUpdateStatement
+        ) {
+            assert(
+                statement == dummy_valid_wallet_update_statement(), 'VALID_WALLET_UPDATE: bad stmt'
+            )
+        }
+
+        fn assert_valid_reblind_statement(self: @ContractState, statement: ValidReblindStatement) {
+            assert(statement == dummy_valid_reblind_statement(), 'VALID_REBLIND: bad stmt')
+        }
+
+        fn assert_valid_commitments_statement(
+            self: @ContractState, statement: ValidCommitmentsStatement
+        ) {
+            assert(statement == dummy_valid_commitments_statement(), 'VALID_COMMITMENTS: bad stmt')
+        }
+
+        fn assert_valid_settle_statement(self: @ContractState, statement: ValidSettleStatement) {
+            assert(statement == dummy_valid_settle_statement(), 'VALID_SETTLE: bad stmt')
+        }
+    }
+}
+
+// --------------------
+// | DUMMY STATEMENTS |
+// --------------------
+
+fn dummy_valid_wallet_create_statement() -> ValidWalletCreateStatement {
+    ValidWalletCreateStatement {
+        private_shares_commitment: DUMMY_VALUE.into(),
+        public_wallet_shares: dummy_public_wallet_shares(),
+    }
+}
+
+fn dummy_valid_wallet_update_statement() -> ValidWalletUpdateStatement {
+    ValidWalletUpdateStatement {
+        old_shares_nullifier: DUMMY_VALUE.into(),
+        new_private_shares_commitment: DUMMY_VALUE.into(),
+        new_public_shares: dummy_public_wallet_shares(),
+        merkle_root: DUMMY_VALUE.into(),
+        external_transfer: Default::default(),
+        old_pk_root: dummy_public_signing_key(),
+        timestamp: DUMMY_VALUE,
+    }
+}
+
+fn dummy_valid_reblind_statement() -> ValidReblindStatement {
+    ValidReblindStatement {
+        original_shares_nullifier: DUMMY_VALUE.into(),
+        reblinded_private_shares_commitment: DUMMY_VALUE.into(),
+        merkle_root: DUMMY_VALUE.into(),
+    }
+}
+
+fn dummy_valid_commitments_statement() -> ValidCommitmentsStatement {
+    ValidCommitmentsStatement {
+        balance_send_index: DUMMY_VALUE,
+        balance_receive_index: DUMMY_VALUE,
+        order_index: DUMMY_VALUE,
+    }
+}
+
+fn dummy_valid_settle_statement() -> ValidSettleStatement {
+    ValidSettleStatement {
+        party0_modified_shares: dummy_public_wallet_shares(),
+        party1_modified_shares: dummy_public_wallet_shares(),
+        party0_send_balance_index: DUMMY_VALUE,
+        party0_receive_balance_index: DUMMY_VALUE,
+        party0_order_index: DUMMY_VALUE,
+        party1_send_balance_index: DUMMY_VALUE,
+        party1_receive_balance_index: DUMMY_VALUE,
+        party1_order_index: DUMMY_VALUE,
+    }
+}
+
+// ---------------------------
+// | DUMMY STATEMENT HELPERS |
+// ---------------------------
+
+fn dummy_public_wallet_shares() -> Array<Scalar> {
+    let mut public_wallet_shares = ArrayTrait::new();
+    let mut i = 0;
+    loop {
+        // Number of shares is:
+        //   2 * MAX_BALANCES (amount, mint)
+        // + 6 * MAX_ORDERS (quote_mint, base_mint, side, amount, worst_case_price, timestamp)
+        // + 4 * MAX_FEES (settle_key, gas_addr, gas_token_amount, percentage_fee)
+        // + 2 (for the public signing key)
+        // + 1 (for the public identification key)
+        // + 1 (for the blinder)
+        if i == 2 * MAX_BALANCES + 6 * MAX_ORDERS + 4 * MAX_FEES + 4 {
+            break;
+        };
+        public_wallet_shares.append(DUMMY_VALUE.into());
+        i += 1;
+    };
+
+    public_wallet_shares
+}
+
+fn dummy_public_signing_key() -> Array<Scalar> {
+    // Public signing key is represented by 2 scalars
+    let mut public_signing_key = ArrayTrait::new();
+
+    public_signing_key.append(DUMMY_VALUE.into());
+    public_signing_key.append(DUMMY_VALUE.into());
+
+    public_signing_key
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,6 +5,7 @@ pub mod darkpool;
 pub mod merkle;
 pub mod nullifier_set;
 pub mod poseidon;
+pub mod statement_serde;
 pub mod transcript;
 pub mod utils;
 pub mod verifier;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
 pub mod darkpool;
 pub mod merkle;
 pub mod nullifier_set;

--- a/tests/src/statement_serde.rs
+++ b/tests/src/statement_serde.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/tests/src/statement_serde/utils.rs
+++ b/tests/src/statement_serde/utils.rs
@@ -1,0 +1,256 @@
+use circuit_types::{
+    keychain::{PublicSigningKey, ROOT_KEY_WORDS},
+    traits::BaseType,
+    transfers::ExternalTransfer,
+    wallet::WalletShare,
+};
+use circuits::zk_circuits::{
+    test_helpers::{MAX_BALANCES, MAX_FEES, MAX_ORDERS},
+    valid_commitments::ValidCommitmentsStatement,
+    valid_reblind::ValidReblindStatement,
+    valid_settle::test_helpers::SizedStatement as SizedValidSettleStatement,
+    valid_wallet_create::test_helpers::SizedStatement as SizedValidWalletCreateStatement,
+    valid_wallet_update::test_helpers::SizedStatement as SizedValidWalletUpdateStatement,
+};
+use dojo_test_utils::sequencer::TestSequencer;
+use eyre::Result;
+use mpc_stark::algebra::scalar::Scalar;
+use once_cell::sync::OnceCell;
+use starknet::core::types::{DeclareTransactionResult, FieldElement};
+use starknet_scripts::commands::utils::{
+    calculate_contract_address, declare, deploy, get_artifacts, ScriptAccount,
+};
+use std::env;
+use tracing::debug;
+
+use crate::utils::{call_contract, global_setup, CalldataSerializable, ARTIFACTS_PATH_ENV_VAR};
+
+const DUMMY_VALUE: u64 = 42;
+
+const STATEMENT_SERDE_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_StatementSerdeWrapper";
+
+const ASSERT_VALID_WALLET_CREATE_STATEMENT_FN_NAME: &str = "assert_valid_wallet_create_statement";
+const ASSERT_VALID_WALLET_UPDATE_STATEMENT_FN_NAME: &str = "assert_valid_wallet_update_statement";
+const ASSERT_VALID_REBLIND_STATEMENT_FN_NAME: &str = "assert_valid_reblind_statement";
+const ASSERT_VALID_COMMITMENTS_STATEMENT_FN_NAME: &str = "assert_valid_commitments_statement";
+const ASSERT_VALID_SETTLE_STATEMENT_FN_NAME: &str = "assert_valid_settle_statement";
+
+pub static STATEMENT_SERDE_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
+
+pub static DUMMY_VALID_WALLET_CREATE_STATEMENT: OnceCell<SizedValidWalletCreateStatement> =
+    OnceCell::new();
+pub static DUMMY_VALID_WALLET_UPDATE_STATEMENT: OnceCell<SizedValidWalletUpdateStatement> =
+    OnceCell::new();
+pub static DUMMY_VALID_REBLIND_STATEMENT: OnceCell<ValidReblindStatement> = OnceCell::new();
+pub static DUMMY_VALID_COMMITMENTS_STATEMENT: OnceCell<ValidCommitmentsStatement> = OnceCell::new();
+pub static DUMMY_VALID_SETTLE_STATEMENT: OnceCell<SizedValidSettleStatement> = OnceCell::new();
+
+// ---------------------
+// | META TEST HELPERS |
+// ---------------------
+
+pub async fn setup_statement_serde_test() -> Result<TestSequencer> {
+    let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
+
+    let sequencer = global_setup().await;
+    let account = sequencer.account();
+
+    debug!("Declaring & deploying statement serde wrapper contract...");
+    let statement_serde_wrapper_address =
+        deploy_statement_serde_wrapper(&account, &artifacts_path).await?;
+
+    if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
+        STATEMENT_SERDE_WRAPPER_ADDRESS
+            .set(statement_serde_wrapper_address)
+            .unwrap();
+    }
+
+    if DUMMY_VALID_WALLET_CREATE_STATEMENT.get().is_none() {
+        DUMMY_VALID_WALLET_CREATE_STATEMENT
+            .set(dummy_valid_wallet_create_statement())
+            .unwrap();
+    }
+    if DUMMY_VALID_WALLET_UPDATE_STATEMENT.get().is_none() {
+        DUMMY_VALID_WALLET_UPDATE_STATEMENT
+            .set(dummy_valid_wallet_update_statement())
+            .unwrap();
+    }
+    if DUMMY_VALID_REBLIND_STATEMENT.get().is_none() {
+        DUMMY_VALID_REBLIND_STATEMENT
+            .set(dummy_valid_reblind_statement())
+            .unwrap();
+    }
+    if DUMMY_VALID_COMMITMENTS_STATEMENT.get().is_none() {
+        DUMMY_VALID_COMMITMENTS_STATEMENT
+            .set(dummy_valid_commitments_statement())
+            .unwrap();
+    }
+    if DUMMY_VALID_SETTLE_STATEMENT.get().is_none() {
+        DUMMY_VALID_SETTLE_STATEMENT
+            .set(dummy_valid_settle_statement())
+            .unwrap();
+    }
+
+    Ok(sequencer)
+}
+
+async fn deploy_statement_serde_wrapper(
+    account: &ScriptAccount,
+    artifacts_path: &str,
+) -> Result<FieldElement> {
+    let (statement_serde_wrapper_sierra_path, statement_serde_wrapper_casm_path) =
+        get_artifacts(artifacts_path, STATEMENT_SERDE_WRAPPER_CONTRACT_NAME);
+    let DeclareTransactionResult { class_hash, .. } = declare(
+        statement_serde_wrapper_sierra_path,
+        statement_serde_wrapper_casm_path,
+        account,
+    )
+    .await?;
+
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
+}
+
+// --------------------------------
+// | CONTRACT INTERACTION HELPERS |
+// --------------------------------
+
+pub async fn assert_valid_wallet_create_statement(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_WALLET_CREATE_STATEMENT_FN_NAME,
+        DUMMY_VALID_WALLET_CREATE_STATEMENT
+            .get()
+            .unwrap()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_wallet_update_statement(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_WALLET_UPDATE_STATEMENT_FN_NAME,
+        DUMMY_VALID_WALLET_UPDATE_STATEMENT
+            .get()
+            .unwrap()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_reblind_statement(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_REBLIND_STATEMENT_FN_NAME,
+        DUMMY_VALID_REBLIND_STATEMENT.get().unwrap().to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_commitments_statement(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_COMMITMENTS_STATEMENT_FN_NAME,
+        DUMMY_VALID_COMMITMENTS_STATEMENT
+            .get()
+            .unwrap()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_settle_statement(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_SETTLE_STATEMENT_FN_NAME,
+        DUMMY_VALID_SETTLE_STATEMENT.get().unwrap().to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+// --------------------
+// | DUMMY STATEMENTS |
+// --------------------
+
+fn dummy_valid_wallet_create_statement() -> SizedValidWalletCreateStatement {
+    SizedValidWalletCreateStatement {
+        private_shares_commitment: Scalar::from(DUMMY_VALUE),
+        public_wallet_shares: dummy_public_wallet_shares(),
+    }
+}
+
+fn dummy_valid_wallet_update_statement() -> SizedValidWalletUpdateStatement {
+    SizedValidWalletUpdateStatement {
+        old_shares_nullifier: Scalar::from(DUMMY_VALUE),
+        new_private_shares_commitment: Scalar::from(DUMMY_VALUE),
+        new_public_shares: dummy_public_wallet_shares(),
+        merkle_root: Scalar::from(DUMMY_VALUE),
+        external_transfer: ExternalTransfer::default(),
+        old_pk_root: dummy_public_signing_key(),
+        timestamp: DUMMY_VALUE,
+    }
+}
+
+fn dummy_valid_reblind_statement() -> ValidReblindStatement {
+    ValidReblindStatement {
+        original_shares_nullifier: Scalar::from(DUMMY_VALUE),
+        reblinded_private_share_commitment: Scalar::from(DUMMY_VALUE),
+        merkle_root: Scalar::from(DUMMY_VALUE),
+    }
+}
+
+fn dummy_valid_commitments_statement() -> ValidCommitmentsStatement {
+    ValidCommitmentsStatement {
+        balance_send_index: DUMMY_VALUE,
+        balance_receive_index: DUMMY_VALUE,
+        order_index: DUMMY_VALUE,
+    }
+}
+
+fn dummy_valid_settle_statement() -> SizedValidSettleStatement {
+    SizedValidSettleStatement {
+        party0_modified_shares: dummy_public_wallet_shares(),
+        party1_modified_shares: dummy_public_wallet_shares(),
+        party0_send_balance_index: DUMMY_VALUE,
+        party0_receive_balance_index: DUMMY_VALUE,
+        party0_order_index: DUMMY_VALUE,
+        party1_send_balance_index: DUMMY_VALUE,
+        party1_receive_balance_index: DUMMY_VALUE,
+        party1_order_index: DUMMY_VALUE,
+    }
+}
+
+// ---------------------------
+// | DUMMY STATEMENT HELPERS |
+// ---------------------------
+
+fn dummy_public_wallet_shares() -> WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES> {
+    // Number of shares is:
+    //   2 * MAX_BALANCES (amount, mint)
+    // + 6 * MAX_ORDERS (quote_mint, base_mint, side, amount, worst_case_price, timestamp)
+    // + 4 * MAX_FEES (settle_key, gas_addr, gas_token_amount, percentage_fee)
+    // + 2 (for the public signing key)
+    // + 1 (for the public identification key)
+    // + 1 (for the blinder)
+    let mut wallet_share_scalars = (0..(2 * MAX_BALANCES + 6 * MAX_ORDERS + 4 * MAX_FEES + 4))
+        .map(|_| Scalar::from(DUMMY_VALUE));
+
+    WalletShare::from_scalars(&mut wallet_share_scalars)
+}
+
+fn dummy_public_signing_key() -> PublicSigningKey {
+    PublicSigningKey {
+        key_words: [Scalar::from(DUMMY_VALUE); ROOT_KEY_WORDS],
+    }
+}

--- a/tests/tests/statement_serde.rs
+++ b/tests/tests/statement_serde.rs
@@ -1,0 +1,64 @@
+use eyre::Result;
+use tests::{
+    statement_serde::utils::{
+        assert_valid_commitments_statement, assert_valid_reblind_statement,
+        assert_valid_settle_statement, assert_valid_wallet_create_statement,
+        assert_valid_wallet_update_statement, setup_statement_serde_test,
+    },
+    utils::global_teardown,
+};
+
+#[tokio::test]
+async fn test_valid_wallet_create_statement_serde() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_wallet_create_statement(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_wallet_update_statement_serde() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_wallet_update_statement(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_reblind_statement_serde() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_reblind_statement(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_commitments_statement_serde() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_commitments_statement(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_settle_statement_serde() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_settle_statement(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces statement types for the `VALID_COMMITMENTS`, `VALID_REBLIND`, `VALID_SETTLE`, & `VALID_MATCH_MPC` circuits into the darkpool contract, and updates the e2e `process_match` tests to make use of the associated statement types from the relayer repo.

All updated tests pass.