### PR TITLE
tests: darkpool: testing multi-circuit verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.1.0-rc0"
-source = "git+https://github.com/dojoengine/blockifier?rev=c794d1b#c794d1b85b0937de9e0f4e3edbc9322792f7ab2e"
+source = "git+https://github.com/renegade-fi/blockifier.git?rev=9c9bbe1#9c9bbe1cc0f1d013caa1fc0ab53c372c8adb7530"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -960,7 +960,7 @@ dependencies = [
  "cairo-lang-sierra-gas",
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
- "cairo-lang-sierra-type-size 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "cairo-vm",
@@ -1024,7 +1024,7 @@ source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba9
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
- "cairo-lang-sierra-type-size 2.1.1 (git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1)",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
  "itertools 0.11.0",
  "thiserror",
@@ -1037,7 +1037,7 @@ source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba9
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
- "cairo-lang-sierra-type-size 2.1.1 (git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1)",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
  "itertools 0.11.0",
  "thiserror",
@@ -1079,7 +1079,7 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
- "cairo-lang-sierra-type-size 2.1.1 (git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1)",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
  "indoc 2.0.3",
  "itertools 0.11.0",
@@ -1087,16 +1087,6 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.16",
  "thiserror",
-]
-
-[[package]]
-name = "cairo-lang-sierra-type-size"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a5e70b5a5826edeb61ec375886847f51e1b995709e3f36d657844fbd703d45"
-dependencies = [
- "cairo-lang-sierra",
- "cairo-lang-utils",
 ]
 
 [[package]]
@@ -1303,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "itertools 0.10.5",
  "mpc-bulletproof",
@@ -1315,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "ark-ff",
  "async-trait",
@@ -1340,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff",
@@ -1384,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
 dependencies = [
  "clap_builder",
  "clap_derive 4.3.12",
@@ -1399,15 +1389,15 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
 dependencies = [
- "clap 4.3.23",
+ "clap 4.3.24",
  "log",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1481,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "base64 0.13.1",
  "bimap",
@@ -1501,7 +1491,7 @@ dependencies = [
  "renegade-crypto",
  "serde",
  "serde_json",
- "starknet 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet",
  "tokio",
  "tracing",
  "uuid 1.4.1",
@@ -1510,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "base64 0.13.1",
  "clap 3.2.25",
@@ -1545,7 +1535,7 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 
 [[package]]
 name = "convert_case"
@@ -2091,7 +2081,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "thiserror",
  "tracing",
  "url",
@@ -2119,7 +2109,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "thiserror",
  "tokio",
  "toml 0.7.6",
@@ -2133,7 +2123,7 @@ version = "0.1.0"
 source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "serde",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
 ]
 
 [[package]]
@@ -2156,7 +2146,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "starknet-crypto 0.5.1",
  "thiserror",
  "tokio",
@@ -2224,9 +2214,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -2336,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "circuit-types",
  "common",
@@ -3361,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "circuit-types",
  "common",
@@ -3857,7 +3847,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "circuit-types",
  "circuits",
@@ -3896,9 +3886,9 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
+checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-proc-macros",
@@ -3909,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
+checksum = "2b5dde66c53d6dcdc8caea1874a45632ec0fcf5b437789f1e45766a1512ce803"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3935,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
+checksum = "44e8ab85614a08792b9bff6c8feee23be78c98d0182d4c622c05256ab553892a"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-crate",
@@ -3948,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb69dad85df79527c019659a992498d03f8495390496da2f07e6c24c2b356fc"
+checksum = "cf4d945a6008c9b03db3354fb3c83ee02d2faa9f2e755ec1dfb69c3551b8f4ba"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3970,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
+checksum = "245ba8e5aa633dd1c1e4fae72bce06e71f42d34c14a2767c6b4d173b57bee5e5"
 dependencies = [
  "anyhow",
  "beef",
@@ -4023,7 +4013,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "starknet_api",
  "thiserror",
  "tokio",
@@ -4047,7 +4037,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "starknet_api",
  "thiserror",
  "tokio",
@@ -4451,7 +4441,7 @@ checksum = "4519a88847ba2d5ead3dc53f1060ec6a571de93f325d9c5c4968147382b1cbc3"
 [[package]]
 name = "mpc-bulletproof"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/mpc-bulletproof.git#58c0f28b0017edd56aa8512d4bcf94a954d8763b"
+source = "git+https://github.com/renegade-fi/mpc-bulletproof.git#0c579bdd3734026f2a096536b52ee6f5863fe3f3"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -4476,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "mpc-stark"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a44e704b52188a1372fe683dff0214e87fe008138e95a87fd7c8e05f5513aa5"
+checksum = "e73ac4d52a6e676d1a27ee72ab463caf87c2b6df28695efc62c6b39dade6855a"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4632,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -5506,7 +5496,7 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff",
@@ -5520,7 +5510,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "serde_json",
- "starknet 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet",
 ]
 
 [[package]]
@@ -5804,7 +5794,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "camino",
- "clap 4.3.23",
+ "clap 4.3.24",
  "clap-verbosity-flag",
  "console",
  "create-output-dir",
@@ -5863,7 +5853,7 @@ version = "1.6.0"
 source = "git+https://github.com/software-mansion/scarb?rev=c07fa61#c07fa61553985f045286166d0235e55492694159"
 dependencies = [
  "camino",
- "clap 4.3.23",
+ "clap 4.3.24",
  "derive_builder",
  "semver",
  "serde",
@@ -6208,9 +6198,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -6301,29 +6291,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcb61961b91757a9bc2d11549067445b2f921bd957f53710db35449767a1ba3"
 dependencies = [
- "starknet-accounts 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-contract 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-signers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "starknet"
-version = "0.5.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "starknet-accounts 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-contract 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-crypto 0.6.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-macros 0.1.2 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-providers 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-signers 0.3.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-accounts",
+ "starknet-contract",
+ "starknet-core",
+ "starknet-crypto 0.6.0",
+ "starknet-ff",
+ "starknet-macros",
+ "starknet-providers",
+ "starknet-signers",
 ]
 
 [[package]]
@@ -6333,42 +6308,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111ed887e4db14f0df1f909905e7737e4730770c8ed70997b58a71d5d940daac"
 dependencies = [
  "async-trait",
- "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-signers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.4.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "async-trait",
- "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-providers 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-signers 0.3.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-core",
+ "starknet-providers",
+ "starknet-signers",
  "thiserror",
 ]
 
 [[package]]
 name = "starknet-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
+ "ark-ff",
  "circuit-types",
  "circuits",
  "common",
  "constants",
  "itertools 0.10.5",
  "lazy_static",
+ "mpc-bulletproof",
  "mpc-stark",
  "num-bigint",
  "renegade-crypto",
  "reqwest",
  "serde",
  "serde_json",
- "starknet 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet",
  "state",
  "tokio",
  "tracing",
@@ -6383,23 +6348,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.4.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "starknet-accounts 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-providers 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-accounts",
+ "starknet-core",
+ "starknet-providers",
  "thiserror",
 ]
 
@@ -6417,25 +6368,8 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3 0.10.8",
- "starknet-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.5.1"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "base64 0.21.2",
- "flate2",
- "hex",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3 0.10.8",
- "starknet-crypto 0.6.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-crypto 0.6.0",
+ "starknet-ff",
 ]
 
 [[package]]
@@ -6452,9 +6386,9 @@ dependencies = [
  "num-traits 0.2.16",
  "rfc6979",
  "sha2 0.10.7",
- "starknet-crypto-codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto-codegen",
  "starknet-curve 0.3.0",
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-ff",
  "zeroize",
 ]
 
@@ -6472,28 +6406,9 @@ dependencies = [
  "num-traits 0.2.16",
  "rfc6979",
  "sha2 0.10.7",
- "starknet-crypto-codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-curve 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.6.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.16",
- "rfc6979",
- "sha2 0.10.7",
- "starknet-crypto-codegen 0.3.2 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-curve 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-crypto-codegen",
+ "starknet-curve 0.4.0",
+ "starknet-ff",
  "zeroize",
 ]
 
@@ -6503,18 +6418,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
- "starknet-curve 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "starknet-crypto-codegen"
-version = "0.3.2"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "starknet-curve 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-curve 0.4.0",
+ "starknet-ff",
  "syn 2.0.29",
 ]
 
@@ -6524,7 +6429,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
 dependencies = [
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-ff",
 ]
 
 [[package]]
@@ -6533,15 +6438,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
 dependencies = [
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.4.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-ff",
 ]
 
 [[package]]
@@ -6560,35 +6457,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-ff"
-version = "0.3.4"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "ark-ff",
- "bigdecimal",
- "crypto-bigint",
- "getrandom 0.2.10",
- "hex",
- "num-bigint",
- "serde",
-]
-
-[[package]]
 name = "starknet-macros"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a5865ee0ed22ade86bdf45e7c09c5641f1c59ccae12c21ecde535b2b6bf64a"
 dependencies = [
- "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "starknet-macros"
-version = "0.1.2"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-core",
  "syn 2.0.29",
 ]
 
@@ -6607,26 +6481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.5.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethereum-types",
- "flate2",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-core",
  "thiserror",
  "url",
 ]
@@ -6642,23 +6497,8 @@ dependencies = [
  "crypto-bigint",
  "eth-keystore",
  "rand 0.8.5",
- "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
-name = "starknet-signers"
-version = "0.3.0"
-source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
-dependencies = [
- "async-trait",
- "auto_impl",
- "crypto-bigint",
- "eth-keystore",
- "rand 0.8.5",
- "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-crypto 0.6.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-core",
+ "starknet-crypto 0.6.0",
  "thiserror",
 ]
 
@@ -6683,11 +6523,11 @@ dependencies = [
 name = "starknet_scripts"
 version = "0.1.0"
 dependencies = [
- "clap 4.3.23",
+ "clap 4.3.24",
  "eyre",
  "json",
  "serde_json",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.17",
@@ -6697,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "state"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "base64 0.13.1",
  "circuit-types",
@@ -6815,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "bus",
  "common",
@@ -6890,7 +6730,7 @@ dependencies = [
  "rand 0.8.5",
  "renegade-crypto",
  "serde_json",
- "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "starknet-client",
  "starknet_scripts",
  "tokio",
@@ -7471,7 +7311,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
+source = "git+https://github.com/renegade-fi/renegade.git#c3ee33d4cf859664833c79916c9035dd98539005"
 dependencies = [
  "chrono",
  "env_logger 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ starknet = "0.5.0"
 mpc-stark = "0.2"
 
 [patch."https://github.com/starkware-libs/blockifier"]
-blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "c794d1b" }
+blockifier = { git = "https://github.com/renegade-fi/blockifier.git", rev = "9c9bbe1" }
 
 [patch.crates-io]
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "262b7eb4b11ab165a2a936a5f914e78aa732d4a2" }
@@ -34,3 +34,4 @@ cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo.git
 cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
 cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
 cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-sierra-type-size = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }

--- a/starknet_scripts/src/commands/deploy.rs
+++ b/starknet_scripts/src/commands/deploy.rs
@@ -73,9 +73,13 @@ pub async fn deploy_and_initialize(args: DeployArgs) -> Result<()> {
                 } else {
                     format!("{verifier_class_hash_felt:#64x}")
                 };
-                let (verifier_address, _, _) =
-                    deploy_verifier(Some(verifier_class_hash_hex), &artifacts_path, &account)
-                        .await?;
+                let (verifier_address, _, _) = deploy_verifier(
+                    Some(verifier_class_hash_hex),
+                    FieldElement::ZERO, /* salt */
+                    &artifacts_path,
+                    &account,
+                )
+                .await?;
 
                 // Initialize darkpool
                 debug!("Initializing darkpool contract...");

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -54,8 +54,12 @@ pub async fn init_merkle_test_state() -> Result<TestSequencer> {
 pub fn init_merkle_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let merkle_address =
-        get_contract_address_from_artifact(&artifacts_path, MERKLE_CONTRACT_NAME, &[])?;
+    let merkle_address = get_contract_address_from_artifact(
+        &artifacts_path,
+        MERKLE_CONTRACT_NAME,
+        FieldElement::ZERO, /* salt */
+        &[],
+    )?;
     if MERKLE_ADDRESS.get().is_none() {
         MERKLE_ADDRESS.set(merkle_address).unwrap();
     }

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -38,8 +38,12 @@ pub async fn init_nullifier_set_test_state() -> Result<TestSequencer> {
 pub fn init_nullifier_set_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let nullifier_set_address =
-        get_contract_address_from_artifact(&artifacts_path, NULLIFIER_SET_CONTRACT_NAME, &[])?;
+    let nullifier_set_address = get_contract_address_from_artifact(
+        &artifacts_path,
+        NULLIFIER_SET_CONTRACT_NAME,
+        FieldElement::ZERO,
+        &[],
+    )?;
     if NULLIFIER_SET_ADDRESS.get().is_none() {
         NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
     }

--- a/tests/src/poseidon/utils.rs
+++ b/tests/src/poseidon/utils.rs
@@ -47,8 +47,12 @@ pub async fn init_poseidon_test_state() -> Result<TestSequencer> {
 pub fn init_poseidon_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let poseidon_wrapper_address =
-        get_contract_address_from_artifact(&artifacts_path, POSEIDON_WRAPPER_CONTRACT_NAME, &[])?;
+    let poseidon_wrapper_address = get_contract_address_from_artifact(
+        &artifacts_path,
+        POSEIDON_WRAPPER_CONTRACT_NAME,
+        FieldElement::ZERO, /* salt */
+        &[],
+    )?;
     if POSEIDON_WRAPPER_ADDRESS.get().is_none() {
         POSEIDON_WRAPPER_ADDRESS
             .set(poseidon_wrapper_address)
@@ -66,8 +70,12 @@ pub async fn deploy_poseidon_wrapper(
         get_artifacts(artifacts_path, POSEIDON_WRAPPER_CONTRACT_NAME);
     let DeclareTransactionResult { class_hash, .. } =
         declare(poseidon_sierra_path, poseidon_casm_path, account).await?;
-    deploy(account, class_hash, &[]).await?;
-    Ok(calculate_contract_address(class_hash, &[]))
+    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
+    Ok(calculate_contract_address(
+        class_hash,
+        FieldElement::ZERO, /* salt */
+        &[],
+    ))
 }
 
 // --------------------------------

--- a/tests/src/statement_serde/utils.rs
+++ b/tests/src/statement_serde/utils.rs
@@ -25,10 +25,8 @@ use tracing::debug;
 
 use crate::utils::{
     call_contract, get_contract_address_from_artifact, global_setup, CalldataSerializable,
-    ARTIFACTS_PATH_ENV_VAR,
+    ARTIFACTS_PATH_ENV_VAR, DUMMY_VALUE,
 };
-
-const DUMMY_VALUE: u64 = 42;
 
 const STATEMENT_SERDE_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_StatementSerdeWrapper";
 
@@ -80,6 +78,7 @@ pub fn init_statement_serde_test_statics() -> Result<()> {
     let statement_serde_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         STATEMENT_SERDE_WRAPPER_CONTRACT_NAME,
+        FieldElement::ZERO, /* salt */
         &[],
     )?;
     if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
@@ -130,8 +129,12 @@ async fn deploy_statement_serde_wrapper(
     )
     .await?;
 
-    deploy(account, class_hash, &[]).await?;
-    Ok(calculate_contract_address(class_hash, &[]))
+    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
+    Ok(calculate_contract_address(
+        class_hash,
+        FieldElement::ZERO, /* salt */
+        &[],
+    ))
 }
 
 // --------------------------------

--- a/tests/src/transcript/utils.rs
+++ b/tests/src/transcript/utils.rs
@@ -70,6 +70,7 @@ pub fn init_transcript_test_statics() -> Result<()> {
     let transcript_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         TRANSCRIPT_WRAPPER_CONTRACT_NAME,
+        FieldElement::ZERO, /* salt */
         &calldata,
     )?;
 
@@ -99,8 +100,18 @@ pub async fn deploy_transcript_wrapper(
         declare(transcript_sierra_path, transcript_casm_path, account).await?;
 
     let calldata = get_transcript_wrapper_constructor_calldata()?;
-    deploy(account, class_hash, &calldata).await?;
-    Ok(calculate_contract_address(class_hash, &calldata))
+    deploy(
+        account,
+        class_hash,
+        &calldata,
+        FieldElement::ZERO, /* salt */
+    )
+    .await?;
+    Ok(calculate_contract_address(
+        class_hash,
+        FieldElement::ZERO, /* salt */
+        &calldata,
+    ))
 }
 
 // --------------------------------

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -1,9 +1,14 @@
 use dojo_test_utils::sequencer::TestSequencer;
-use eyre::Result;
+use eyre::{eyre, Result};
 
-use mpc_bulletproof::r1cs::R1CSProof;
-use mpc_stark::algebra::stark_curve::StarkPoint;
+use merlin::HashChainTranscript;
+use mpc_bulletproof::{
+    r1cs::{CircuitWeights, ConstraintSystem, Prover, R1CSProof, Variable, Verifier},
+    BulletproofGens, PedersenGens,
+};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
 use once_cell::sync::OnceCell;
+use rand::thread_rng;
 use starknet::core::types::FieldElement;
 use starknet_scripts::commands::utils::{
     deploy_verifier, initialize, ScriptAccount, VERIFIER_CONTRACT_NAME,
@@ -12,12 +17,13 @@ use std::env;
 use tracing::debug;
 
 use crate::utils::{
-    get_contract_address_from_artifact, get_dummy_circuit_params, global_setup, invoke_contract,
-    CalldataSerializable, ARTIFACTS_PATH_ENV_VAR,
+    call_contract, get_contract_address_from_artifact, global_setup, invoke_contract,
+    CalldataSerializable, CircuitParams, ARTIFACTS_PATH_ENV_VAR, TRANSCRIPT_SEED,
 };
 
 pub const FUZZ_ROUNDS: usize = 1;
 
+const CHECK_VERIFICATION_JOB_STATUS_FN_NAME: &str = "check_verification_job_status";
 const QUEUE_VERIFICATION_JOB_FN_NAME: &str = "queue_verification_job";
 const STEP_VERIFICATION_FN_NAME: &str = "step_verification";
 
@@ -34,7 +40,13 @@ pub async fn init_verifier_test_state() -> Result<TestSequencer> {
     let account = sequencer.account();
 
     debug!("Declaring & deploying verifier contract...");
-    let (verifier_address, _, _) = deploy_verifier(None, &artifacts_path, &account).await?;
+    let (verifier_address, _, _) = deploy_verifier(
+        None,
+        FieldElement::ZERO, /* salt */
+        &artifacts_path,
+        &account,
+    )
+    .await?;
 
     debug!("Initializing verifier contract...");
     initialize_verifier(&account, verifier_address).await?;
@@ -45,8 +57,12 @@ pub async fn init_verifier_test_state() -> Result<TestSequencer> {
 pub fn init_verifier_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let verifier_address =
-        get_contract_address_from_artifact(&artifacts_path, VERIFIER_CONTRACT_NAME, &[])?;
+    let verifier_address = get_contract_address_from_artifact(
+        &artifacts_path,
+        VERIFIER_CONTRACT_NAME,
+        FieldElement::ZERO, /* salt */
+        &[],
+    )?;
     if VERIFIER_ADDRESS.get().is_none() {
         VERIFIER_ADDRESS.set(verifier_address).unwrap();
     }
@@ -69,6 +85,29 @@ pub async fn initialize_verifier<'t, 'g>(
     )
     .await
     .map(|_| ())
+}
+
+pub async fn check_verification_job_status(
+    account: &ScriptAccount,
+    verification_job_id: FieldElement,
+) -> Result<Option<bool>> {
+    call_contract(
+        account,
+        *VERIFIER_ADDRESS.get().unwrap(),
+        CHECK_VERIFICATION_JOB_STATUS_FN_NAME,
+        vec![verification_job_id],
+    )
+    .await
+    .map(|r| {
+        // The Cairo corelib serializes an Option::None(()) as 1,
+        // and an Option::Some(x) as [0, ..serialize(x)].
+        // In our case, x is a bool => serializes as a true = 1, false = 0.
+        if r[0] == FieldElement::ONE {
+            None
+        } else {
+            Some(r[1] == FieldElement::ONE)
+        }
+    })
 }
 
 pub async fn queue_verification_job(
@@ -106,4 +145,147 @@ pub async fn step_verification(
     )
     .await
     .map(|_| ())
+}
+
+// -----------------
+// | DUMMY CIRCUIT |
+// -----------------
+
+// The dummy circuit we're using is a very simple circuit with 4 witness elements,
+// 3 multiplication gates, and 2 linear constraints. In total, it is parameterized as follows:
+// n = 3
+// n_plus = 4
+// k = log2(n_plus) = 2
+// m = 4
+// q = 8 (The total number of linear constraints is 8 because there are 3 multiplication gates, and 2 linear constraints per multiplication gate)
+
+// The circuit is defined as follows:
+//
+// Witness:
+// a, b, x, y (all scalars)
+//
+// Circuit:
+// m_1 = multiply(a, b)
+// m_2 = multiply(x, y)
+// m_3 = multiply(m_1, m_2)
+// constrain(a - 69)
+// constrain(m_3 - 420)
+
+// Bearing the following weights:
+// W_L = [[(0, -1)], [], [(1, -1)], [], [(2, -1)], [], [], []]
+// W_R = [[], [(0, -1)], [], [(1, -1)], [], [(2, -1)], [], []]
+// W_O = [[], [], [], [], [(0, 1)], [(1, 1)], [], [(2, 1)]]
+// W_V = [[(0, -1)], [(1, -1)], [(2, -1)], [(3, -1)], [], [], [(0, -1)], []]
+// c = [(6, 69), (7, 420)]
+
+pub const DUMMY_CIRCUIT_N: usize = 3;
+pub const DUMMY_CIRCUIT_N_PLUS: usize = 4;
+pub const DUMMY_CIRCUIT_K: usize = 2;
+pub const DUMMY_CIRCUIT_M: usize = 4;
+pub const DUMMY_CIRCUIT_Q: usize = 8;
+
+pub fn singleprover_prove_dummy_circuit() -> Result<(R1CSProof, Vec<StarkPoint>)> {
+    debug!("Generating proof for dummy circuit...");
+    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
+    let pc_gens = PedersenGens::default();
+    let prover = Prover::new(&pc_gens, &mut transcript);
+
+    let witness = get_dummy_circuit_witness();
+
+    prove(prover, witness)
+}
+
+fn get_dummy_circuit_witness() -> Vec<Scalar> {
+    let a = Scalar::from(69);
+    let b = Scalar::from(420) * a.inverse();
+    let x = Scalar::one();
+    let y = Scalar::one();
+    vec![a, b, x, y]
+}
+
+fn prove(mut prover: Prover, witness: Vec<Scalar>) -> Result<(R1CSProof, Vec<StarkPoint>)> {
+    let mut rng = thread_rng();
+
+    // Commit to the witness
+    let a_blind = Scalar::random(&mut rng);
+    let b_blind = Scalar::random(&mut rng);
+    let x_blind = Scalar::random(&mut rng);
+    let y_blind = Scalar::random(&mut rng);
+
+    let (a_comm, a_var) = prover.commit(witness[0], a_blind);
+    let (b_comm, b_var) = prover.commit(witness[1], b_blind);
+    let (x_comm, x_var) = prover.commit(witness[2], x_blind);
+    let (y_comm, y_var) = prover.commit(witness[3], y_blind);
+
+    // Apply the constraints
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
+
+    // Generate the proof
+    let bp_gens = BulletproofGens::new(8 /* gens_capacity */, 1 /* party_capacity */);
+    let proof = prover
+        .prove(&bp_gens)
+        .map_err(|e| eyre!("error generating proof: {e}"))?;
+
+    Ok((proof, vec![a_comm, b_comm, x_comm, y_comm]))
+}
+
+fn apply_dummy_circuit_constraints<CS: ConstraintSystem>(
+    a: Variable,
+    b: Variable,
+    x: Variable,
+    y: Variable,
+    cs: &mut CS,
+) {
+    let (_, _, m_1) = cs.multiply(a.into(), b.into());
+    let (_, _, m_2) = cs.multiply(x.into(), y.into());
+    let (_, _, m_3) = cs.multiply(m_1.into(), m_2.into());
+    cs.constrain(a - Scalar::from(69));
+    cs.constrain(m_3 - Scalar::from(420));
+}
+
+pub fn prep_dummy_circuit_verifier(verifier: &mut Verifier, witness_commitments: Vec<StarkPoint>) {
+    // Allocate witness commitments into circuit
+    let a_var = verifier.commit(witness_commitments[0]);
+    let b_var = verifier.commit(witness_commitments[1]);
+    let x_var = verifier.commit(witness_commitments[2]);
+    let y_var = verifier.commit(witness_commitments[3]);
+
+    debug!("Applying dummy circuit constraints on verifier...");
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, verifier);
+}
+
+fn get_dummy_circuit_weights() -> CircuitWeights {
+    let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
+    let pc_gens = PedersenGens::default();
+    let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+    let mut rng = thread_rng();
+
+    let (_, a_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+    let (_, b_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+    let (_, x_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+    let (_, y_var) = prover.commit(Scalar::random(&mut rng), Scalar::random(&mut rng));
+
+    apply_dummy_circuit_constraints(a_var, b_var, x_var, y_var, &mut prover);
+
+    prover.get_weights()
+}
+
+fn get_dummy_circuit_params() -> CircuitParams {
+    let circuit_weights = get_dummy_circuit_weights();
+    let pc_gens = PedersenGens::default();
+    CircuitParams {
+        n: DUMMY_CIRCUIT_N,
+        n_plus: DUMMY_CIRCUIT_N_PLUS,
+        k: DUMMY_CIRCUIT_K,
+        q: DUMMY_CIRCUIT_Q,
+        m: DUMMY_CIRCUIT_M,
+        b: pc_gens.B,
+        b_blind: pc_gens.B_blinding,
+        w_l: circuit_weights.w_l,
+        w_o: circuit_weights.w_o,
+        w_r: circuit_weights.w_r,
+        w_v: circuit_weights.w_v,
+        c: circuit_weights.c,
+    }
 }

--- a/tests/src/verifier_utils/utils.rs
+++ b/tests/src/verifier_utils/utils.rs
@@ -15,11 +15,15 @@ use starknet_scripts::commands::utils::{
 use std::{env, iter};
 use tracing::debug;
 
-use crate::utils::{
-    call_contract, felt_to_scalar, felt_to_u32, get_contract_address_from_artifact, global_setup,
-    prep_dummy_circuit_verifier, setup_sequencer, singleprover_prove_dummy_circuit,
-    CalldataSerializable, TestConfig, ARTIFACTS_PATH_ENV_VAR, DUMMY_CIRCUIT_K, DUMMY_CIRCUIT_M,
-    DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS,
+use crate::{
+    utils::{
+        call_contract, felt_to_scalar, felt_to_u32, get_contract_address_from_artifact,
+        global_setup, setup_sequencer, CalldataSerializable, TestConfig, ARTIFACTS_PATH_ENV_VAR,
+    },
+    verifier::utils::{
+        prep_dummy_circuit_verifier, singleprover_prove_dummy_circuit, DUMMY_CIRCUIT_K,
+        DUMMY_CIRCUIT_M, DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS,
+    },
 };
 
 const VERIFIER_UTILS_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_VerifierUtilsWrapper";
@@ -66,6 +70,7 @@ pub fn init_verifier_utils_test_statics() -> Result<()> {
     let verifier_utils_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         VERIFIER_UTILS_WRAPPER_CONTRACT_NAME,
+        FieldElement::ZERO, /* salt */
         &[],
     )?;
     if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
@@ -90,8 +95,12 @@ pub async fn deploy_verifier_utils_wrapper(
     )
     .await?;
 
-    deploy(account, class_hash, &[]).await?;
-    Ok(calculate_contract_address(class_hash, &[]))
+    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
+    Ok(calculate_contract_address(
+        class_hash,
+        FieldElement::ZERO, /* salt */
+        &[],
+    ))
 }
 
 // --------------------------------

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -31,11 +31,8 @@ use tests::{
 
 #[tokio::test]
 async fn test_initialization_root() -> Result<()> {
-    let (sequencer, ark_merkle_tree) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, ark_merkle_tree) = setup_darkpool_test(true /* init_arkworks_tree */).await?;
+    let ark_merkle_tree = ark_merkle_tree.unwrap();
 
     assert_roots_equal(
         &sequencer.account(),
@@ -51,12 +48,9 @@ async fn test_initialization_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_new_wallet_root() -> Result<()> {
-    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, ark_merkle_tree) = setup_darkpool_test(true /* init_arkworks_tree */).await?;
     let account = sequencer.account();
+    let mut ark_merkle_tree = ark_merkle_tree.unwrap();
 
     let args = get_dummy_new_wallet_args()?;
     poll_new_wallet_to_completion(&account, &args).await?;
@@ -76,12 +70,9 @@ async fn test_new_wallet_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_root() -> Result<()> {
-    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, ark_merkle_tree) = setup_darkpool_test(true /* init_arkworks_tree */).await?;
     let account = sequencer.account();
+    let mut ark_merkle_tree = ark_merkle_tree.unwrap();
 
     let old_wallet = INITIAL_WALLET.clone();
     let mut new_wallet = INITIAL_WALLET.clone();
@@ -105,12 +96,9 @@ async fn test_update_wallet_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_process_match_root() -> Result<()> {
-    let (sequencer, mut ark_merkle_tree) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, ark_merkle_tree) = setup_darkpool_test(true /* init_arkworks_tree */).await?;
     let account = sequencer.account();
+    let mut ark_merkle_tree = ark_merkle_tree.unwrap();
 
     let args = get_dummy_process_match_args(WALLET1.clone(), WALLET2.clone(), MATCH_RES.clone())?;
     poll_process_match_to_completion(&account, &args).await?;
@@ -145,11 +133,7 @@ async fn test_process_match_root() -> Result<()> {
 
 #[tokio::test]
 async fn test_new_wallet_last_modified() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     let args = get_dummy_new_wallet_args()?;
@@ -167,11 +151,7 @@ async fn test_new_wallet_last_modified() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_last_modified() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     let old_wallet = INITIAL_WALLET.clone();
@@ -193,11 +173,7 @@ async fn test_update_wallet_last_modified() -> Result<()> {
 
 #[tokio::test]
 async fn test_process_match_last_modified() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     let args = get_dummy_process_match_args(WALLET1.clone(), WALLET2.clone(), MATCH_RES.clone())?;
@@ -224,11 +200,7 @@ async fn test_process_match_last_modified() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_nullifiers() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     let old_wallet = INITIAL_WALLET.clone();
@@ -264,11 +236,7 @@ async fn test_update_wallet_nullifiers() -> Result<()> {
 
 #[tokio::test]
 async fn test_process_match_nullifiers() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        false, /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     let args = get_dummy_process_match_args(WALLET1.clone(), WALLET2.clone(), MATCH_RES.clone())?;
@@ -328,11 +296,7 @@ async fn test_process_match_nullifiers() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_deposit() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        true,  /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     // Adapted from `test_external_transfer__valid_deposit_new_balance` in https://github.com/renegade-fi/renegade/blob/main/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -382,11 +346,7 @@ async fn test_update_wallet_deposit() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_wallet_withdrawal() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        true,  /* init_erc20 */
-        false, /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     // Adapted from `test_external_transfer__valid_withdrawal` in https://github.com/renegade-fi/renegade/blob/main/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -431,11 +391,7 @@ async fn test_update_wallet_withdrawal() -> Result<()> {
 
 #[tokio::test]
 async fn test_upgrade_darkpool_storage() -> Result<()> {
-    let (sequencer, _) = setup_darkpool_test(
-        false, /* init_erc20 */
-        true,  /* init_upgrade_target */
-    )
-    .await?;
+    let (sequencer, _) = setup_darkpool_test(false /* init_arkworks_tree */).await?;
     let account = sequencer.account();
 
     let old_wallet = INITIAL_WALLET.clone();

--- a/tests/tests/verifier.rs
+++ b/tests/tests/verifier.rs
@@ -2,11 +2,11 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
-    utils::{
-        check_verification_job_status, global_teardown, random_felt, setup_sequencer,
-        singleprover_prove_dummy_circuit, TestConfig,
+    utils::{global_teardown, random_felt, setup_sequencer, TestConfig},
+    verifier::utils::{
+        check_verification_job_status, queue_verification_job, singleprover_prove_dummy_circuit,
+        step_verification, FUZZ_ROUNDS,
     },
-    verifier::utils::{queue_verification_job, step_verification, FUZZ_ROUNDS, VERIFIER_ADDRESS},
 };
 
 #[tokio::test]
@@ -19,24 +19,16 @@ async fn test_full_verification_fuzz() -> Result<()> {
         let verification_job_id = random_felt();
         queue_verification_job(&account, &proof, &witness_commitments, verification_job_id).await?;
 
-        while check_verification_job_status(
-            &account,
-            *VERIFIER_ADDRESS.get().unwrap(),
-            verification_job_id,
-        )
-        .await?
-        .is_none()
+        while check_verification_job_status(&account, verification_job_id)
+            .await?
+            .is_none()
         {
             step_verification(&account, verification_job_id).await?;
         }
 
-        assert!(check_verification_job_status(
-            &account,
-            *VERIFIER_ADDRESS.get().unwrap(),
-            verification_job_id
-        )
-        .await?
-        .unwrap());
+        assert!(check_verification_job_status(&account, verification_job_id)
+            .await?
+            .unwrap());
     }
 
     global_teardown(sequencer);
@@ -54,24 +46,18 @@ async fn test_full_verification_invalid_proof() -> Result<()> {
     let verification_job_id = random_felt();
     queue_verification_job(&account, &proof, &witness_commitments, verification_job_id).await?;
 
-    while check_verification_job_status(
-        &account,
-        *VERIFIER_ADDRESS.get().unwrap(),
-        verification_job_id,
-    )
-    .await?
-    .is_none()
+    while check_verification_job_status(&account, verification_job_id)
+        .await?
+        .is_none()
     {
         step_verification(&account, verification_job_id).await?;
     }
 
-    assert!(!check_verification_job_status(
-        &account,
-        *VERIFIER_ADDRESS.get().unwrap(),
-        verification_job_id
-    )
-    .await?
-    .unwrap());
+    assert!(
+        !check_verification_job_status(&account, verification_job_id)
+            .await?
+            .unwrap()
+    );
 
     global_teardown(sequencer);
     Ok(())

--- a/tests/tests/verifier_utils.rs
+++ b/tests/tests/verifier_utils.rs
@@ -6,7 +6,8 @@ use mpc_bulletproof::{
     PedersenGens,
 };
 use tests::{
-    utils::{global_teardown, DUMMY_CIRCUIT_N, TRANSCRIPT_SEED},
+    utils::{global_teardown, TRANSCRIPT_SEED},
+    verifier::utils::DUMMY_CIRCUIT_N,
     verifier_utils::utils::{
         calc_delta, get_expected_dummy_circuit_delta, get_expected_dummy_circuit_s, get_s_elem,
         setup_verifier_utils_test, squeeze_challenge_scalars,


### PR DESCRIPTION
This PR refactors the `darkpool` e2e tests and utilities to be aware of multi-circuit verification.

Primarily, this means we are now deploying & initializing separate verifier contracts, and using new dummy circuits which expect the right witness type (so that contract-side appending of the statement into the witness works properly), but do almost nothing (so that the circuit itself stays small).

The updated tests (and those affected by changes to the utilities) pass.

This PR does NOT make all the necessary changes to the deploy scripts so that they properly deploy and initialize all of the verifier contracts, this is low priority at the moment and will be left for a future PR.