### PR TITLE
renegade_contracts: darkpool: inject statement into witness

### DIFF
--- a/src/transcript.cairo
+++ b/src/transcript.cairo
@@ -7,7 +7,7 @@ use keccak::keccak_u256s_le_inputs;
 use ec::{ec_point_unwrap, ec_point_non_zero, ec_point_is_zero};
 use zeroable::IsZeroResult;
 
-use renegade_contracts::{utils::math::hash_to_scalar, verifier::scalar::Scalar};
+use renegade_contracts::{utils::crypto::hash_to_scalar, verifier::scalar::Scalar};
 
 
 // TODO: Make a unit test w/ a wrapper contract for this

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -6,4 +6,5 @@ mod serde;
 mod collections;
 mod eq;
 mod constants;
+mod crypto;
 

--- a/src/utils/crypto.cairo
+++ b/src/utils/crypto.cairo
@@ -1,0 +1,76 @@
+use traits::{TryInto, Into};
+use option::OptionTrait;
+use array::{ArrayTrait, SpanTrait};
+use keccak::keccak_u256s_le_inputs;
+use ec::ec_mul;
+
+use alexandria::data_structures::array_ext::ArrayTraitExt;
+use renegade_contracts::verifier::scalar::{Scalar, ScalarSerializable};
+
+use super::constants::{BASE_FIELD_ORDER, SCALAR_FIELD_ORDER, SHIFT_256_FELT, SHIFT_256_SCALAR};
+
+
+/// Reduces a hash to an element of the scalar field,
+/// ensuring an indistinguishable-from-uniform sampling of the field.
+fn hash_to_scalar(hash: u256) -> Scalar {
+    // We generate another hash to sample  total bytes.
+    // We use this to construct a "u512" given by
+    // low_u256 + (high_u256 << 256).
+    // Reducing this "u512" modulo the STARK scalar field order `r`
+    // allows us to get an indistinguishable-from-uniform sampling of the field.
+    // This reduction is given by:
+    // our_u512 % r = (low_u256 % r) + (high_u256 % r) * 2^256 % r
+
+    let mut data = ArrayTrait::new();
+    data.append(hash);
+    let high_u256 = keccak_u256s_le_inputs(data.span());
+
+    let low_scalar: Scalar = hash.into(); // low_u256 % r
+    let high_scalar: Scalar = high_u256.into(); // high_u256 % r
+
+    low_scalar + (high_scalar * SHIFT_256_SCALAR.into())
+}
+
+/// Reduces a hash to an element of the base field,
+/// ensuring an indistinguishable-from-uniform sampling of the field.
+fn hash_to_felt(hash: u256) -> felt252 {
+    // Same idea as `hash_to_scalar`, but using the base field order `q` instead of `r`.
+
+    let mut data = ArrayTrait::new();
+    data.append(hash);
+    let high_u256 = keccak_u256s_le_inputs(data.span());
+
+    let low_felt = (hash % BASE_FIELD_ORDER).try_into().unwrap(); // low_u256 % q
+    let high_felt = (high_u256 % BASE_FIELD_ORDER).try_into().unwrap(); // high_u256 % q
+
+    low_felt + (high_felt * SHIFT_256_FELT)
+}
+
+
+/// Computes Pedersen commitments of the given public inputs using the given generators.
+/// We use 1 as the scalar blinding factor for public inputs.
+fn commit_public(B: EcPoint, B_blind: EcPoint, mut inputs: Span<Scalar>) -> Array<EcPoint> {
+    let mut commitments = ArrayTrait::new();
+
+    loop {
+        match inputs.pop_front() {
+            Option::Some(input) => {
+                // Using 1 as scalar blinding factor => simply add B_blind
+                commitments.append(ec_mul(B, (*input).into()) + B_blind);
+            },
+            Option::None(()) => {
+                break;
+            },
+        };
+    };
+
+    commitments
+}
+
+fn append_statement_commitments<T, impl TScalarSerializable: ScalarSerializable<T>>(
+    B: EcPoint, B_blind: EcPoint, statement: @T, ref witness_commitments: Array<EcPoint>
+) {
+    let statement_scalars = statement.to_scalars();
+    let mut statement_commitments = commit_public(B, B_blind, statement_scalars.span());
+    witness_commitments.append_all(ref statement_commitments);
+}

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,13 +1,8 @@
-use traits::{TryInto, Into};
+use traits::Into;
 use option::OptionTrait;
 use array::{ArrayTrait, SpanTrait};
-use keccak::keccak_u256s_le_inputs;
 
-use super::constants::{BASE_FIELD_ORDER, SCALAR_FIELD_ORDER, SHIFT_256_FELT, SHIFT_256_SCALAR};
-
-use renegade_contracts::verifier::scalar::{Scalar, ScalarTrait};
-
-use debug::PrintTrait;
+use renegade_contracts::verifier::scalar::Scalar;
 
 
 /// Get `num_powers` consecutive powers of `val`, starting from `val^1`
@@ -60,40 +55,4 @@ fn binary_exp(base: Scalar, exp: usize) -> Scalar {
     } else {
         base * binary_exp(base * base, (exp - 1) / 2)
     }
-}
-
-/// Reduces a hash to an element of the scalar field,
-/// ensuring an indistinguishable-from-uniform sampling of the field.
-fn hash_to_scalar(hash: u256) -> Scalar {
-    // We generate another hash to sample  total bytes.
-    // We use this to construct a "u512" given by
-    // low_u256 + (high_u256 << 256).
-    // Reducing this "u512" modulo the STARK scalar field order `r`
-    // allows us to get an indistinguishable-from-uniform sampling of the field.
-    // This reduction is given by:
-    // our_u512 % r = (low_u256 % r) + (high_u256 % r) * 2^256 % r
-
-    let mut data = ArrayTrait::new();
-    data.append(hash);
-    let high_u256 = keccak_u256s_le_inputs(data.span());
-
-    let low_scalar: Scalar = hash.into(); // low_u256 % r
-    let high_scalar: Scalar = high_u256.into(); // high_u256 % r
-
-    low_scalar + (high_scalar * SHIFT_256_SCALAR.into())
-}
-
-/// Reduces a hash to an element of the base field,
-/// ensuring an indistinguishable-from-uniform sampling of the field.
-fn hash_to_felt(hash: u256) -> felt252 {
-    // Same idea as `hash_to_scalar`, but using the base field order `q` instead of `r`.
-
-    let mut data = ArrayTrait::new();
-    data.append(hash);
-    let high_u256 = keccak_u256s_le_inputs(data.span());
-
-    let low_felt = (hash % BASE_FIELD_ORDER).try_into().unwrap(); // low_u256 % q
-    let high_felt = (high_u256 % BASE_FIELD_ORDER).try_into().unwrap(); // high_u256 % q
-
-    low_felt + (high_felt * SHIFT_256_FELT)
 }

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -21,7 +21,7 @@ trait IVerifier<TContractState> {
         verification_job_id: felt252
     );
     fn step_verification(ref self: TContractState, verification_job_id: felt252) -> Option<bool>;
-    fn get_circuit_params(self: @TContractState) -> CircuitParams;
+    fn get_pc_gens(self: @TContractState) -> (EcPoint, EcPoint);
     fn check_verification_job_status(
         self: @TContractState, verification_job_id: felt252
     ) -> Option<bool>;
@@ -286,21 +286,8 @@ mod Verifier {
         // | GETTERS |
         // -----------
 
-        fn get_circuit_params(self: @ContractState) -> CircuitParams {
-            CircuitParams {
-                n: self.n.read(),
-                n_plus: self.n_plus.read(),
-                k: self.k.read(),
-                q: self.q.read(),
-                m: self.m.read(),
-                B: self.B.read().inner,
-                B_blind: self.B_blind.read().inner,
-                W_L: self.W_L.read().inner,
-                W_R: self.W_R.read().inner,
-                W_O: self.W_O.read().inner,
-                W_V: self.W_V.read().inner,
-                c: self.c.read().inner,
-            }
+        fn get_pc_gens(self: @ContractState) -> (EcPoint, EcPoint) {
+            (self.B.read().inner, self.B_blind.read().inner)
         }
 
         fn check_verification_job_status(

--- a/src/verifier/types.cairo
+++ b/src/verifier/types.cairo
@@ -10,8 +10,8 @@ use starknet::StorageAccess;
 use renegade_contracts::utils::{
     serde::{EcPointSerde},
     eq::{EcPointPartialEq, ArrayTPartialEq, OptionTPartialEq, TupleSize2PartialEq},
-    math::{binary_exp, hash_to_scalar}, collections::{DeepSpan, get_scalar_or_zero, insert_scalar},
-    constants::MAX_USIZE,
+    math::binary_exp, crypto::hash_to_scalar,
+    collections::{DeepSpan, get_scalar_or_zero, insert_scalar}, constants::MAX_USIZE,
 };
 
 use super::scalar::{Scalar, ScalarTrait};


### PR DESCRIPTION
This PR introduces witness injection, i.e. converts the proof statements into an array of scalars, computes a pedersen commitment to each, and appends these commitments to the witness commitments. This ordering should be consistent with what is in the relayer.

**Testing**
The current darkpool tests will fail in response to these changes. Now that we are injecting (real) statements into (dummy) witnesses, the dummy circuit proof witnesses effectively become malformed and will not verify.
This PR deliberately doesn't make any testing changes yet, as I need to weight out the options of either 1) forking the darkpool contract & making dummy statement types just for testing, or 2) configuring the e2e tests to use our actual circuits (!!)