### PR TITLE
renegade_contracts: update to cairo v2.1.1 syntax

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1.0.1
         with:
-          scarb-version: "0.5.1"
+          scarb-version: "0.6.2"
 
       - name: Check Cairo formatting
         run: scarb fmt --check

--- a/.github/workflows/test_cairo.yml
+++ b/.github/workflows/test_cairo.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1.0.1
         with:
-          scarb-version: "0.5.1"
+          scarb-version: "0.6.2"
 
       - name: Run Cairo tests
         run: scarb test

--- a/.github/workflows/test_devnet.yml
+++ b/.github/workflows/test_devnet.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1.0.1
         with:
-          scarb-version: "0.5.1"
+          scarb-version: "0.6.2"
 
       - name: Build Cairo
         run: scarb -P release build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +168,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.4.0",
+ "ark-std",
  "blake2",
  "derivative",
  "digest 0.10.7",
@@ -178,7 +184,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize",
- "ark-std 0.4.0",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
@@ -195,7 +201,7 @@ dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
- "ark-std 0.4.0",
+ "ark-std",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -237,7 +243,7 @@ checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
  "ark-ff",
  "ark-serialize",
- "ark-std 0.4.0",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
 ]
@@ -249,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
 dependencies = [
  "ark-ff",
- "ark-std 0.4.0",
+ "ark-std",
  "tracing",
  "tracing-subscriber 0.2.25",
 ]
@@ -262,7 +268,7 @@ checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
 dependencies = [
  "ark-ec",
  "ark-ff",
- "ark-std 0.4.0",
+ "ark-std",
 ]
 
 [[package]]
@@ -273,7 +279,7 @@ checksum = "3975a01b0a6e3eae0f72ec7ca8598a6620fc72fa5981f6f5cca33b7cd788f633"
 dependencies = [
  "ark-ec",
  "ark-ff",
- "ark-std 0.4.0",
+ "ark-std",
 ]
 
 [[package]]
@@ -283,7 +289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.4.0",
+ "ark-std",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -308,17 +314,7 @@ dependencies = [
  "ark-ff",
  "ark-relations",
  "ark-serialize",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits 0.2.16",
- "rand 0.8.5",
+ "ark-std",
 ]
 
 [[package]]
@@ -500,8 +496,8 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.2"
-source = "git+https://github.com/bincode-org/bincode.git?tag=v2.0.0-rc.2#6c219e9214bda2bdce1327db6ed7f66d2fa4bf02"
+version = "2.0.0-rc.3"
+source = "git+https://github.com/bincode-org/bincode.git?tag=v2.0.0-rc.3#aada4bb4cb457677a4b8e47572ae7ca8dd44927c"
 dependencies = [
  "serde",
 ]
@@ -595,8 +591,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.1.0"
-source = "git+https://github.com/dojoengine/blockifier?rev=a31892d#a31892d0beaf00226f9667b40764e377bea7add1"
+version = "0.1.0-rc0"
+source = "git+https://github.com/dojoengine/blockifier?rev=c794d1b#c794d1b85b0937de9e0f4e3edbc9322792f7ab2e"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -721,8 +717,8 @@ checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
 name = "cairo-felt"
-version = "0.6.1"
-source = "git+https://github.com/dojoengine/cairo-rs.git?rev=51a35b2b405f29786e48a94f364d64d373d79eea#51a35b2b405f29786e48a94f364d64d373d79eea"
+version = "0.8.2"
+source = "git+https://github.com/dojoengine/cairo-rs.git?rev=262b7eb4b11ab165a2a936a5f914e78aa732d4a2#262b7eb4b11ab165a2a936a5f914e78aa732d4a2"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -733,11 +729,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-utils",
- "indoc",
+ "indoc 2.0.3",
  "num-bigint",
  "num-traits 0.2.16",
  "parity-scale-codec",
@@ -749,8 +745,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -773,16 +769,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -790,38 +786,39 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
+ "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "salsa",
 ]
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
 ]
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -833,8 +830,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -845,7 +842,7 @@ dependencies = [
  "colored",
  "diffy",
  "ignore",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "salsa",
  "smol_str",
@@ -853,8 +850,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -866,8 +863,8 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -877,8 +874,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -886,7 +883,7 @@ dependencies = [
  "cairo-lang-syntax-codegen",
  "cairo-lang-utils",
  "colored",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -897,8 +894,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -907,46 +904,47 @@ dependencies = [
  "cairo-lang-semantic",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "indoc",
- "itertools 0.10.5",
+ "indoc 2.0.3",
+ "itertools 0.11.0",
+ "num-bigint",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "serde",
  "smol_str",
  "thiserror",
- "toml 0.4.10",
+ "toml 0.7.6",
 ]
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6dd17668d38b3374ae5198a009765b5fd5b645ab240e1cae7df720594b1999"
+checksum = "55ce3aa736c0180b5ed5320138b3f8ed70696618f2cb23bc86217eebfa2274ea"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-std 0.3.0",
+ "ark-std",
  "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-compiler",
@@ -960,10 +958,11 @@ dependencies = [
  "cairo-lang-sierra-gas",
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
+ "cairo-lang-sierra-type-size 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "cairo-vm",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "keccak",
  "num-bigint",
  "num-integer",
@@ -974,8 +973,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -986,7 +985,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -996,14 +995,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lalrpop",
  "lalrpop-util",
  "num-bigint",
@@ -1018,32 +1017,34 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
+ "cairo-lang-sierra-type-size 2.1.1 (git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1)",
  "cairo-lang-utils",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
+ "cairo-lang-sierra-type-size 2.1.1 (git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1)",
  "cairo-lang-utils",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1058,8 +1059,8 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "num-bigint",
  "salsa",
  "smol_str",
@@ -1067,8 +1068,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -1076,9 +1077,10 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
+ "cairo-lang-sierra-type-size 2.1.1 (git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1)",
  "cairo-lang-utils",
- "indoc",
- "itertools 0.10.5",
+ "indoc 2.0.3",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -1086,9 +1088,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-sierra-type-size"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a5e70b5a5826edeb61ec375886847f51e1b995709e3f36d657844fbd703d45"
+dependencies = [
+ "cairo-lang-sierra",
+ "cairo-lang-utils",
+]
+
+[[package]]
+name = "cairo-lang-sierra-type-size"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
+dependencies = [
+ "cairo-lang-sierra",
+ "cairo-lang-utils",
+]
+
+[[package]]
 name = "cairo-lang-starknet"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1110,8 +1131,9 @@ dependencies = [
  "cairo-lang-utils",
  "convert_case 0.6.0",
  "genco",
- "indoc",
- "itertools 0.10.5",
+ "indent",
+ "indoc 2.0.3",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-integer",
@@ -1126,8 +1148,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1142,8 +1164,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
  "genco",
  "xshell",
@@ -1151,12 +1173,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.0.1"
-source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.0.1#cf142a28ef88efb7b27e148b58a902ce95ca8207"
+version = "2.1.1"
+source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba97660c1e7b0ab8fbd5f43b99065f9f"
 dependencies = [
- "env_logger",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "env_logger 0.10.0",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-integer",
@@ -1168,25 +1190,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cairo-take_until_unbalanced"
-version = "0.30.0"
-source = "git+https://github.com/dojoengine/cairo-rs.git?rev=51a35b2b405f29786e48a94f364d64d373d79eea#51a35b2b405f29786e48a94f364d64d373d79eea"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cairo-vm"
-version = "0.6.1"
-source = "git+https://github.com/dojoengine/cairo-rs.git?rev=51a35b2b405f29786e48a94f364d64d373d79eea#51a35b2b405f29786e48a94f364d64d373d79eea"
+version = "0.8.2"
+source = "git+https://github.com/dojoengine/cairo-rs.git?rev=262b7eb4b11ab165a2a936a5f914e78aa732d4a2#262b7eb4b11ab165a2a936a5f914e78aa732d4a2"
 dependencies = [
  "anyhow",
- "bincode 2.0.0-rc.2",
+ "bincode 2.0.0-rc.3",
  "bitvec",
  "cairo-felt",
- "cairo-take_until_unbalanced",
  "generic-array 0.14.7",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "hex",
  "keccak",
  "lazy_static",
@@ -1197,14 +1210,11 @@ dependencies = [
  "num-prime",
  "num-traits 0.2.16",
  "rand 0.8.5",
- "rand_core 0.6.4",
  "serde",
- "serde_bytes",
  "serde_json",
  "sha2 0.10.7",
  "sha3 0.10.8",
  "starknet-crypto 0.5.1",
- "thiserror",
  "thiserror-no-std",
 ]
 
@@ -1228,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -1489,7 +1499,7 @@ dependencies = [
  "renegade-crypto",
  "serde",
  "serde_json",
- "starknet 0.5.0",
+ "starknet 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "tokio",
  "tracing",
  "uuid 1.4.1",
@@ -1596,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
-source = "git+https://github.com/software-mansion/scarb?tag=v0.5.1#798acce7f95f52746cc21e641de49537ececc66b"
+source = "git+https://github.com/software-mansion/scarb?rev=c07fa61#c07fa61553985f045286166d0235e55492694159"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -1869,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc7ee9db8e2094ace8b1c318b6c83533bc923524f9a5425846fb0e2cd4731a7"
+checksum = "4dbbad0a7ba06a961df3cd638ab117f5d67787607f627defa65629a4ef29d576"
 dependencies = [
  "anyhow",
  "futures",
@@ -2048,7 +2058,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "dojo-lang"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo.git?rev=e305d4d#e305d4dfa6fd81add0a5f3e8e9ebeac4b7c4f6d8"
+source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2069,6 +2079,7 @@ dependencies = [
  "convert_case 0.6.0",
  "dojo-types",
  "dojo-world",
+ "indoc 1.0.9",
  "itertools 0.10.5",
  "salsa",
  "sanitizer",
@@ -2078,7 +2089,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tracing",
  "url",
@@ -2087,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "dojo-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo.git?rev=e305d4d#e305d4dfa6fd81add0a5f3e8e9ebeac4b7c4f6d8"
+source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2106,7 +2117,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "toml 0.7.6",
@@ -2117,16 +2128,16 @@ dependencies = [
 [[package]]
 name = "dojo-types"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo.git?rev=e305d4d#e305d4dfa6fd81add0a5f3e8e9ebeac4b7c4f6d8"
+source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "serde",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "dojo-world"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo.git?rev=e305d4d#e305d4dfa6fd81add0a5f3e8e9ebeac4b7c4f6d8"
+source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2138,11 +2149,13 @@ dependencies = [
  "dojo-types",
  "futures",
  "reqwest",
+ "scarb",
  "serde",
  "serde_json",
  "serde_with",
  "smol_str",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.5.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -2224,6 +2237,19 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -2601,11 +2627,12 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gix"
-version = "0.47.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f5281c55e0a7415877d91a15fae4a10ec7444615d64d78e48c07f20bcfcd9b"
+checksum = "275b1bfa0d6f6ed31a2e2e878a4539f4994eac8840546283ab3aebbd8fcaa42d"
 dependencies = [
  "gix-actor",
+ "gix-archive",
  "gix-attributes",
  "gix-commitgraph",
  "gix-config",
@@ -2613,8 +2640,9 @@ dependencies = [
  "gix-date",
  "gix-diff",
  "gix-discover",
- "gix-features 0.31.1",
- "gix-fs 0.3.0",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
  "gix-glob",
  "gix-hash",
  "gix-hashtable",
@@ -2639,6 +2667,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "gix-worktree",
+ "gix-worktree-stream",
  "log",
  "once_cell",
  "signal-hook",
@@ -2649,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70d0d809ee387113df810ab4ebe585a076e35ae6ed59b5b280072146955a3ff"
+checksum = "abd2566c12095a584716f2c16f051850bd8987f57556f1fef4a7cce0300b83d0"
 dependencies = [
  "bstr",
  "btoi",
@@ -2662,10 +2691,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-attributes"
-version = "0.14.1"
+name = "gix-archive"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3772b0129dcd1fc73e985bbd08a1482d082097d2915cb1ee31ce8092b8e4434"
+checksum = "fc89a798842b519048e947339a9c9f3cfd8fb9c2d9b66b6ebcb0c3cc8fe5874d"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-object",
+ "gix-worktree-stream",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a134a674e39e238bd273326a9815296cc71f867ad5466518da71392cff98ce"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2707,38 +2749,38 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed42baa50075d41c1a0931074ce1a97c5797c7c6fe7591d9f1f2dcd448532c26"
+checksum = "8219fe6f39588a29dbfb8d1c244b07ee653126edc5b6f3860752c3b5454fa10b"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-hash",
- "memmap2 0.7.1",
+ "memmap2",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b32541232a2c626849df7843e05b50cb43ac38a4f675abbe2f661874fc1e9d"
+checksum = "2135b921a699a4c36167148193bea23c653a16ef0686f6a280e383469709a773"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-glob",
  "gix-path",
  "gix-ref",
  "gix-sec",
  "log",
  "memchr",
- "nom",
  "once_cell",
  "smallvec",
  "thiserror",
  "unicode-bom",
+ "winnow",
 ]
 
 [[package]]
@@ -2756,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a75565e0e6e7f80cfa4eb1b05cc448c6846ddd48dcf413a28875fbc11ee9af"
+checksum = "307d91ec5f7c8e9bfaa217fe30c2e0099101cbe83dbed27a222dbb6def38725f"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2772,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0213f923d63c2c7d10799c1977f42df38ec586ebbf1d14fd00dfa363ac994c2b"
+checksum = "e4f7c76578a69b736c3f0770f14757e9027354011d24c56d79207add9d7d1be6"
 dependencies = [
  "bstr",
  "itoa",
@@ -2784,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5049dd5a60d5608912da0ab184f35064901f192f4adf737716789715faffa080"
+checksum = "9a49d7a9a9ed5ec3428c3061da45d0fc5f50b3c07b91ea4e7ec4959668f25f6c"
 dependencies = [
  "gix-hash",
  "gix-object",
@@ -2796,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.20.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14865cb9c6eb817d6a8d53595f1051239d2d31feae7a5e5b2f00910c94a8eb4"
+checksum = "041480eb03d8aa0894d9b73d25d182d51bc4d0ea8925a6ee0c971262bbc7715e"
 dependencies = [
  "bstr",
  "dunce",
@@ -2811,10 +2853,11 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06142d8cff5d17509399b04052b64d2f9b3a311d5cff0b1a32b220f62cd0d595"
+checksum = "882695cccf38da4c3cc7ee687bdb412cf25e37932d7f8f2c306112ea712449f1"
 dependencies = [
+ "bytes",
  "bytesize",
  "crc32fast",
  "crossbeam-channel",
@@ -2832,23 +2875,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-features"
-version = "0.32.1"
+name = "gix-filter"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882695cccf38da4c3cc7ee687bdb412cf25e37932d7f8f2c306112ea712449f1"
+checksum = "ef4d4d61f2ab07de4612f8e078d7f1a443c7ab5c40f382784c8eacdf0fd172b9"
 dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
  "gix-hash",
+ "gix-object",
+ "gix-packetline-blocking",
+ "gix-path",
+ "gix-quote",
  "gix-trace",
- "libc",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb15956bc0256594c62a2399fcf6958a02a11724217eddfdc2b49b21b6292496"
-dependencies = [
- "gix-features 0.31.1",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2857,18 +2900,18 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5b6e9d34a2c61ea4a02bbca94c409ab6dbbca1348cbb67298cd7fed8758761"
 dependencies = [
- "gix-features 0.32.1",
+ "gix-features",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18bdff83143d61e7d60da6183b87542a870d026b2a2d0b30170b8e9c0cd321a"
+checksum = "b7255c717f49a556fa5029f6d9f2b3c008b4dd016c87f23c2ab8ca9636d5fade"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-path",
 ]
 
@@ -2895,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca801f2d0535210f77b33e2c067d565aedecacc82f1b3dbce26da1388ebc4634"
+checksum = "a88b95ceb3bc45abcab6eb55ef4e0053e58b4df0712d3f9aec7d0ca990952603"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2907,22 +2950,23 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef2fa392d351e62ac3a6309146f61880abfbe0c07474e075d3b2ac78a6834a5"
+checksum = "732f61ec71576bd443a3c24f4716dc7eac180d8929e7bb8603c7310161507106"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
  "btoi",
  "filetime",
  "gix-bitmap",
- "gix-features 0.31.1",
+ "gix-features",
+ "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-traverse",
  "itoa",
- "memmap2 0.5.10",
+ "memmap2",
  "smallvec",
  "thiserror",
 ]
@@ -2940,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.14.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bef8d360a6a9fc5a6d872471588d8ca7db77b940e48ff20c3b4706ad5f481d"
+checksum = "7fc0dbbf35d29639770af68d7ff55924d83786c8924b0e6a1766af1a98b7d58b"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2952,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b626aafb9f4088058f1baa5d2029b2191820c84f6c81e43535ba70bfdc7b7d56"
+checksum = "ce0061b7ae867e830c77b1ecfc5875f0d042aebb3d7e6014d04fd86ca6c71d59"
 dependencies = [
  "bitflags 2.4.0",
  "gix-commitgraph",
@@ -2968,15 +3012,15 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.31.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255e477ae4cc8d10778238f011e6125b01cc0e7067dc8df87acd67a428a81f20"
+checksum = "bfdd87520c71a19afecfa616863a4b761621074878f5a3999243b3e37e233943"
 dependencies = [
  "bstr",
  "btoi",
  "gix-actor",
  "gix-date",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-hash",
  "gix-validate",
  "hex",
@@ -2988,13 +3032,13 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.48.0"
+version = "0.50.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b73469f145d1e6afbcfd0ab6499a366fbbcb958c2999d41d283d6c7b94024b9"
+checksum = "e827dbda6d3dabadb94cd437d0e0fe8c314a60d136a3235fc6f5bf7b96b976ac"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-hash",
  "gix-object",
  "gix-pack",
@@ -3007,25 +3051,36 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.38.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f3bcd1aaa72aea7163b147d2bde2480a01eadefc774a479d38f29920f7f1c8"
+checksum = "46f029a4dce9ac91da35c968c3abdcae573b3e52c123be86cbab3011599de533"
 dependencies = [
  "clru",
  "gix-chunk",
  "gix-diff",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-path",
  "gix-tempfile",
  "gix-traverse",
- "memmap2 0.5.10",
+ "memmap2",
  "parking_lot 0.12.1",
  "smallvec",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "gix-packetline-blocking"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20276373def40fc3be7a86d09e1bb607d33dd6bf83e3504e83cd594e51438667"
+dependencies = [
+ "bstr",
+ "hex",
+ "thiserror",
 ]
 
 [[package]]
@@ -3067,30 +3122,30 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.31.0"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6c74873a9d8ff5d1310f2325f09164c15a91402ab5cde4d479ae12ff55ed69"
+checksum = "25db11edd78bf33043d1969fff51c567a4b30edd77ab44f6f8eb460a4c14985d"
 dependencies = [
  "gix-actor",
  "gix-date",
- "gix-features 0.31.1",
- "gix-fs 0.3.0",
+ "gix-features",
+ "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-path",
  "gix-tempfile",
  "gix-validate",
- "memmap2 0.5.10",
+ "memmap2",
  "nom",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1bc6c40bad62570683d642fcb04e977433ac8f76b674860ef7b1483c1f8990"
+checksum = "d19a02bf740b326d6c082a7d6f754ebe56eef900986c5e91be7cf000df9ea18d"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -3102,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3751d6643d731fc5829d2f43ca049f4333c968f30908220ba0783c9dfe5010c"
+checksum = "38a13500890435e3b9e7746bceda248646bfc69e259210884c98e29bb7a1aa6f"
 dependencies = [
  "bstr",
  "gix-date",
@@ -3117,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144995229c6e5788b1c7386f8a3f7146ace3745c9a6b56cef9123a7d83b110c5"
+checksum = "71d4cbaf3cfbfde2b81b5ee8b469aff42c34693ce0fe17fc3c244d5085307f2c"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -3148,7 +3203,7 @@ version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa28d567848cec8fdd77d36ad4f5f78ecfaba7d78f647d4f63c8ae1a2cec7243"
 dependencies = [
- "gix-fs 0.4.1",
+ "gix-fs",
  "libc",
  "once_cell",
  "parking_lot 0.12.1",
@@ -3165,9 +3220,9 @@ checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
 
 [[package]]
 name = "gix-traverse"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f6bba1686bfbc7e0e93d4932bc6e14d479c9c9524f7c8d65b25d2a9446a99e"
+checksum = "e12e0fe428394226c37dd686ad64b09a04b569fe157d638b125b4a4c1e7e2df0"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -3181,12 +3236,12 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beaede6dbc83f408b19adfd95bb52f1dbf01fb8862c3faf6c6243e2e67fcdfa1"
+checksum = "4411bdbd1d46b35ae50e84c191660d437f89974e4236627785024be0b577170a"
 dependencies = [
  "bstr",
- "gix-features 0.31.1",
+ "gix-features",
  "gix-path",
  "home",
  "thiserror",
@@ -3214,15 +3269,16 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.20.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee22549d6723189366235e1c6959ccdac73b58197cdbb437684eaa2169edcb9"
+checksum = "9f8bb6dd57dc6c9dfa03cc2cf2cc0942edae405eb6dfd1c34dbd2be00a90cab2"
 dependencies = [
  "bstr",
  "filetime",
  "gix-attributes",
- "gix-features 0.31.1",
- "gix-fs 0.3.0",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
  "gix-glob",
  "gix-hash",
  "gix-ignore",
@@ -3230,6 +3286,24 @@ dependencies = [
  "gix-object",
  "gix-path",
  "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2a0fa070db8f3c0f7e9d5e8f189df7f8fdbb0fed331c79dae4c3410d7106dd"
+dependencies = [
+ "gix-attributes",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot 0.12.1",
  "thiserror",
 ]
 
@@ -3322,7 +3396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
- "serde",
 ]
 
 [[package]]
@@ -3330,6 +3403,11 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -3628,6 +3706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3652,6 +3736,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -3666,6 +3751,12 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
 ]
+
+[[package]]
+name = "indoc"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "indoc"
@@ -3887,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "katana-core"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo.git?rev=e305d4d#e305d4dfa6fd81add0a5f3e8e9ebeac4b7c4f6d8"
+source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,10 +3991,12 @@ dependencies = [
  "flate2",
  "futures",
  "lazy_static",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "starknet 0.4.0",
+ "serde_with",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet_api",
  "thiserror",
  "tokio",
@@ -3913,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "katana-rpc"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo.git?rev=e305d4d#e305d4dfa6fd81add0a5f3e8e9ebeac4b7c4f6d8"
+source = "git+https://github.com/dojoengine/dojo.git?rev=954dbb3#954dbb32e1454cbd1491991ad16feeadbc78d6de"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -3927,7 +4020,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet_api",
  "thiserror",
  "tokio",
@@ -3956,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -3968,8 +4061,9 @@ dependencies = [
  "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
+ "pico-args",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3978,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
@@ -4205,15 +4299,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmap2"
@@ -4709,6 +4794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits 0.2.16",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,9 +4906,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-clean"
-version = "0.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "path-dedot"
@@ -4938,6 +5032,12 @@ dependencies = [
  "serde_derive",
  "thiserror",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -5391,7 +5491,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "serde_json",
- "starknet 0.5.0",
+ "starknet 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
 ]
 
 [[package]]
@@ -5662,8 +5762,8 @@ dependencies = [
 
 [[package]]
 name = "scarb"
-version = "0.5.1"
-source = "git+https://github.com/software-mansion/scarb?tag=v0.5.1#798acce7f95f52746cc21e641de49537ececc66b"
+version = "0.6.2"
+source = "git+https://github.com/software-mansion/scarb?rev=c07fa61#c07fa61553985f045286166d0235e55492694159"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5675,7 +5775,6 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "camino",
- "cargo_metadata",
  "clap 4.3.21",
  "clap-verbosity-flag",
  "console",
@@ -5689,17 +5788,20 @@ dependencies = [
  "fs4",
  "futures",
  "gix",
+ "glob",
  "ignore",
  "include_dir",
  "indicatif",
- "indoc",
+ "indoc 2.0.3",
  "itertools 0.11.0",
  "once_cell",
  "pathdiff",
  "petgraph",
+ "scarb-build-metadata",
  "scarb-metadata",
  "semver",
  "serde",
+ "serde-value",
  "serde_json",
  "smol_str",
  "thiserror",
@@ -5719,9 +5821,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "scarb-build-metadata"
+version = "0.6.2"
+source = "git+https://github.com/software-mansion/scarb?rev=c07fa61#c07fa61553985f045286166d0235e55492694159"
+dependencies = [
+ "cargo_metadata",
+]
+
+[[package]]
 name = "scarb-metadata"
-version = "1.4.2"
-source = "git+https://github.com/software-mansion/scarb?tag=v0.5.1#798acce7f95f52746cc21e641de49537ececc66b"
+version = "1.6.0"
+source = "git+https://github.com/software-mansion/scarb?rev=c07fa61#c07fa61553985f045286166d0235e55492694159"
 dependencies = [
  "camino",
  "clap 4.3.21",
@@ -5833,6 +5943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -6148,17 +6268,18 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2a1d8fc6a9747641a5a5fa7e8ae401be8bb73c817f16f573dd9cd440173d09"
+checksum = "8fcb61961b91757a9bc2d11549067445b2f921bd957f53710db35449767a1ba3"
 dependencies = [
- "starknet-accounts 0.3.0",
- "starknet-contract 0.3.0",
- "starknet-core 0.4.0",
+ "starknet-accounts 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-contract 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.4.1",
- "starknet-signers 0.2.2",
+ "starknet-providers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-signers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6166,26 +6287,26 @@ name = "starknet"
 version = "0.5.0"
 source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
 dependencies = [
- "starknet-accounts 0.4.0",
- "starknet-contract 0.4.0",
+ "starknet-accounts 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-contract 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
  "starknet-crypto 0.6.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
  "starknet-macros 0.1.2 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-providers 0.5.0",
- "starknet-signers 0.3.0",
+ "starknet-providers 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-signers 0.3.0 (git+https://github.com/renegade-fi/starknet-rs)",
 ]
 
 [[package]]
 name = "starknet-accounts"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44adbf4180a34e2697744506e91a114b46edbbd5261b1eb1c713a435638b3e69"
+checksum = "111ed887e4db14f0df1f909905e7737e4730770c8ed70997b58a71d5d940daac"
 dependencies = [
  "async-trait",
- "starknet-core 0.4.0",
- "starknet-providers 0.4.1",
- "starknet-signers 0.2.2",
+ "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-providers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-signers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -6196,8 +6317,8 @@ source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd1
 dependencies = [
  "async-trait",
  "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-providers 0.5.0",
- "starknet-signers 0.3.0",
+ "starknet-providers 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
+ "starknet-signers 0.3.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "thiserror",
 ]
 
@@ -6218,7 +6339,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "starknet 0.5.0",
+ "starknet 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "state",
  "tokio",
  "tracing",
@@ -6226,16 +6347,16 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcb3b31f32d8e455579b4d15f3dc214ce50df1f1fa8db7c16235a45cd722559"
+checksum = "d0d6f81a647694b2cb669ab60e77954b57bf5fbc757f5fcaf0a791c3bd341f04"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.3.0",
- "starknet-core 0.4.0",
- "starknet-providers 0.4.1",
+ "starknet-accounts 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-providers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -6247,28 +6368,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.4.0",
+ "starknet-accounts 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "starknet-providers 0.5.0",
+ "starknet-providers 0.5.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "thiserror",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e758b2966915b7ef9457e5d32e9c2017ec1e391996999cd6821db7e6b8f169"
-dependencies = [
- "base64 0.21.2",
- "flate2",
- "hex",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3 0.10.8",
- "starknet-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6462,19 +6565,20 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4554a49009d0a9414f6958edaaa337bc03a7ac5a8630c5162ab9cd5a417c6b1d"
+checksum = "dbbfccb46a8969fb3ac803718d9d8270cff4eed5b7f6b9ba234875ad2cc997c5"
 dependencies = [
  "async-trait",
  "auto_impl",
  "ethereum-types",
  "flate2",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.4.0",
+ "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "url",
 ]
@@ -6500,16 +6604,16 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2aa29798d32aa75f8184bf6cf3c7502c46d762acea6f68a40c742566cd84e5"
+checksum = "5313524cc79344015ef2a8618947332ab17012b5c50600c7f84c60989bdec980"
 dependencies = [
  "async-trait",
  "auto_impl",
  "crypto-bigint",
  "eth-keystore",
  "rand 0.8.5",
- "starknet-core 0.4.0",
+ "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -6531,8 +6635,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/starknet-api?rev=a4c78ff#a4c78ff11e8b661eb8824e6d5adb2cbd36e77a2a"
+version = "0.2.0"
+source = "git+https://github.com/starkware-libs/starknet-api?rev=ecc9b6946ef13003da202838e4124a9ad2efabb0#ecc9b6946ef13003da202838e4124a9ad2efabb0"
 dependencies = [
  "cairo-lang-starknet",
  "derive_more",
@@ -6553,7 +6657,7 @@ dependencies = [
  "clap 4.3.21",
  "eyre",
  "serde_json",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.17",
@@ -6741,7 +6845,7 @@ version = "0.1.0"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff",
- "ark-std 0.4.0",
+ "ark-std",
  "byteorder",
  "circuit-types",
  "circuits",
@@ -6755,7 +6859,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "renegade-crypto",
- "starknet 0.4.0",
+ "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-client",
  "starknet_scripts",
  "tokio",
@@ -6958,15 +7062,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7193,13 +7288,22 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.14.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cba322cb9b7bc6ca048de49e83918223f35e7a86311267013afff257004870"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7328,7 +7432,7 @@ version = "0.1.0"
 source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
 dependencies = [
  "chrono",
- "env_logger",
+ "env_logger 0.9.3",
  "futures",
  "libp2p",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,33 +4,33 @@ default-members = ["starknet_scripts"]
 resolver = "2"
 
 [workspace.dependencies]
-starknet = "0.4.0"
+starknet = "0.5.0"
 mpc-stark = "0.2"
 
 [patch."https://github.com/starkware-libs/blockifier"]
-blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "a31892d" }
+blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "c794d1b" }
 
 [patch.crates-io]
-cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "51a35b2b405f29786e48a94f364d64d373d79eea" }
-cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "51a35b2b405f29786e48a94f364d64d373d79eea" }
+cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "262b7eb4b11ab165a2a936a5f914e78aa732d4a2" }
+cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "262b7eb4b11ab165a2a936a5f914e78aa732d4a2" }
 
-cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.0.1" }
+cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.1.1" }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains the Starknet Cairo code for Renegade's settlement
 layer. This includes managing the system-global state, verifying bulletproofs,
 and emitting events that are consumed by the p2p network.
 
-Our contracts and tooling stack currently targets the Cairo `v2.0.1` compiler.
+Our contracts and tooling stack currently targets the Cairo `v2.1.1` compiler.
 
 ## Contract Development Setup
 
@@ -51,7 +51,7 @@ Make sure you have Rust installed, using e.g. [`rustup`](https://rustup.rs/)
 
 ### Install Scarb
 
-Install `scarb` version `0.5.1` by following the instructions [here](https://docs.swmansion.com/scarb/docs/install).
+Install `scarb` version `0.6.2` by following the instructions [here](https://docs.swmansion.com/scarb/docs/install).
 
 ## Running Cairo tests
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -8,5 +8,7 @@ casm = true
 casm-add-pythonic-hints = true
 
 [dependencies]
-starknet = "=2.0.1"
-alexandria = { git = "https://github.com/keep-starknet-strange/alexandria", branch = "cairo-v2.0.1" }
+starknet = "=2.1.1"
+alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "b519245" }
+alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "b519245" }
+alexandria_linalg = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "b519245" }

--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -10,8 +10,7 @@ mod statements;
 use starknet::{ClassHash, ContractAddress};
 
 use renegade_contracts::{
-    verifier::{scalar::Scalar, types::{Proof, CircuitParams}},
-    utils::serde::{EcPointSerde, ResultSerde}
+    verifier::{scalar::Scalar, types::{Proof, CircuitParams}}, utils::serde::EcPointSerde,
 };
 
 use types::{
@@ -115,8 +114,7 @@ mod Darkpool {
         merkle::{IMerkleLibraryDispatcher, IMerkleDispatcherTrait},
         nullifier_set::{INullifierSetLibraryDispatcher, INullifierSetDispatcherTrait},
         utils::{
-            serde::{EcPointSerde, ResultSerde}, storage::StorageAccessSerdeWrapper,
-            crypto::append_statement_commitments
+            serde::EcPointSerde, storage::StoreSerdeWrapper, crypto::append_statement_commitments
         },
         oz::erc20::{IERC20DispatcherTrait, IERC20Dispatcher},
     };
@@ -160,18 +158,17 @@ mod Darkpool {
         valid_settle_verifier_address: ContractAddress,
         /// Mapping of elements to be used in the post-polling merkle & nullifier set
         /// callback logic for in-progress `new_wallet` verification jobs
-        new_wallet_callback_elems: LegacyMap<felt252,
-        StorageAccessSerdeWrapper<NewWalletCallbackElems>>,
+        new_wallet_callback_elems: LegacyMap<felt252, StoreSerdeWrapper<NewWalletCallbackElems>>,
         /// Mapping of elements to be used in the post-polling merkle & nullifier set
         /// callback logic for in-progress `update_wallet` verification jobs
         update_wallet_callback_elems: LegacyMap<felt252,
-        StorageAccessSerdeWrapper<UpdateWalletCallbackElems>>,
+        StoreSerdeWrapper<UpdateWalletCallbackElems>>,
         /// Mapping of elements to be used in the post-polling merkle & nullifier set
         /// callback logic for in-progress `process_match` verification jobs.
         /// Uses the first verification job id in the list of ids for the process_match proofs
         /// as the mapping key.
         process_match_callback_elems: LegacyMap<felt252,
-        StorageAccessSerdeWrapper<ProcessMatchCallbackElems>>,
+        StoreSerdeWrapper<ProcessMatchCallbackElems>>,
         /// Stores a mapping from the wallet identity to the hash of the last transaction
         /// in which it was changed
         wallet_last_modified: LegacyMap<Scalar, felt252>
@@ -493,7 +490,7 @@ mod Darkpool {
             };
             self
                 .new_wallet_callback_elems
-                .write(verification_job_id, StorageAccessSerdeWrapper { inner: callback_elems });
+                .write(verification_job_id, StoreSerdeWrapper { inner: callback_elems });
 
             // Kick off verification
             _poll_new_wallet_inner(ref self, callback_elems, verification_job_id)
@@ -554,9 +551,7 @@ mod Darkpool {
             };
             self
                 .update_wallet_callback_elems
-                .write(
-                    verification_job_id, StorageAccessSerdeWrapper { inner: callback_elems.clone() }
-                );
+                .write(verification_job_id, StoreSerdeWrapper { inner: callback_elems.clone() });
 
             // Kick off verification
             _poll_update_wallet_inner(ref self, callback_elems, verification_job_id)
@@ -704,9 +699,8 @@ mod Darkpool {
             };
             self
                 .process_match_callback_elems
-                .write(
-                    // Use the first verification job id as the mapping key for the callback elements
-                    *verification_job_ids[0], StorageAccessSerdeWrapper { inner: callback_elems }
+                .write( // Use the first verification job id as the mapping key for the callback elements
+                    *verification_job_ids[0], StoreSerdeWrapper { inner: callback_elems }
                 );
 
             // Kick off verification

--- a/src/darkpool/statements.cairo
+++ b/src/darkpool/statements.cairo
@@ -2,7 +2,7 @@ use traits::Into;
 use clone::Clone;
 use array::ArrayTrait;
 
-use alexandria::data_structures::array_ext::ArrayTraitExt;
+use alexandria_data_structures::array_ext::ArrayTraitExt;
 use renegade_contracts::{
     verifier::scalar::{Scalar, ScalarSerializable}, utils::eq::ArrayTPartialEq
 };

--- a/src/merkle.cairo
+++ b/src/merkle.cairo
@@ -17,7 +17,7 @@ mod Merkle {
     use array::ArrayTrait;
     use option::OptionTrait;
 
-    use alexandria::math::fast_power::fast_power;
+    use alexandria_math::fast_power::fast_power;
 
     use renegade_contracts::{utils::constants::MAX_U128, verifier::scalar::Scalar};
     use super::poseidon::poseidon_hash;

--- a/src/merkle/poseidon.cairo
+++ b/src/merkle/poseidon.cairo
@@ -3,7 +3,8 @@ mod constants;
 use traits::Into;
 use array::{ArrayTrait, SpanTrait};
 
-use alexandria::{data_structures::vec::{NullableVec, VecTrait}, linalg::dot::dot};
+use alexandria_data_structures::vec::{NullableVec, VecTrait};
+use alexandria_linalg::dot::dot;
 
 use renegade_contracts::{
     verifier::scalar::{Scalar, ScalarTrait}, utils::collections::{DeepSpan, vec_to_arr}

--- a/src/testing/test_contracts/poseidon_wrapper.cairo
+++ b/src/testing/test_contracts/poseidon_wrapper.cairo
@@ -12,13 +12,13 @@ mod PoseidonWrapper {
     use array::ArrayTrait;
 
     use renegade_contracts::{
-        merkle::poseidon::{PoseidonSponge, PoseidonTrait},
-        utils::storage::StorageAccessSerdeWrapper, verifier::scalar::Scalar,
+        merkle::poseidon::{PoseidonSponge, PoseidonTrait}, utils::storage::StoreSerdeWrapper,
+        verifier::scalar::Scalar,
     };
 
     #[storage]
     struct Storage {
-        hash: StorageAccessSerdeWrapper<Array<Scalar>>, 
+        hash: StoreSerdeWrapper<Array<Scalar>>, 
     }
 
     #[external(v0)]
@@ -27,7 +27,7 @@ mod PoseidonWrapper {
             let mut sponge = PoseidonTrait::new();
             sponge.absorb(input.span());
             let hash = sponge.squeeze(num_elements);
-            self.hash.write(StorageAccessSerdeWrapper { inner: hash });
+            self.hash.write(StoreSerdeWrapper { inner: hash });
         }
 
         fn get_hash(self: @ContractState) -> Array<Scalar> {

--- a/src/testing/test_contracts/storage_serde_wrapper.cairo
+++ b/src/testing/test_contracts/storage_serde_wrapper.cairo
@@ -21,20 +21,20 @@ trait IStorageSerde<TContractState> {
 mod StorageSerdeTestWrapper {
     use array::ArrayTrait;
 
-    use renegade_contracts::utils::storage::StorageAccessSerdeWrapper;
+    use renegade_contracts::utils::storage::StoreSerdeWrapper;
 
     use super::ComplexType;
 
     #[storage]
     struct Storage {
-        arr: StorageAccessSerdeWrapper<Array<felt252>>,
-        s: StorageAccessSerdeWrapper<ComplexType>,
+        arr: StoreSerdeWrapper<Array<felt252>>,
+        s: StoreSerdeWrapper<ComplexType>,
     }
 
     #[external(v0)]
     impl StorageSerdeTestWrapperImpl of super::IStorageSerde<ContractState> {
         fn store_arr(ref self: ContractState, arr: Array<felt252>) {
-            self.arr.write(StorageAccessSerdeWrapper { inner: arr });
+            self.arr.write(StoreSerdeWrapper { inner: arr });
         }
 
         fn get_arr(self: @ContractState) -> Array<felt252> {
@@ -42,7 +42,7 @@ mod StorageSerdeTestWrapper {
         }
 
         fn store_struct(ref self: ContractState, s: ComplexType) {
-            self.s.write(StorageAccessSerdeWrapper { inner: s });
+            self.s.write(StoreSerdeWrapper { inner: s });
         }
 
         fn get_struct(self: @ContractState) -> ComplexType {

--- a/src/testing/test_contracts/transcript_wrapper.cairo
+++ b/src/testing/test_contracts/transcript_wrapper.cairo
@@ -18,20 +18,20 @@ mod TranscriptWrapper {
     use option::OptionTrait;
     use renegade_contracts::{
         transcript::{Transcript, TranscriptProtocol, TranscriptTrait}, verifier::scalar::Scalar,
-        utils::{serde::EcPointSerde, storage::StorageAccessSerdeWrapper}
+        utils::{serde::EcPointSerde, storage::StoreSerdeWrapper}
     };
 
     #[storage]
     struct Storage {
-        transcript: StorageAccessSerdeWrapper<Transcript>,
-        challenge_scalar: StorageAccessSerdeWrapper<Option<Scalar>>,
+        transcript: StoreSerdeWrapper<Transcript>,
+        challenge_scalar: StoreSerdeWrapper<Option<Scalar>>,
     }
 
     #[constructor]
     fn constructor(ref self: ContractState, label: u256) {
         let transcript = TranscriptTrait::new(label);
-        self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
-        self.challenge_scalar.write(StorageAccessSerdeWrapper { inner: Option::None(()) });
+        self.transcript.write(StoreSerdeWrapper { inner: transcript });
+        self.challenge_scalar.write(StoreSerdeWrapper { inner: Option::None(()) });
     }
 
     #[external(v0)]
@@ -39,52 +39,52 @@ mod TranscriptWrapper {
         fn rangeproof_domain_sep(ref self: ContractState, n: u64, m: u64) {
             let mut transcript = self.transcript.read().inner;
             transcript.rangeproof_domain_sep(n, m);
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn innerproduct_domain_sep(ref self: ContractState, n: u64) {
             let mut transcript = self.transcript.read().inner;
             transcript.innerproduct_domain_sep(n);
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn r1cs_domain_sep(ref self: ContractState) {
             let mut transcript = self.transcript.read().inner;
             transcript.r1cs_domain_sep();
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn r1cs_1phase_domain_sep(ref self: ContractState) {
             let mut transcript = self.transcript.read().inner;
             transcript.r1cs_1phase_domain_sep();
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn append_scalar(ref self: ContractState, label: u256, scalar: Scalar) {
             let mut transcript = self.transcript.read().inner;
             transcript.append_scalar(label, scalar);
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn append_point(ref self: ContractState, label: u256, point: EcPoint) {
             let mut transcript = self.transcript.read().inner;
             transcript.append_point(label, point);
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn validate_and_append_point(ref self: ContractState, label: u256, point: EcPoint) {
             let mut transcript = self.transcript.read().inner;
             transcript.validate_and_append_point(label, point);
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
         }
 
         fn challenge_scalar(ref self: ContractState, label: u256) {
             let mut transcript = self.transcript.read().inner;
             let challenge_scalar = transcript.challenge_scalar(label);
-            self.transcript.write(StorageAccessSerdeWrapper { inner: transcript });
+            self.transcript.write(StoreSerdeWrapper { inner: transcript });
             self
                 .challenge_scalar
-                .write(StorageAccessSerdeWrapper { inner: Option::Some(challenge_scalar) });
+                .write(StoreSerdeWrapper { inner: Option::Some(challenge_scalar) });
         }
 
         fn get_challenge_scalar(self: @ContractState) -> Scalar {

--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -2,7 +2,7 @@ use array::ArrayTrait;
 use serde::Serde;
 use option::OptionTrait;
 use traits::Into;
-use ec::{ec_point_from_x, ec_mul, ec_point_new, StarkCurve};
+use ec::{ec_point_from_x, ec_mul, ec_point_new, stark_curve};
 
 use renegade_contracts::verifier::types::{
     Proof, SparseWeightMatrix, SparseWeightVec, CircuitParams
@@ -189,7 +189,7 @@ fn get_dummy_circuit_size_params() -> (usize, usize, usize, usize, usize) {
 }
 
 fn get_dummy_circuit_pc_gens() -> (EcPoint, EcPoint) {
-    let gen = ec_point_new(StarkCurve::GEN_X, StarkCurve::GEN_Y);
+    let gen = ec_point_new(stark_curve::GEN_X, stark_curve::GEN_Y);
 
     (gen, gen)
 }

--- a/src/utils/collections.cairo
+++ b/src/utils/collections.cairo
@@ -5,7 +5,7 @@ use dict::Felt252DictTrait;
 use nullable::FromNullableResult;
 use box::BoxTrait;
 
-use alexandria::data_structures::vec::VecTrait;
+use alexandria_data_structures::vec::VecTrait;
 
 use renegade_contracts::verifier::scalar::Scalar;
 

--- a/src/utils/crypto.cairo
+++ b/src/utils/crypto.cairo
@@ -4,7 +4,7 @@ use array::{ArrayTrait, SpanTrait};
 use keccak::keccak_u256s_le_inputs;
 use ec::ec_mul;
 
-use alexandria::data_structures::array_ext::ArrayTraitExt;
+use alexandria_data_structures::array_ext::ArrayTraitExt;
 use renegade_contracts::verifier::scalar::{Scalar, ScalarSerializable};
 
 use super::constants::{BASE_FIELD_ORDER, SCALAR_FIELD_ORDER, SHIFT_256_FELT, SHIFT_256_SCALAR};

--- a/src/utils/eq.cairo
+++ b/src/utils/eq.cairo
@@ -7,20 +7,6 @@ use zeroable::{IsZeroResult};
 
 use super::serde::EcPointSerde;
 
-
-impl TupleSize2PartialEq<
-    E0, E1, impl E0PartialEq: PartialEq<E0>, impl E1PartialEq: PartialEq<E1>
-> of PartialEq<(E0, E1)> {
-    fn eq(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
-        let (lhs1, lhs2) = lhs;
-        let (rhs1, rhs2) = rhs;
-        lhs1 == rhs1 && lhs2 == rhs2
-    }
-    fn ne(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
-        !(rhs == lhs)
-    }
-}
-
 impl ArrayTPartialEq<T, impl TPartialEq: PartialEq<T>, impl TDrop: Drop<T>> of PartialEq<Array<T>> {
     fn eq(lhs: @Array<T>, rhs: @Array<T>) -> bool {
         let mut lhs_span = Span { snapshot: lhs };

--- a/src/utils/serde.cairo
+++ b/src/utils/serde.cairo
@@ -30,30 +30,3 @@ impl EcPointSerde of Serde<EcPoint> {
         Option::Some(ec_point_new(x, y))
     }
 }
-
-// Follows the same pattern as OptionSerde in the corelib
-impl ResultSerde<T, E, impl TSerde: Serde<T>, impl ESerde: Serde<E>> of Serde<Result<T, E>> {
-    fn serialize(self: @Result<T, E>, ref output: Array<felt252>) {
-        match self {
-            Result::Ok(t) => {
-                0.serialize(ref output);
-                t.serialize(ref output)
-            },
-            Result::Err(e) => {
-                1.serialize(ref output);
-                e.serialize(ref output)
-            },
-        }
-    }
-
-    fn deserialize(ref serialized: Span<felt252>) -> Option<Result<T, E>> {
-        let variant = *serialized.pop_front()?;
-        if variant == 0 {
-            Option::Some(Result::Ok(Serde::<T>::deserialize(ref serialized)?))
-        } else if variant == 1 {
-            Option::Some(Result::Err(Serde::<E>::deserialize(ref serialized)?))
-        } else {
-            Option::None(())
-        }
-    }
-}

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -35,9 +35,10 @@ mod Verifier {
     use array::{ArrayTrait, SpanTrait};
     use ec::{EcPoint, ec_point_zero, ec_mul, ec_point_unwrap, ec_point_non_zero};
 
-    use alexandria::{data_structures::array_ext::ArrayTraitExt, math::fast_power::fast_power};
+    use alexandria_data_structures::array_ext::ArrayTraitExt;
+    use alexandria_math::fast_power::fast_power;
     use renegade_contracts::utils::{
-        math::get_consecutive_powers, storage::StorageAccessSerdeWrapper, eq::EcPointPartialEq,
+        math::get_consecutive_powers, storage::StoreSerdeWrapper, eq::EcPointPartialEq,
         serde::EcPointSerde, constants::{MAX_USIZE, G_LABEL, H_LABEL}
     };
 
@@ -63,13 +64,13 @@ mod Verifier {
     #[storage]
     struct Storage {
         /// Queue of in-progress verification jobs
-        verification_queue: LegacyMap<felt252, StorageAccessSerdeWrapper<VerificationJob>>,
+        verification_queue: LegacyMap<felt252, StoreSerdeWrapper<VerificationJob>>,
         /// Map of in-use verification job IDs
         job_id_in_use: LegacyMap<felt252, bool>,
         /// Generator used for Pedersen commitments
-        B: StorageAccessSerdeWrapper<EcPoint>,
+        B: StoreSerdeWrapper<EcPoint>,
         /// Generator used for blinding in Pedersen commitments
-        B_blind: StorageAccessSerdeWrapper<EcPoint>,
+        B_blind: StoreSerdeWrapper<EcPoint>,
         /// Number of multiplication gates in the circuit
         n: usize,
         /// Number of multiplication gates in the circuit,
@@ -83,15 +84,15 @@ mod Verifier {
         m: usize,
         // TODO: These may just have to be lists of pointers (StorageBaseAddress) to the matrices
         /// Sparse-reduced matrix of left input weights for the circuit
-        W_L: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        W_L: StoreSerdeWrapper<SparseWeightMatrix>,
         /// Sparse-reduced matrix of right input weights for the circuit
-        W_R: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        W_R: StoreSerdeWrapper<SparseWeightMatrix>,
         /// Sparse-reduced matrix of output weights for the circuit
-        W_O: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        W_O: StoreSerdeWrapper<SparseWeightMatrix>,
         /// Sparse-reduced matrix of witness weights for the circuit
-        W_V: StorageAccessSerdeWrapper<SparseWeightMatrix>,
+        W_V: StoreSerdeWrapper<SparseWeightMatrix>,
         /// Sparse-reduced vector of constants for the circuit
-        c: StorageAccessSerdeWrapper<SparseWeightVec>,
+        c: StoreSerdeWrapper<SparseWeightVec>,
     }
 
     // ----------
@@ -160,13 +161,13 @@ mod Verifier {
             self.k.write(circuit_params.k);
             self.q.write(circuit_params.q);
             self.m.write(circuit_params.m);
-            self.B.write(StorageAccessSerdeWrapper { inner: circuit_params.B });
-            self.B_blind.write(StorageAccessSerdeWrapper { inner: circuit_params.B_blind });
-            self.W_L.write(StorageAccessSerdeWrapper { inner: circuit_params.W_L });
-            self.W_R.write(StorageAccessSerdeWrapper { inner: circuit_params.W_R });
-            self.W_O.write(StorageAccessSerdeWrapper { inner: circuit_params.W_O });
-            self.W_V.write(StorageAccessSerdeWrapper { inner: circuit_params.W_V });
-            self.c.write(StorageAccessSerdeWrapper { inner: circuit_params.c });
+            self.B.write(StoreSerdeWrapper { inner: circuit_params.B });
+            self.B_blind.write(StoreSerdeWrapper { inner: circuit_params.B_blind });
+            self.W_L.write(StoreSerdeWrapper { inner: circuit_params.W_L });
+            self.W_R.write(StoreSerdeWrapper { inner: circuit_params.W_R });
+            self.W_O.write(StoreSerdeWrapper { inner: circuit_params.W_O });
+            self.W_V.write(StoreSerdeWrapper { inner: circuit_params.W_V });
+            self.c.write(StoreSerdeWrapper { inner: circuit_params.c });
 
             self.emit(Event::Initialized(Initialized {}));
         }
@@ -250,7 +251,7 @@ mod Verifier {
             // Enqueue verification job
             self
                 .verification_queue
-                .write(verification_job_id, StorageAccessSerdeWrapper { inner: verification_job });
+                .write(verification_job_id, StoreSerdeWrapper { inner: verification_job });
 
             self.emit(Event::VerificationJobQueued(VerificationJobQueued { verification_job_id }));
         }
@@ -277,7 +278,7 @@ mod Verifier {
 
             self
                 .verification_queue
-                .write(verification_job_id, StorageAccessSerdeWrapper { inner: verification_job });
+                .write(verification_job_id, StoreSerdeWrapper { inner: verification_job });
 
             verified
         }

--- a/src/verifier/scalar.cairo
+++ b/src/verifier/scalar.cairo
@@ -4,7 +4,7 @@ use integer::NumericLiteral;
 use debug::PrintTrait;
 use hash::LegacyHash;
 
-use alexandria::math::mod_arithmetics::{
+use alexandria_math::mod_arithmetics::{
     mult_inverse, pow_mod, add_mod, sub_mod, mult_mod, div_mod, add_inverse_mod
 };
 
@@ -13,7 +13,7 @@ use renegade_contracts::utils::constants::SCALAR_FIELD_ORDER;
 // TODO: When deserializing Scalars from calldata / storage, we need to assert that they are
 // within the scalar field order.
 // Best way to do this is probably to accept felts for calldata, and call .into() then.
-#[derive(Default, Drop, Copy, PartialEq, PartialOrd, Serde, storage_access::StorageAccess)]
+#[derive(Default, Drop, Copy, PartialEq, PartialOrd, Serde, starknet::Store)]
 struct Scalar {
     inner: felt252
 }

--- a/src/verifier/types.cairo
+++ b/src/verifier/types.cairo
@@ -7,8 +7,7 @@ use ec::{stark_curve, EcPoint, ec_point_new, ec_mul};
 use keccak::keccak_u256s_le_inputs;
 
 use renegade_contracts::utils::{
-    serde::{EcPointSerde},
-    eq::{EcPointPartialEq, ArrayTPartialEq, OptionTPartialEq},
+    serde::EcPointSerde, eq::{EcPointPartialEq, ArrayTPartialEq, OptionTPartialEq},
     math::binary_exp, crypto::hash_to_scalar,
     collections::{DeepSpan, get_scalar_or_zero, insert_scalar}, constants::MAX_USIZE,
 };

--- a/src/verifier/types.cairo
+++ b/src/verifier/types.cairo
@@ -3,13 +3,12 @@ use clone::Clone;
 use option::{OptionTrait, OptionSerde};
 use array::{ArrayTrait, SpanTrait};
 use dict::Felt252DictTrait;
-use ec::{StarkCurve, EcPoint, ec_point_new, ec_mul};
+use ec::{stark_curve, EcPoint, ec_point_new, ec_mul};
 use keccak::keccak_u256s_le_inputs;
-use starknet::StorageAccess;
 
 use renegade_contracts::utils::{
     serde::{EcPointSerde},
-    eq::{EcPointPartialEq, ArrayTPartialEq, OptionTPartialEq, TupleSize2PartialEq},
+    eq::{EcPointPartialEq, ArrayTPartialEq, OptionTPartialEq},
     math::binary_exp, crypto::hash_to_scalar,
     collections::{DeepSpan, get_scalar_or_zero, insert_scalar}, constants::MAX_USIZE,
 };
@@ -289,7 +288,7 @@ impl RemainingGeneratorsImpl of RemainingGeneratorsTrait {
         input.append(self.hash_state);
         let hash_state = keccak_u256s_le_inputs(input.span());
         self = RemainingGenerators { hash_state, num_gens_rem: self.num_gens_rem - 1 };
-        let basepoint = ec_point_new(StarkCurve::GEN_X, StarkCurve::GEN_Y);
+        let basepoint = ec_point_new(stark_curve::GEN_X, stark_curve::GEN_Y);
         // It is important to sample a scalar field element here rather than
         // a base field element, since this has a one-to-one mapping with
         // curve points.

--- a/src/verifier/utils.cairo
+++ b/src/verifier/utils.cairo
@@ -3,7 +3,7 @@ use option::OptionTrait;
 use array::{ArrayTrait, SpanTrait};
 use ec::{ec_point_unwrap, ec_point_non_zero, ec_point_zero};
 
-use alexandria::linalg::dot::dot;
+use alexandria_linalg::dot::dot;
 use renegade_contracts::{
     transcript::{Transcript, TranscriptTrait, TranscriptProtocol, TRANSCRIPT_SEED},
     utils::math::elt_wise_mul

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,8 +23,8 @@ num-bigint = { version = "0.4.3", features = ["rand"] }
 byteorder = "1.4.3"
 
 starknet = { workspace = true }
-katana-core = { git = "https://github.com/dojoengine/dojo.git", rev = "e305d4d" }
-dojo-test-utils = { git = "https://github.com/dojoengine/dojo.git", rev = "e305d4d" }
+katana-core = { git = "https://github.com/dojoengine/dojo.git", rev = "954dbb3" }
+dojo-test-utils = { git = "https://github.com/dojoengine/dojo.git", rev = "954dbb3" }
 mpc-stark = { workspace = true }
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof.git", features = ["integration_test"] }
 merlin = { git = "https://github.com/renegade-fi/merlin.git" }


### PR DESCRIPTION
This PR updates the contracts (and cairo tests) to cairo v2.1.1 syntax. The contracts build and the cairo tests pass.

e2e tests build, but I have not tried running them yet. will work any fixes necessary into #68.