### PR TITLE
renegade_contracts: add `to_scalars` serialization for statement types

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -1,9 +1,12 @@
-use traits::TryInto;
+use traits::{TryInto, Into};
 use option::OptionTrait;
 use clone::Clone;
+use array::ArrayTrait;
 use starknet::ContractAddress;
 
-use renegade_contracts::{verifier::{scalar::Scalar, types::Proof}, utils::serde::EcPointSerde};
+use renegade_contracts::{
+    verifier::{scalar::{Scalar, ScalarSerializable}, types::Proof}, utils::serde::EcPointSerde
+};
 
 use super::statements::{ValidReblindStatement, ValidCommitmentsStatement};
 
@@ -32,6 +35,23 @@ impl ExternalTransferDefault of Default<ExternalTransfer> {
             amount: Default::default(),
             is_withdrawal: false,
         }
+    }
+}
+
+impl ExternalTransferToScalarsImpl of ScalarSerializable<ExternalTransfer> {
+    fn to_scalars(self: @ExternalTransfer) -> Array<Scalar> {
+        let mut scalars: Array<Scalar> = ArrayTrait::new();
+
+        scalars.append((*self.account_addr).into());
+        scalars.append((*self.mint).into());
+        scalars.append((*self.amount).into());
+        scalars.append((if *self.is_withdrawal {
+            1
+        } else {
+            0
+        }).into());
+
+        scalars
     }
 }
 

--- a/src/testing/test_contracts/statement_serde_wrapper.cairo
+++ b/src/testing/test_contracts/statement_serde_wrapper.cairo
@@ -30,13 +30,31 @@ trait IStatementSerde<TContractState> {
         self: @TContractState, statement: ValidCommitmentsStatement
     );
     fn assert_valid_settle_statement(self: @TContractState, statement: ValidSettleStatement);
+    fn assert_valid_wallet_create_statement_to_scalars(
+        self: @TContractState, statement_scalars: Array<Scalar>
+    );
+    fn assert_valid_wallet_update_statement_to_scalars(
+        self: @TContractState, statement_scalars: Array<Scalar>
+    );
+    fn assert_valid_reblind_statement_to_scalars(
+        self: @TContractState, statement_scalars: Array<Scalar>
+    );
+    fn assert_valid_commitments_statement_to_scalars(
+        self: @TContractState, statement_scalars: Array<Scalar>
+    );
+    fn assert_valid_settle_statement_to_scalars(
+        self: @TContractState, statement_scalars: Array<Scalar>
+    );
 }
 
 #[starknet::contract]
 mod StatementSerdeWrapper {
-    use renegade_contracts::darkpool::statements::{
-        ValidWalletCreateStatement, ValidWalletUpdateStatement, ValidReblindStatement,
-        ValidCommitmentsStatement, ValidSettleStatement
+    use renegade_contracts::{
+        darkpool::statements::{
+            ValidWalletCreateStatement, ValidWalletUpdateStatement, ValidReblindStatement,
+            ValidCommitmentsStatement, ValidSettleStatement
+        },
+        verifier::scalar::{Scalar, ScalarSerializable}, utils::eq::ArrayTPartialEq
     };
 
     use super::{
@@ -54,7 +72,7 @@ mod StatementSerdeWrapper {
             self: @ContractState, statement: ValidWalletCreateStatement
         ) {
             assert(
-                statement == dummy_valid_wallet_create_statement(), 'VALID_WALLET_CREATE: bad stmt'
+                statement == dummy_valid_wallet_create_statement(), 'VALID_WALLET_CREATE: statement'
             )
         }
 
@@ -62,22 +80,67 @@ mod StatementSerdeWrapper {
             self: @ContractState, statement: ValidWalletUpdateStatement
         ) {
             assert(
-                statement == dummy_valid_wallet_update_statement(), 'VALID_WALLET_UPDATE: bad stmt'
+                statement == dummy_valid_wallet_update_statement(), 'VALID_WALLET_UPDATE: statement'
             )
         }
 
         fn assert_valid_reblind_statement(self: @ContractState, statement: ValidReblindStatement) {
-            assert(statement == dummy_valid_reblind_statement(), 'VALID_REBLIND: bad stmt')
+            assert(statement == dummy_valid_reblind_statement(), 'VALID_REBLIND: statement')
         }
 
         fn assert_valid_commitments_statement(
             self: @ContractState, statement: ValidCommitmentsStatement
         ) {
-            assert(statement == dummy_valid_commitments_statement(), 'VALID_COMMITMENTS: bad stmt')
+            assert(statement == dummy_valid_commitments_statement(), 'VALID_COMMITMENTS: statement')
         }
 
         fn assert_valid_settle_statement(self: @ContractState, statement: ValidSettleStatement) {
-            assert(statement == dummy_valid_settle_statement(), 'VALID_SETTLE: bad stmt')
+            assert(statement == dummy_valid_settle_statement(), 'VALID_SETTLE: statement')
+        }
+
+        fn assert_valid_wallet_create_statement_to_scalars(
+            self: @ContractState, statement_scalars: Array<Scalar>
+        ) {
+            assert(
+                statement_scalars == dummy_valid_wallet_create_statement().to_scalars(),
+                'VALID_WALLET_CREATE: scalar ser'
+            )
+        }
+
+        fn assert_valid_wallet_update_statement_to_scalars(
+            self: @ContractState, statement_scalars: Array<Scalar>
+        ) {
+            assert(
+                statement_scalars == dummy_valid_wallet_update_statement().to_scalars(),
+                'VALID_WALLET_UPDATE: scalar ser'
+            )
+        }
+
+        fn assert_valid_reblind_statement_to_scalars(
+            self: @ContractState, statement_scalars: Array<Scalar>
+        ) {
+            assert(
+                statement_scalars == dummy_valid_reblind_statement().to_scalars(),
+                'VALID_REBLIND: scalar ser'
+            )
+        }
+
+        fn assert_valid_commitments_statement_to_scalars(
+            self: @ContractState, statement_scalars: Array<Scalar>
+        ) {
+            assert(
+                statement_scalars == dummy_valid_commitments_statement().to_scalars(),
+                'VALID_COMMITMENTS: scalar ser'
+            )
+        }
+
+        fn assert_valid_settle_statement_to_scalars(
+            self: @ContractState, statement_scalars: Array<Scalar>
+        ) {
+            assert(
+                statement_scalars == dummy_valid_settle_statement().to_scalars(),
+                'VALID_SETTLE: scalar ser'
+            )
         }
     }
 }

--- a/src/verifier/scalar.cairo
+++ b/src/verifier/scalar.cairo
@@ -139,11 +139,19 @@ impl ScalarNeg of Neg<Scalar> {
 // | CONVERSION |
 // --------------
 
-impl IntoScalar<T, impl TIntoU256: Into<T, u256>> of Into<T, Scalar> {
-    fn into(self: T) -> Scalar {
-        let inner_u256 = self.into() % SCALAR_FIELD_ORDER;
+impl U256IntoScalar of Into<u256, Scalar> {
+    fn into(self: u256) -> Scalar {
+        let inner_u256 = self % SCALAR_FIELD_ORDER;
         // Safe to unwrap b/c scalar field is smaller than base field
         Scalar { inner: inner_u256.try_into().unwrap() }
+    }
+}
+
+impl FeltIntoScalar<T, impl TIntoFelt: Into<T, felt252>> of Into<T, Scalar> {
+    fn into(self: T) -> Scalar {
+        let inner_felt: felt252 = self.into();
+        let inner_u256: u256 = inner_felt.into();
+        inner_u256.into()
     }
 }
 
@@ -195,4 +203,12 @@ impl ScalarLegacyHash of LegacyHash<Scalar> {
     fn hash(state: felt252, value: Scalar) -> felt252 {
         LegacyHash::hash(state, value.inner)
     }
+}
+
+// --------------------------
+// | EXTERNAL SERIALIZATION |
+// --------------------------
+
+trait ScalarSerializable<T> {
+    fn to_scalars(self: @T) -> Array<Scalar>;
 }

--- a/tests/src/statement_serde/utils.rs
+++ b/tests/src/statement_serde/utils.rs
@@ -34,6 +34,16 @@ const ASSERT_VALID_WALLET_UPDATE_STATEMENT_FN_NAME: &str = "assert_valid_wallet_
 const ASSERT_VALID_REBLIND_STATEMENT_FN_NAME: &str = "assert_valid_reblind_statement";
 const ASSERT_VALID_COMMITMENTS_STATEMENT_FN_NAME: &str = "assert_valid_commitments_statement";
 const ASSERT_VALID_SETTLE_STATEMENT_FN_NAME: &str = "assert_valid_settle_statement";
+const ASSERT_VALID_WALLET_CREATE_STATEMENT_TO_SCALARS_FN_NAME: &str =
+    "assert_valid_wallet_create_statement_to_scalars";
+const ASSERT_VALID_WALLET_UPDATE_STATEMENT_TO_SCALARS_FN_NAME: &str =
+    "assert_valid_wallet_update_statement_to_scalars";
+const ASSERT_VALID_REBLIND_STATEMENT_TO_SCALARS_FN_NAME: &str =
+    "assert_valid_reblind_statement_to_scalars";
+const ASSERT_VALID_COMMITMENTS_STATEMENT_TO_SCALARS_FN_NAME: &str =
+    "assert_valid_commitments_statement_to_scalars";
+const ASSERT_VALID_SETTLE_STATEMENT_TO_SCALARS_FN_NAME: &str =
+    "assert_valid_settle_statement_to_scalars";
 
 pub static STATEMENT_SERDE_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -174,6 +184,85 @@ pub async fn assert_valid_settle_statement(account: &ScriptAccount) -> Result<()
         *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
         ASSERT_VALID_SETTLE_STATEMENT_FN_NAME,
         DUMMY_VALID_SETTLE_STATEMENT.get().unwrap().to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_wallet_create_statement_to_scalars(
+    account: &ScriptAccount,
+) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_WALLET_CREATE_STATEMENT_TO_SCALARS_FN_NAME,
+        DUMMY_VALID_WALLET_CREATE_STATEMENT
+            .get()
+            .unwrap()
+            .to_scalars()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_wallet_update_statement_to_scalars(
+    account: &ScriptAccount,
+) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_WALLET_UPDATE_STATEMENT_TO_SCALARS_FN_NAME,
+        DUMMY_VALID_WALLET_UPDATE_STATEMENT
+            .get()
+            .unwrap()
+            .to_scalars()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_reblind_statement_to_scalars(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_REBLIND_STATEMENT_TO_SCALARS_FN_NAME,
+        DUMMY_VALID_REBLIND_STATEMENT
+            .get()
+            .unwrap()
+            .to_scalars()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_commitments_statement_to_scalars(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_COMMITMENTS_STATEMENT_TO_SCALARS_FN_NAME,
+        DUMMY_VALID_COMMITMENTS_STATEMENT
+            .get()
+            .unwrap()
+            .to_scalars()
+            .to_calldata(),
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn assert_valid_settle_statement_to_scalars(account: &ScriptAccount) -> Result<()> {
+    call_contract(
+        account,
+        *STATEMENT_SERDE_WRAPPER_ADDRESS.get().unwrap(),
+        ASSERT_VALID_SETTLE_STATEMENT_TO_SCALARS_FN_NAME,
+        DUMMY_VALID_SETTLE_STATEMENT
+            .get()
+            .unwrap()
+            .to_scalars()
+            .to_calldata(),
     )
     .await
     .map(|_| ())

--- a/tests/tests/statement_serde.rs
+++ b/tests/tests/statement_serde.rs
@@ -1,9 +1,12 @@
 use eyre::Result;
 use tests::{
     statement_serde::utils::{
-        assert_valid_commitments_statement, assert_valid_reblind_statement,
-        assert_valid_settle_statement, assert_valid_wallet_create_statement,
-        assert_valid_wallet_update_statement, setup_statement_serde_test,
+        assert_valid_commitments_statement, assert_valid_commitments_statement_to_scalars,
+        assert_valid_reblind_statement, assert_valid_reblind_statement_to_scalars,
+        assert_valid_settle_statement, assert_valid_settle_statement_to_scalars,
+        assert_valid_wallet_create_statement, assert_valid_wallet_create_statement_to_scalars,
+        assert_valid_wallet_update_statement, assert_valid_wallet_update_statement_to_scalars,
+        setup_statement_serde_test,
     },
     utils::global_teardown,
 };
@@ -57,6 +60,61 @@ async fn test_valid_settle_statement_serde() -> Result<()> {
     let sequencer = setup_statement_serde_test().await?;
 
     assert_valid_settle_statement(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_wallet_create_statement_to_scalars() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_wallet_create_statement_to_scalars(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_wallet_update_statement_to_scalars() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_wallet_update_statement_to_scalars(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_reblind_statement_to_scalars() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_reblind_statement_to_scalars(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_commitments_statement_to_scalars() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_commitments_statement_to_scalars(&sequencer.account()).await?;
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_settle_statement_to_scalars() -> Result<()> {
+    let sequencer = setup_statement_serde_test().await?;
+
+    assert_valid_settle_statement_to_scalars(&sequencer.account()).await?;
 
     global_teardown(sequencer);
 


### PR DESCRIPTION
This PR introduces a `ScalarSerializable` trait which allows a type to be serialized into an `Array<Scalar>`, and implements this trait for each of the statement types in a way that is consistent with the relayer-side implementation of the `to_scalars` method on the `BaseType` trait. This is in preparation for witness injection.

New tests asserting that the `to_scalars` serializations match have been added and pass.