### PR TITLE
renegade_contracts: darkpool: multiple verifier contracts

### DIFF
--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -320,12 +320,11 @@ mod Darkpool {
             circuit_params: CircuitParams
         ) {
             ownable__assert_only_owner(@self);
-            let verifier = _get_verifier(@self, circuit);
 
             // Save verifier contract address to storage
             _write_verifier_address(ref self, circuit, verifier_contract_address);
             // Initialize the verifier
-            verifier.initialize(circuit_params);
+            _get_verifier(@self, circuit).initialize(circuit_params);
         }
 
         // -----------
@@ -762,14 +761,7 @@ mod Darkpool {
     /// Returns:
     /// - Contract dispatcher instance
     fn _get_verifier(self: @ContractState, circuit: Circuit) -> IVerifierDispatcher {
-        let contract_address = match circuit {
-            Circuit::ValidWalletCreate(()) => self.valid_wallet_create_verifier_address.read(),
-            Circuit::ValidWalletUpdate(()) => self.valid_wallet_update_verifier_address.read(),
-            Circuit::ValidCommitments(()) => self.valid_commitments_verifier_address.read(),
-            Circuit::ValidReblind(()) => self.valid_reblind_verifier_address.read(),
-            Circuit::ValidMatchMpc(()) => self.valid_match_mpc_verifier_address.read(),
-            Circuit::ValidSettle(()) => self.valid_settle_verifier_address.read(),
-        };
+        let contract_address = _read_verifier_address(self, circuit);
 
         IVerifierDispatcher { contract_address }
     }

--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -97,3 +97,17 @@ struct ProcessMatchCallbackElems {
     party_1_original_shares_nullifier: Scalar,
     tx_hash: felt252,
 }
+
+// ------------
+// | CIRCUITS |
+// ------------
+
+#[derive(Drop, Serde, Copy, PartialEq)]
+enum Circuit {
+    ValidWalletCreate: (),
+    ValidWalletUpdate: (),
+    ValidCommitments: (),
+    ValidReblind: (),
+    ValidMatchMpc: (),
+    ValidSettle: (),
+}

--- a/src/testing/test_contracts/dummy_upgrade_target.cairo
+++ b/src/testing/test_contracts/dummy_upgrade_target.cairo
@@ -10,6 +10,9 @@ trait IUpgradeTarget<TContractState> {
     ) -> felt252;
     fn get_root(self: @TContractState) -> Scalar;
     fn is_nullifier_used(self: @TContractState, nullifier: Scalar) -> bool;
+    fn check_verification_job_status(
+        self: @TContractState, verification_job_id: felt252
+    ) -> Option<bool>;
     fn upgrade(ref self: TContractState, impl_hash: ClassHash);
 }
 
@@ -38,6 +41,12 @@ mod DummyUpgradeTarget {
 
         fn is_nullifier_used(self: @ContractState, nullifier: Scalar) -> bool {
             true
+        }
+
+        fn check_verification_job_status(
+            self: @ContractState, verification_job_id: felt252
+        ) -> Option<bool> {
+            Option::Some(true)
         }
 
         fn upgrade(ref self: ContractState, impl_hash: ClassHash) {

--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -53,6 +53,18 @@ fn get_dummy_proof() -> Proof {
     }
 }
 
+fn get_dummy_witness_commitments() -> Array<EcPoint> {
+    let mut commitments = ArrayTrait::new();
+
+    let basepoint = ec_point_from_x(1).unwrap();
+    commitments.append(basepoint);
+    commitments.append(ec_mul(basepoint, 2));
+    commitments.append(ec_mul(basepoint, 3));
+    commitments.append(ec_mul(basepoint, 4));
+
+    commitments
+}
+
 fn get_test_matrix() -> SparseWeightMatrix {
     // Matrix (full):
     // [

--- a/src/testing/tests/darkpool_tests.cairo
+++ b/src/testing/tests/darkpool_tests.cairo
@@ -8,14 +8,19 @@ use starknet::{
 };
 
 use renegade_contracts::{
-    darkpool::{Darkpool, IDarkpoolDispatcher, IDarkpoolDispatcherTrait, }, merkle::Merkle,
-    nullifier_set::NullifierSet, verifier::Verifier,
+    darkpool::{Darkpool, IDarkpoolDispatcher, IDarkpoolDispatcherTrait, types::Circuit},
+    merkle::Merkle, nullifier_set::NullifierSet,
+    verifier::{Verifier, IVerifierDispatcher, IVerifierDispatcherTrait},
+    utils::eq::OptionTPartialEq,
 };
 
 use super::{
     merkle_tests::TEST_MERKLE_HEIGHT,
     super::{
-        test_utils::{get_dummy_circuit_params, DUMMY_ROOT_INNER, DUMMY_WALLET_BLINDER_TX},
+        test_utils::{
+            get_dummy_circuit_params, get_dummy_proof, get_dummy_witness_commitments,
+            DUMMY_ROOT_INNER, DUMMY_WALLET_BLINDER_TX
+        },
         test_contracts::{dummy_upgrade_target::DummyUpgradeTarget}
     }
 };
@@ -33,11 +38,11 @@ const DUMMY_CALLER: felt252 = 'DUMMY_CALLER';
 // -----------------
 
 #[test]
-#[available_gas(1000000000)] // 10x
+#[available_gas(10000000000)] // 100x
 fn test_upgrade_darkpool() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     darkpool.upgrade(DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap());
     // The dummy upgrade target has a hardcoded response for the `get_wallet_blinder_transaction`
@@ -52,11 +57,11 @@ fn test_upgrade_darkpool() {
 }
 
 #[test]
-#[available_gas(1000000000)] // 10x
+#[available_gas(10000000000)] // 100x
 fn test_upgrade_merkle() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     let original_root = darkpool.get_root();
 
@@ -68,11 +73,11 @@ fn test_upgrade_merkle() {
 }
 
 #[test]
-#[available_gas(1000000000)] // 10x
+#[available_gas(10000000000)] // 100x
 fn test_upgrade_nullifier_set() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     darkpool.upgrade_nullifier_set(DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap());
     assert(darkpool.is_nullifier_used(0.into()), 'upgrade target wrong result');
@@ -81,16 +86,85 @@ fn test_upgrade_nullifier_set() {
     assert(!darkpool.is_nullifier_used(0.into()), 'original target wrong result');
 }
 
+#[test]
+#[available_gas(10000000000)] // 100x
+fn test_upgrade_verifier() {
+    let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
+    set_contract_address(test_caller);
+    let (
+        mut darkpool,
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    ) =
+        setup_darkpool();
+
+    let (upgrade_target_address, _) = deploy_syscall(
+        DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap(), 0, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+
+    // For each circuit, queue a dummy verification job, check that the verifier has not verified it,
+    // upgrade the verifier, check that it (and it alone) has verified the dummy job,
+    // and then upgrade it back to the original verifier contract.
+
+    queue_job_direct(valid_wallet_create_verifier_address, 0);
+    queue_job_direct(valid_wallet_update_verifier_address, 0);
+    queue_job_direct(valid_commitments_verifier_address, 0);
+    queue_job_direct(valid_reblind_verifier_address, 0);
+    queue_job_direct(valid_match_mpc_verifier_address, 0);
+    queue_job_direct(valid_settle_verifier_address, 0);
+
+    // VALID WALLET CREATE
+    assert_not_verified(ref darkpool, Circuit::ValidWalletCreate(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidWalletCreate(()), upgrade_target_address);
+    assert_only_upgraded_circuit_verified(ref darkpool, Circuit::ValidWalletCreate(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidWalletCreate(()), valid_wallet_create_verifier_address);
+
+    // VALID WALLET UPDATE
+    assert_not_verified(ref darkpool, Circuit::ValidWalletUpdate(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidWalletUpdate(()), upgrade_target_address);
+    assert_only_upgraded_circuit_verified(ref darkpool, Circuit::ValidWalletUpdate(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidWalletUpdate(()), valid_wallet_update_verifier_address);
+
+    // VALID COMMITMENTS
+    assert_not_verified(ref darkpool, Circuit::ValidCommitments(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidCommitments(()), upgrade_target_address);
+    assert_only_upgraded_circuit_verified(ref darkpool, Circuit::ValidCommitments(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidCommitments(()), valid_commitments_verifier_address);
+
+    // VALID REBLIND
+    assert_not_verified(ref darkpool, Circuit::ValidReblind(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidReblind(()), upgrade_target_address);
+    assert_only_upgraded_circuit_verified(ref darkpool, Circuit::ValidReblind(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidReblind(()), valid_reblind_verifier_address);
+
+    // VALID MATCH MPC
+    assert_not_verified(ref darkpool, Circuit::ValidMatchMpc(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidMatchMpc(()), upgrade_target_address);
+    assert_only_upgraded_circuit_verified(ref darkpool, Circuit::ValidMatchMpc(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidMatchMpc(()), valid_match_mpc_verifier_address);
+
+    // VALID SETTLE
+    assert_not_verified(ref darkpool, Circuit::ValidSettle(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidSettle(()), upgrade_target_address);
+    assert_only_upgraded_circuit_verified(ref darkpool, Circuit::ValidSettle(()), 0);
+    darkpool.upgrade_verifier(Circuit::ValidSettle(()), valid_settle_verifier_address);
+}
+
 // ----------------------------
 // | OWNERSHIP TRANSFER TESTS |
 // ----------------------------
 
 #[test]
-#[available_gas(1000000000)] // 10x
+#[available_gas(10000000000)] // 100x
 fn test_transfer_ownership() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     darkpool.transfer_ownership(dummy_caller);
@@ -103,21 +177,21 @@ fn test_transfer_ownership() {
 // ------------------------
 
 #[test]
-#[should_panic]
-#[available_gas(1000000000)] // 10x
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
 fn test_initialize_access() {
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
-    setup_darkpool();
+    let (_, _, _, _, _, _, _) = setup_darkpool();
 }
 
 #[test]
-#[should_panic]
-#[available_gas(1000000000)] // 10x
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
 fn test_upgrade_darkpool_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -126,12 +200,12 @@ fn test_upgrade_darkpool_access() {
 }
 
 #[test]
-#[should_panic]
-#[available_gas(1000000000)] // 10x
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
 fn test_upgrade_merkle_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -140,12 +214,12 @@ fn test_upgrade_merkle_access() {
 }
 
 #[test]
-#[should_panic]
-#[available_gas(1000000000)] // 10x
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
 fn test_upgrade_nullifier_set_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -154,12 +228,31 @@ fn test_upgrade_nullifier_set_access() {
 }
 
 #[test]
-#[should_panic]
-#[available_gas(1000000000)] // 10x
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
+fn test_upgrade_verifier_access() {
+    let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
+    set_contract_address(test_caller);
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+
+    let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
+    set_contract_address(dummy_caller);
+
+    // Testing w/ multiple `Circuit` enum variants is irrelevant as the access control is
+    // checked before ever referencing the `Circuit` argument
+    darkpool
+        .upgrade_verifier(
+            Circuit::ValidWalletCreate(()), DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap()
+        );
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
 fn test_transfer_ownership_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let mut darkpool = setup_darkpool();
+    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -171,8 +264,8 @@ fn test_transfer_ownership_access() {
 // ------------------------
 
 #[test]
-#[should_panic]
-#[available_gas(1000000000)] // 10x
+#[should_panic(expected: ('Initializable: is initialized', 'ENTRYPOINT_FAILED', ))]
+#[available_gas(10000000000)] // 100x
 fn test_initialize_twice() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
@@ -185,22 +278,51 @@ fn test_initialize_twice() {
     )
         .unwrap();
 
-    let (verifier_address, _) = deploy_syscall(
-        Verifier::TEST_CLASS_HASH.try_into().unwrap(), 0, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
+    let (
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    ) =
+        deploy_all_verifier_contracts();
 
     let mut darkpool = IDarkpoolDispatcher { contract_address: darkpool_address };
 
-    initialize_darkpool(ref darkpool, verifier_address);
-    initialize_darkpool(ref darkpool, verifier_address);
+    initialize_darkpool(
+        ref darkpool,
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    );
+    initialize_darkpool(
+        ref darkpool,
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    );
 }
 
 // -----------
 // | HELPERS |
 // -----------
 
-fn setup_darkpool() -> IDarkpoolDispatcher {
+fn setup_darkpool() -> (
+    IDarkpoolDispatcher,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+) {
     let mut calldata = ArrayTrait::new();
     calldata.append(TEST_CALLER);
 
@@ -209,24 +331,178 @@ fn setup_darkpool() -> IDarkpoolDispatcher {
     )
         .unwrap();
 
-    let (verifier_address, _) = deploy_syscall(
-        Verifier::TEST_CLASS_HASH.try_into().unwrap(), 0, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
+    let (
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    ) =
+        deploy_all_verifier_contracts();
 
     let mut darkpool = IDarkpoolDispatcher { contract_address: darkpool_address };
-    initialize_darkpool(ref darkpool, verifier_address);
+    initialize_darkpool(
+        ref darkpool,
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    );
 
-    darkpool
+    (
+        darkpool,
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    )
 }
 
-fn initialize_darkpool(ref darkpool: IDarkpoolDispatcher, verifier_address: ContractAddress) {
+fn initialize_darkpool(
+    ref darkpool: IDarkpoolDispatcher,
+    valid_wallet_create_verifier_address: ContractAddress,
+    valid_wallet_update_verifier_address: ContractAddress,
+    valid_commitments_verifier_address: ContractAddress,
+    valid_reblind_verifier_address: ContractAddress,
+    valid_match_mpc_verifier_address: ContractAddress,
+    valid_settle_verifier_address: ContractAddress,
+) {
     darkpool
         .initialize(
             Merkle::TEST_CLASS_HASH.try_into().unwrap(),
             NullifierSet::TEST_CLASS_HASH.try_into().unwrap(),
-            verifier_address,
             TEST_MERKLE_HEIGHT,
+        );
+
+    darkpool
+        .initialize_verifier(
+            Circuit::ValidWalletCreate(()),
+            valid_wallet_create_verifier_address,
             get_dummy_circuit_params(),
         );
+    darkpool
+        .initialize_verifier(
+            Circuit::ValidWalletUpdate(()),
+            valid_wallet_update_verifier_address,
+            get_dummy_circuit_params(),
+        );
+    darkpool
+        .initialize_verifier(
+            Circuit::ValidCommitments(()),
+            valid_commitments_verifier_address,
+            get_dummy_circuit_params(),
+        );
+    darkpool
+        .initialize_verifier(
+            Circuit::ValidReblind(()), valid_reblind_verifier_address, get_dummy_circuit_params(), 
+        );
+    darkpool
+        .initialize_verifier(
+            Circuit::ValidMatchMpc(()),
+            valid_match_mpc_verifier_address,
+            get_dummy_circuit_params(),
+        );
+    darkpool
+        .initialize_verifier(
+            Circuit::ValidSettle(()), valid_settle_verifier_address, get_dummy_circuit_params(), 
+        );
+}
+
+fn deploy_all_verifier_contracts() -> (
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+    ContractAddress,
+) {
+    let verifier_class_hash = Verifier::TEST_CLASS_HASH.try_into().unwrap();
+
+    let (valid_wallet_create_verifier_address, _) = deploy_syscall(
+        verifier_class_hash, 0, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+    let (valid_wallet_update_verifier_address, _) = deploy_syscall(
+        verifier_class_hash, 1, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+    let (valid_commitments_verifier_address, _) = deploy_syscall(
+        verifier_class_hash, 2, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+    let (valid_reblind_verifier_address, _) = deploy_syscall(
+        verifier_class_hash, 3, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+    let (valid_match_mpc_verifier_address, _) = deploy_syscall(
+        verifier_class_hash, 4, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+    let (valid_settle_verifier_address, _) = deploy_syscall(
+        verifier_class_hash, 5, ArrayTrait::new().span(), false, 
+    )
+        .unwrap();
+
+    (
+        valid_wallet_create_verifier_address,
+        valid_wallet_update_verifier_address,
+        valid_commitments_verifier_address,
+        valid_reblind_verifier_address,
+        valid_match_mpc_verifier_address,
+        valid_settle_verifier_address,
+    )
+}
+
+fn assert_only_upgraded_circuit_verified(
+    ref darkpool: IDarkpoolDispatcher, upgraded_circuit: Circuit, verification_job_id: felt252
+) {
+    let mut circuits = ArrayTrait::new();
+    circuits.append(Circuit::ValidWalletCreate(()));
+    circuits.append(Circuit::ValidWalletUpdate(()));
+    circuits.append(Circuit::ValidCommitments(()));
+    circuits.append(Circuit::ValidReblind(()));
+    circuits.append(Circuit::ValidMatchMpc(()));
+    circuits.append(Circuit::ValidSettle(()));
+
+    loop {
+        match circuits.pop_front() {
+            Option::Some(circuit) => {
+                if circuit == upgraded_circuit {
+                    assert(
+                        darkpool
+                            .check_verification_job_status(
+                                circuit, verification_job_id
+                            ) == Option::Some(true),
+                        'upgraded circuit not verified'
+                    );
+                } else {
+                    assert_not_verified(ref darkpool, circuit, verification_job_id);
+                }
+            },
+            Option::None(()) => {
+                break;
+            }
+        };
+    };
+}
+
+fn assert_not_verified(
+    ref darkpool: IDarkpoolDispatcher, circuit: Circuit, verification_job_id: felt252
+) {
+    assert(
+        darkpool.check_verification_job_status(circuit, verification_job_id) == Option::None(()),
+        'circuit verified'
+    );
+}
+
+fn queue_job_direct(verifier_address: ContractAddress, verification_job_id: felt252) {
+    let mut verifier = IVerifierDispatcher { contract_address: verifier_address };
+    let proof = get_dummy_proof();
+    let witness_commitments = get_dummy_witness_commitments();
+    verifier.queue_verification_job(proof, witness_commitments, verification_job_id);
 }

--- a/src/utils/eq.cairo
+++ b/src/utils/eq.cairo
@@ -79,6 +79,7 @@ impl EcPointPartialEq of PartialEq<EcPoint> {
         !(lhs == rhs)
     }
 }
+
 impl OptionTPartialEq<
     T, impl TPartialEq: PartialEq<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>
 > of PartialEq<Option<T>> {


### PR DESCRIPTION
This PR introduces usage of multiple verifier contracts in the darkpool for each separate circuit.

New Cairo tests have been added for upgrading the verifier contracts and ensuring that upgrading is access-gated.

E2E tests for this (and witness injection) are left for a future PR, I'l be creating a new dummy circuit that expects the actual circuits' statements but does nothing with them, keeping the circuit small but allowing us to accurately test both multi-circuit verification and witness injection.