### PR TITLE
starknet-scripts: Add `dump-deployments` CLI option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "jsonrpsee"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6656,6 +6662,7 @@ version = "0.1.0"
 dependencies = [
  "clap 4.3.21",
  "eyre",
+ "json",
  "serde_json",
  "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",

--- a/starknet_scripts/Cargo.toml
+++ b/starknet_scripts/Cargo.toml
@@ -10,6 +10,7 @@ starknet = { workspace = true }
 clap = { version = "4.3.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"
+json = "0.12"
 serde_json = "1.0.96"
 url = "2.3.1"
 tracing = { version = "0.1", features = ["log"] }

--- a/starknet_scripts/src/cli.rs
+++ b/starknet_scripts/src/cli.rs
@@ -1,5 +1,7 @@
 //! Command line interface for the Starknet scripts
 
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 use clap::{Args, ValueEnum};
 
 // TODO: Move everything except for `CliArgs` and `Commands` into library crate,
@@ -42,6 +44,11 @@ pub struct DeployArgs {
     #[arg(short, long, long_help)]
     /// Whether or not to initialize the contract.
     pub initialize: bool,
+
+    #[arg(long, long_help)]
+    /// Whether or not to dump the deployed addresses to a `deployments.txt` file in the
+    /// working directory
+    pub dump_deployments: bool,
 
     #[arg(short, long, long_help)]
     /// The account address of the owner of the Darkpool contract,
@@ -115,6 +122,17 @@ pub enum Contract {
     Merkle,
     NullifierSet,
     // TODO: Add verifier contract
+}
+
+impl Display for Contract {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let s = match self {
+            Contract::Darkpool => "darkpool",
+            Contract::Merkle => "merkle",
+            Contract::NullifierSet => "nullifier_set",
+        };
+        write!(f, "{s}")
+    }
 }
 
 #[derive(Debug, Clone, ValueEnum)]


### PR DESCRIPTION
### Purpose
This PR adds the `dump-deployments` CLI option to the `starknet-scripts`. When this flag is activated, the script will dump a JSON representation of the deployment state to `$(pwd)/deployments.json`.

This will be used by the `renegade` integration tests to pull the contract address at runtime from the dumped state in the Katana container.

### Testing
- Deployed to a local Katana node with `--dump-deployments` and verified the `deployments.json` file was created as expected