### PR TITLE
tests: devnet state dumping/loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6f84b74db2535ebae81eede2f39b947dcbf01d093ae5f791e5dd414a1bf289"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arc-swap"
@@ -189,6 +189,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "itertools 0.10.5",
  "num-traits 0.2.16",
+ "rayon",
  "zeroize",
 ]
 
@@ -325,6 +326,7 @@ checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits 0.2.16",
  "rand 0.8.5",
+ "rayon",
 ]
 
 [[package]]
@@ -393,7 +395,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -676,9 +678,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bus"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34701d821c19736317bc716b8eb6153a78b431b06fbd3950716cedc705a6c811"
+checksum = "4b7118d0221d84fada881b657c2ddb7cd55108db79c8764c9ee212c0c259b783"
 dependencies = [
  "crossbeam-channel",
  "num_cpus",
@@ -918,7 +920,7 @@ source = "git+https://github.com/starkware-libs/cairo.git?tag=v2.1.1#be25046bba9
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1258,9 +1260,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1301,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "itertools 0.10.5",
  "mpc-bulletproof",
@@ -1313,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "ark-ff",
  "async-trait",
@@ -1338,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff",
@@ -1382,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
  "clap_builder",
  "clap_derive 4.3.12",
@@ -1397,15 +1399,15 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
 dependencies = [
- "clap 4.3.21",
+ "clap 4.3.23",
  "log",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1435,7 +1437,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1479,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "base64 0.13.1",
  "bimap",
@@ -1508,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "base64 0.13.1",
  "clap 3.2.25",
@@ -1543,7 +1545,7 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 
 [[package]]
 name = "convert_case"
@@ -1756,7 +1758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
 dependencies = [
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1826,7 +1828,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1848,7 +1850,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1895,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 dependencies = [
  "serde",
 ]
@@ -2170,9 +2172,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
+checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
 
 [[package]]
 name = "ed25519"
@@ -2334,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "circuit-types",
  "common",
@@ -2355,6 +2357,15 @@ checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9042d281a5eec0f2387f8c3ea6c4514e2cf2732c90a85aaf383b761ee3b290d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2506,7 +2517,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2722,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa8bbde7551a9e3e783a2871f53bbb0f50aac7a77db5680c8709f69e8ce724f"
+checksum = "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959"
 dependencies = [
  "thiserror",
 ]
@@ -2740,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2783ad148fb16bf9cfd46423706ba552a62a4d4a18fda5dd07648eb0228862dd"
+checksum = "0f28f654184b5f725c5737c7e4f466cbd8f0102ac352d5257eeab19647ee4256"
 dependencies = [
  "bstr",
 ]
@@ -2814,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f7c76578a69b736c3f0770f14757e9027354011d24c56d79207add9d7d1be6"
+checksum = "01e476b4e156f6044d35bf1ce2079d97b7207515cfb5a2bb6fcd489bb697d700"
 dependencies = [
  "bstr",
  "itoa",
@@ -3074,12 +3085,12 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20276373def40fc3be7a86d09e1bb607d33dd6bf83e3504e83cd594e51438667"
+checksum = "e39142400d3faa7057680ed3947c3b70e46b6a0b16a7c242ec8f0249e37518ba"
 dependencies = [
  "bstr",
- "hex",
+ "faster-hex",
  "thiserror",
 ]
 
@@ -3111,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd80d3d0c733508df9449b1d3795da36083807e31d851d7d61d29af13bd4b0a"
+checksum = "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905"
 dependencies = [
  "bstr",
  "btoi",
@@ -3339,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473d618f0f2c16d1ecb73bc755b207150665fd6b3e5b9570313cee6bba3880db"
+checksum = "4286919dfa7d06a1f3397e04381575043e87dd48e43548396874a5547b9b3913"
 dependencies = [
  "fnv",
  "minilp",
@@ -3350,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "circuit-types",
  "common",
@@ -3363,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -3846,7 +3857,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "circuit-types",
  "circuits",
@@ -3979,6 +3990,16 @@ checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
 dependencies = [
  "crossbeam",
  "rayon",
+]
+
+[[package]]
+name = "kanal"
+version = "0.1.0-pre8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
+dependencies = [
+ "futures-core",
+ "lock_api",
 ]
 
 [[package]]
@@ -4430,9 +4451,8 @@ checksum = "4519a88847ba2d5ead3dc53f1060ec6a571de93f325d9c5c4968147382b1cbc3"
 [[package]]
 name = "mpc-bulletproof"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/mpc-bulletproof.git#9c877dfeea45651c4e862c918a46b10e7e94f9d0"
+source = "git+https://github.com/renegade-fi/mpc-bulletproof.git#58c0f28b0017edd56aa8512d4bcf94a954d8763b"
 dependencies = [
- "ark-ec",
  "ark-ff",
  "ark-serialize",
  "byteorder",
@@ -4445,18 +4465,20 @@ dependencies = [
  "num-bigint",
  "rand 0.8.5",
  "rand_core 0.5.1",
+ "rayon",
  "serde",
  "serde_derive",
  "sha3 0.8.2",
  "thiserror",
  "tokio",
+ "unzip-n",
 ]
 
 [[package]]
 name = "mpc-stark"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf5acde6612e020f9263df169cdb405b4e2d13e3c8f238d88fa3ba695b42747"
+checksum = "7a44e704b52188a1372fe683dff0214e87fe008138e95a87fd7c8e05f5513aa5"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4467,6 +4489,7 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "itertools 0.10.5",
+ "kanal",
  "num-bigint",
  "quinn",
  "rand 0.8.5",
@@ -4772,7 +4795,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4901,7 +4924,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4960,12 +4983,12 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -4998,7 +5021,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -5062,7 +5085,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -5187,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c236e70b7f9b9ea00d33c69f63ec1ae6e9ae96118923cd37bd4e9c7396f0b107"
+checksum = "1d67eb4220992a4a052a4bb03cf776e493ecb1a3a36bab551804153d63486af7"
 dependencies = [
  "bytesize",
  "human_format",
@@ -5265,9 +5288,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -5476,14 +5499,14 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "relative-path"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff",
@@ -5502,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "20b9b67e2ca7dd9e9f9285b759de30ff538aab981abaaf7bc9bd90b84a0126c3"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -5664,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -5781,7 +5804,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "camino",
- "clap 4.3.21",
+ "clap 4.3.23",
  "clap-verbosity-flag",
  "console",
  "create-output-dir",
@@ -5840,7 +5863,7 @@ version = "1.6.0"
 source = "git+https://github.com/software-mansion/scarb?rev=c07fa61#c07fa61553985f045286166d0235e55492694159"
 dependencies = [
  "camino",
- "clap 4.3.21",
+ "clap 4.3.23",
  "derive_builder",
  "semver",
  "serde",
@@ -5944,9 +5967,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
@@ -5981,13 +6004,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6069,7 +6092,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6191,9 +6214,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -6331,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "starknet-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "circuit-types",
  "circuits",
@@ -6482,7 +6505,7 @@ checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
  "starknet-curve 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-ff 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6492,7 +6515,7 @@ source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd1
 dependencies = [
  "starknet-curve 0.4.0 (git+https://github.com/renegade-fi/starknet-rs)",
  "starknet-ff 0.3.4 (git+https://github.com/renegade-fi/starknet-rs)",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6557,7 +6580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a5865ee0ed22ade86bdf45e7c09c5641f1c59ccae12c21ecde535b2b6bf64a"
 dependencies = [
  "starknet-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6566,7 +6589,7 @@ version = "0.1.2"
 source = "git+https://github.com/renegade-fi/starknet-rs#a9f8093f4cbf3a811d34cd14fb5da5c4108a90ad"
 dependencies = [
  "starknet-core 0.5.1 (git+https://github.com/renegade-fi/starknet-rs)",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6660,7 +6683,7 @@ dependencies = [
 name = "starknet_scripts"
 version = "0.1.0"
 dependencies = [
- "clap 4.3.21",
+ "clap 4.3.23",
  "eyre",
  "json",
  "serde_json",
@@ -6674,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "state"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "base64 0.13.1",
  "circuit-types",
@@ -6768,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6792,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "bus",
  "common",
@@ -6809,9 +6832,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6883,22 +6906,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6998,9 +7021,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7023,7 +7046,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7199,7 +7222,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7311,7 +7334,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7343,18 +7366,18 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995483205de764db1185c9461a000fff73fa4b9ee2bbe4c8b4027a94692700fe"
+checksum = "a96a44ae11e25afb520af4534fd7b0bd8cd613e35a78def813b8cf41631fa3c8"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
@@ -7417,6 +7440,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "unzip-n"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7437,7 +7471,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#1eaf35ccb3f07bce35dc9b9bab2f832204c0ebe4"
+source = "git+https://github.com/renegade-fi/renegade.git#0549968634dc3c0b17203691dd3b5888724e0029"
 dependencies = [
  "chrono",
  "env_logger 0.9.3",
@@ -7549,7 +7583,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -7583,7 +7617,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7616,12 +7650,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
@@ -7671,7 +7702,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7704,7 +7735,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7724,17 +7755,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.2",
- "windows_aarch64_msvc 0.48.2",
- "windows_i686_gnu 0.48.2",
- "windows_i686_msvc 0.48.2",
- "windows_x86_64_gnu 0.48.2",
- "windows_x86_64_gnullvm 0.48.2",
- "windows_x86_64_msvc 0.48.2",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7745,9 +7776,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7757,9 +7788,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7769,9 +7800,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7781,9 +7812,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7793,9 +7824,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7805,9 +7836,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7817,26 +7848,27 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7895,7 +7927,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6866,6 +6866,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "renegade-crypto",
+ "serde_json",
  "starknet 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-client",
  "starknet_scripts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -429,9 +429,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -1188,7 +1188,7 @@ dependencies = [
  "parity-scale-codec",
  "schemars",
  "serde",
- "time 0.3.25",
+ "time 0.3.27",
 ]
 
 [[package]]
@@ -2632,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gix"
@@ -2832,7 +2832,7 @@ dependencies = [
  "bstr",
  "itoa",
  "thiserror",
- "time 0.3.25",
+ "time 0.3.27",
 ]
 
 [[package]]
@@ -4735,9 +4735,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]
@@ -5408,7 +5408,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.25",
+ "time 0.3.27",
  "yasna",
 ]
 
@@ -6080,7 +6080,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.25",
+ "time 0.3.27",
 ]
 
 [[package]]
@@ -6967,9 +6967,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
 dependencies = [
  "deranged",
  "itoa",
@@ -6988,9 +6988,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
 dependencies = [
  "time-core",
 ]
@@ -7907,7 +7907,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.25",
+ "time 0.3.27",
 ]
 
 [[package]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,6 +14,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "std"] }
 
 tokio = "1"
+serde_json = "1.0.96"
 
 ark-crypto-primitives = { version = "0.4", features = ["crh", "merkle_tree", "sponge"] }
 ark-std = "0.4"

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -1,4 +1,7 @@
-use std::env;
+use std::{
+    env,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use dojo_test_utils::sequencer::TestSequencer;
 use eyre::Result;
@@ -6,19 +9,26 @@ use mpc_stark::algebra::scalar::Scalar;
 use once_cell::sync::OnceCell;
 use rand::thread_rng;
 use starknet::core::types::FieldElement;
-use starknet_scripts::commands::utils::{deploy_merkle, initialize, ScriptAccount};
+use starknet_scripts::commands::utils::{
+    deploy_merkle, initialize, ScriptAccount, MERKLE_CONTRACT_NAME,
+};
 use tracing::debug;
 
 use crate::utils::{
-    global_setup, insert_scalar_to_ark_merkle_tree, invoke_contract, ARTIFACTS_PATH_ENV_VAR,
+    dump_state, get_contract_address_from_artifact, global_setup, insert_scalar_to_ark_merkle_tree,
+    invoke_contract, load_state, ARTIFACTS_PATH_ENV_VAR, LOAD_STATE_ENV_VAR,
 };
 
 use super::ark_merkle::{setup_empty_tree, ScalarMerkleTree};
 
+const DEVNET_STATE_PATH_SEPARATOR: &str = "merkle_state";
+
 pub const TEST_MERKLE_HEIGHT: usize = 3;
-pub const MULTI_INSERT_ROUNDS: usize = 10;
+pub const MULTI_INSERT_ROUNDS: usize = 5;
 
 const INSERT_FN_NAME: &str = "insert";
+
+static MERKLE_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub static MERKLE_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -29,19 +39,40 @@ pub static MERKLE_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 pub async fn setup_merkle_test() -> Result<(TestSequencer, ScalarMerkleTree)> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = global_setup().await;
-    let account = sequencer.account();
+    // If the LOAD_STATE env var is set, or another test thread has dumped,
+    // we load the state, assuming that it contains all the necessary setup.
+    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
+        || MERKLE_STATE_INITIALIZED.load(Ordering::Relaxed)
+    {
+        debug!("Loading merkle state...");
+        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
+        let merkle_address =
+            get_contract_address_from_artifact(&artifacts_path, MERKLE_CONTRACT_NAME, &[])?;
+        if MERKLE_ADDRESS.get().is_none() {
+            MERKLE_ADDRESS.set(merkle_address).unwrap();
+        }
 
-    debug!("Declaring & deploying merkle contract...");
-    let (merkle_address, _, _) = deploy_merkle(None, &artifacts_path, &account).await?;
-    if MERKLE_ADDRESS.get().is_none() {
-        // When running multiple tests, it's possible for the OnceCell to already be set.
-        // However, we still want to deploy the contract, since each test gets its own sequencer.
-        MERKLE_ADDRESS.set(merkle_address).unwrap();
-    }
+        sequencer
+    } else {
+        let sequencer = global_setup(None).await;
+        let account = sequencer.account();
+        debug!("Declaring & deploying merkle contract...");
+        let (merkle_address, _, _) = deploy_merkle(None, &artifacts_path, &account).await?;
+        if MERKLE_ADDRESS.get().is_none() {
+            MERKLE_ADDRESS.set(merkle_address).unwrap();
+        }
 
-    debug!("Initializing merkle contract...");
-    initialize_merkle(&account, merkle_address, TEST_MERKLE_HEIGHT.into()).await?;
+        debug!("Initializing merkle contract...");
+        initialize_merkle(&account, merkle_address, TEST_MERKLE_HEIGHT.into()).await?;
+
+        // Dump the state
+        debug!("Dumping merkle state...");
+        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
+        // Mark the state as initialized
+        MERKLE_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+
+        sequencer
+    };
 
     debug!("Initializing arkworks merkle tree...");
     // arkworks implementation does height inclusive of root,

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -1,8 +1,3 @@
-use std::{
-    env,
-    sync::atomic::{AtomicBool, Ordering},
-};
-
 use dojo_test_utils::sequencer::TestSequencer;
 use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
@@ -12,11 +7,13 @@ use starknet::core::types::FieldElement;
 use starknet_scripts::commands::utils::{
     deploy_merkle, initialize, ScriptAccount, MERKLE_CONTRACT_NAME,
 };
+use std::env;
+use tokio::sync::Mutex;
 use tracing::debug;
 
 use crate::utils::{
-    dump_state, get_contract_address_from_artifact, global_setup, insert_scalar_to_ark_merkle_tree,
-    invoke_contract, load_state, ARTIFACTS_PATH_ENV_VAR, LOAD_STATE_ENV_VAR,
+    get_contract_address_from_artifact, global_setup, insert_scalar_to_ark_merkle_tree,
+    invoke_contract, setup_sequencer, ARTIFACTS_PATH_ENV_VAR,
 };
 
 use super::ark_merkle::{setup_empty_tree, ScalarMerkleTree};
@@ -28,7 +25,7 @@ pub const MULTI_INSERT_ROUNDS: usize = 5;
 
 const INSERT_FN_NAME: &str = "insert";
 
-static MERKLE_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static MERKLE_STATE_DUMPED: Mutex<bool> = Mutex::const_new(false);
 
 pub static MERKLE_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -39,40 +36,24 @@ pub static MERKLE_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 pub async fn setup_merkle_test() -> Result<(TestSequencer, ScalarMerkleTree)> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    // If the LOAD_STATE env var is set, or another test thread has dumped,
-    // we load the state, assuming that it contains all the necessary setup.
-    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
-        || MERKLE_STATE_INITIALIZED.load(Ordering::Relaxed)
-    {
-        debug!("Loading merkle state...");
-        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
-        let merkle_address =
-            get_contract_address_from_artifact(&artifacts_path, MERKLE_CONTRACT_NAME, &[])?;
-        if MERKLE_ADDRESS.get().is_none() {
-            MERKLE_ADDRESS.set(merkle_address).unwrap();
-        }
-
-        sequencer
-    } else {
+    let sequencer = setup_sequencer(&MERKLE_STATE_DUMPED, DEVNET_STATE_PATH_SEPARATOR, async {
         let sequencer = global_setup(None).await;
         let account = sequencer.account();
         debug!("Declaring & deploying merkle contract...");
         let (merkle_address, _, _) = deploy_merkle(None, &artifacts_path, &account).await?;
-        if MERKLE_ADDRESS.get().is_none() {
-            MERKLE_ADDRESS.set(merkle_address).unwrap();
-        }
 
         debug!("Initializing merkle contract...");
         initialize_merkle(&account, merkle_address, TEST_MERKLE_HEIGHT.into()).await?;
 
-        // Dump the state
-        debug!("Dumping merkle state...");
-        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
-        // Mark the state as initialized
-        MERKLE_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+        Ok(sequencer)
+    })
+    .await?;
 
-        sequencer
-    };
+    let merkle_address =
+        get_contract_address_from_artifact(&artifacts_path, MERKLE_CONTRACT_NAME, &[])?;
+    if MERKLE_ADDRESS.get().is_none() {
+        MERKLE_ADDRESS.set(merkle_address).unwrap();
+    }
 
     debug!("Initializing arkworks merkle tree...");
     // arkworks implementation does height inclusive of root,

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -15,7 +15,7 @@ use crate::utils::{
 
 use super::ark_merkle::{setup_empty_tree, ScalarMerkleTree};
 
-pub const TEST_MERKLE_HEIGHT: usize = 5;
+pub const TEST_MERKLE_HEIGHT: usize = 3;
 pub const MULTI_INSERT_ROUNDS: usize = 10;
 
 const INSERT_FN_NAME: &str = "insert";

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -3,15 +3,27 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use once_cell::sync::OnceCell;
 use starknet::core::types::FieldElement;
-use starknet_scripts::commands::utils::{deploy_nullifier_set, ScriptAccount};
-use std::env;
+use starknet_scripts::commands::utils::{
+    deploy_nullifier_set, ScriptAccount, NULLIFIER_SET_CONTRACT_NAME,
+};
+use std::{
+    env,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use tracing::debug;
 
-use crate::utils::{global_setup, invoke_contract, scalar_to_felt, ARTIFACTS_PATH_ENV_VAR};
+use crate::utils::{
+    dump_state, get_contract_address_from_artifact, global_setup, invoke_contract, load_state,
+    scalar_to_felt, ARTIFACTS_PATH_ENV_VAR, LOAD_STATE_ENV_VAR,
+};
+
+const DEVNET_STATE_PATH_SEPARATOR: &str = "nullifier_set_state";
 
 pub const FUZZ_ROUNDS: usize = 100;
 
 const MARK_NULLIFIER_USED_FN_NAME: &str = "mark_nullifier_used";
+
+static NULLIFIER_SET_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -22,17 +34,37 @@ pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 pub async fn setup_nullifier_set_test() -> Result<TestSequencer> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = global_setup().await;
-    let account = sequencer.account();
+    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
+        || NULLIFIER_SET_STATE_INITIALIZED.load(Ordering::Relaxed)
+    {
+        debug!("Loading nullifier set state...");
+        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
+        let nullifier_set_address =
+            get_contract_address_from_artifact(&artifacts_path, NULLIFIER_SET_CONTRACT_NAME, &[])?;
+        debug!("Nullifier set contract address: {}", nullifier_set_address);
+        if NULLIFIER_SET_ADDRESS.get().is_none() {
+            NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
+        }
 
-    debug!("Declaring & deploying nullifier set contract...");
-    let (nullifier_set_address, _, _) =
-        deploy_nullifier_set(None, &artifacts_path, &account).await?;
-    if NULLIFIER_SET_ADDRESS.get().is_none() {
-        // When running multiple tests, it's possible for the OnceCell to already be set.
-        // However, we still want to deploy the contract, since each test gets its own sequencer.
-        NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
-    }
+        sequencer
+    } else {
+        let sequencer = global_setup(None).await;
+        let account = sequencer.account();
+        debug!("Declaring & deploying nullifier set contract...");
+        let (nullifier_set_address, _, _) =
+            deploy_nullifier_set(None, &artifacts_path, &account).await?;
+        if NULLIFIER_SET_ADDRESS.get().is_none() {
+            NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
+        }
+
+        // Dump the state
+        debug!("Dumping nullifier set state...");
+        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
+        // Mark the state as initialized
+        NULLIFIER_SET_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+
+        sequencer
+    };
 
     Ok(sequencer)
 }

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -7,21 +7,16 @@ use starknet_scripts::commands::utils::{
     deploy_nullifier_set, ScriptAccount, NULLIFIER_SET_CONTRACT_NAME,
 };
 use std::env;
-use tokio::sync::Mutex;
 use tracing::debug;
 
 use crate::utils::{
     get_contract_address_from_artifact, global_setup, invoke_contract, scalar_to_felt,
-    setup_sequencer, ARTIFACTS_PATH_ENV_VAR,
+    ARTIFACTS_PATH_ENV_VAR,
 };
-
-const DEVNET_STATE_PATH_SEPARATOR: &str = "nullifier_set_state";
 
 pub const FUZZ_ROUNDS: usize = 100;
 
 const MARK_NULLIFIER_USED_FN_NAME: &str = "mark_nullifier_used";
-
-static NULLIFIER_SET_STATE_DUMPED: Mutex<bool> = Mutex::const_new(false);
 
 pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -29,22 +24,19 @@ pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 // | META TEST HELPERS |
 // ---------------------
 
-pub async fn setup_nullifier_set_test() -> Result<TestSequencer> {
+pub async fn init_nullifier_set_test_state() -> Result<TestSequencer> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = setup_sequencer(
-        &NULLIFIER_SET_STATE_DUMPED,
-        DEVNET_STATE_PATH_SEPARATOR,
-        async {
-            let sequencer = global_setup(None).await;
-            let account = sequencer.account();
-            debug!("Declaring & deploying nullifier set contract...");
-            deploy_nullifier_set(None, &artifacts_path, &account).await?;
+    let sequencer = global_setup(None).await;
+    let account = sequencer.account();
+    debug!("Declaring & deploying nullifier set contract...");
+    deploy_nullifier_set(None, &artifacts_path, &account).await?;
 
-            Ok(sequencer)
-        },
-    )
-    .await?;
+    Ok(sequencer)
+}
+
+pub fn init_nullifier_set_test_statics() -> Result<()> {
+    let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
     let nullifier_set_address =
         get_contract_address_from_artifact(&artifacts_path, NULLIFIER_SET_CONTRACT_NAME, &[])?;
@@ -52,7 +44,7 @@ pub async fn setup_nullifier_set_test() -> Result<TestSequencer> {
         NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
     }
 
-    Ok(sequencer)
+    Ok(())
 }
 
 // --------------------------------

--- a/tests/src/poseidon/utils.rs
+++ b/tests/src/poseidon/utils.rs
@@ -11,13 +11,18 @@ use starknet::core::types::{DeclareTransactionResult, FieldElement};
 use starknet_scripts::commands::utils::{
     calculate_contract_address, declare, deploy, get_artifacts, ScriptAccount,
 };
-use std::{env, iter};
+use std::{
+    env, iter,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use tracing::debug;
 
 use crate::utils::{
-    call_contract, felt_to_scalar, global_setup, invoke_contract, CalldataSerializable,
-    ARTIFACTS_PATH_ENV_VAR,
+    call_contract, dump_state, felt_to_scalar, get_contract_address_from_artifact, global_setup,
+    invoke_contract, load_state, CalldataSerializable, ARTIFACTS_PATH_ENV_VAR, LOAD_STATE_ENV_VAR,
 };
+
+const DEVNET_STATE_PATH_SEPARATOR: &str = "poseidon_state";
 
 pub const FUZZ_ROUNDS: usize = 4;
 const MAX_INPUT_SIZE: usize = 16;
@@ -26,6 +31,8 @@ const MAX_OUTPUT_SIZE: usize = 16;
 const POSEIDON_WRAPPER_CONTRACT_NAME: &str = "renegade_contracts_PoseidonWrapper";
 const STORE_HASH_FN_NAME: &str = "store_hash";
 const GET_HASH_FN_NAME: &str = "get_hash";
+
+static POSEIDON_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub static POSEIDON_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -36,19 +43,42 @@ pub static POSEIDON_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 pub async fn setup_poseidon_test() -> Result<TestSequencer> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = global_setup().await;
-    let account = sequencer.account();
+    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
+        || POSEIDON_STATE_INITIALIZED.load(Ordering::Relaxed)
+    {
+        debug!("Loading poseidon state...");
+        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
+        let poseidon_wrapper_address = get_contract_address_from_artifact(
+            &artifacts_path,
+            POSEIDON_WRAPPER_CONTRACT_NAME,
+            &[],
+        )?;
+        if POSEIDON_WRAPPER_ADDRESS.get().is_none() {
+            POSEIDON_WRAPPER_ADDRESS
+                .set(poseidon_wrapper_address)
+                .unwrap();
+        }
 
-    debug!("Declaring & deploying poseidon wrapper contract...");
-    let poseidon_wrapper_address = deploy_poseidon_wrapper(artifacts_path, &account).await?;
-    if POSEIDON_WRAPPER_ADDRESS.get().is_none() {
-        // When running multiple tests, it's possible for the OnceCell to already be set.
-        // However, we still want to deploy the contract, since each test gets its own sequencer.
+        sequencer
+    } else {
+        let sequencer = global_setup(None).await;
+        let account = sequencer.account();
+        debug!("Declaring & deploying poseidon wrapper contract...");
+        let poseidon_wrapper_address = deploy_poseidon_wrapper(artifacts_path, &account).await?;
+        if POSEIDON_WRAPPER_ADDRESS.get().is_none() {
+            POSEIDON_WRAPPER_ADDRESS
+                .set(poseidon_wrapper_address)
+                .unwrap();
+        }
 
-        POSEIDON_WRAPPER_ADDRESS
-            .set(poseidon_wrapper_address)
-            .unwrap();
-    }
+        // Dump the state
+        debug!("Dumping poseidon state...");
+        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
+        // Mark the state as initialized
+        POSEIDON_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+
+        sequencer
+    };
 
     Ok(sequencer)
 }

--- a/tests/src/statement_serde/utils.rs
+++ b/tests/src/statement_serde/utils.rs
@@ -20,15 +20,13 @@ use starknet::core::types::{DeclareTransactionResult, FieldElement};
 use starknet_scripts::commands::utils::{
     calculate_contract_address, declare, deploy, get_artifacts, ScriptAccount,
 };
-use std::{
-    env,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::env;
+use tokio::sync::Mutex;
 use tracing::debug;
 
 use crate::utils::{
-    call_contract, dump_state, get_contract_address_from_artifact, global_setup, load_state,
-    CalldataSerializable, ARTIFACTS_PATH_ENV_VAR, LOAD_STATE_ENV_VAR,
+    call_contract, get_contract_address_from_artifact, global_setup, setup_sequencer,
+    CalldataSerializable, ARTIFACTS_PATH_ENV_VAR,
 };
 
 const DEVNET_STATE_PATH_SEPARATOR: &str = "statement_serde_state";
@@ -53,7 +51,7 @@ const ASSERT_VALID_COMMITMENTS_STATEMENT_TO_SCALARS_FN_NAME: &str =
 const ASSERT_VALID_SETTLE_STATEMENT_TO_SCALARS_FN_NAME: &str =
     "assert_valid_settle_statement_to_scalars";
 
-static STATEMENT_SERDE_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static STATEMENT_SERDE_STATE_DUMPED: Mutex<bool> = Mutex::const_new(false);
 
 pub static STATEMENT_SERDE_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -72,46 +70,32 @@ pub static DUMMY_VALID_SETTLE_STATEMENT: OnceCell<SizedValidSettleStatement> = O
 pub async fn setup_statement_serde_test() -> Result<TestSequencer> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
-        || STATEMENT_SERDE_STATE_INITIALIZED.load(Ordering::Relaxed)
-    {
-        debug!("Loading statement serde state...");
-        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
-        let statement_serde_wrapper_address = get_contract_address_from_artifact(
-            &artifacts_path,
-            STATEMENT_SERDE_WRAPPER_CONTRACT_NAME,
-            &[],
-        )?;
+    let sequencer = setup_sequencer(
+        &STATEMENT_SERDE_STATE_DUMPED,
+        DEVNET_STATE_PATH_SEPARATOR,
+        async {
+            let sequencer = global_setup(None).await;
+            let account = sequencer.account();
 
-        if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
-            STATEMENT_SERDE_WRAPPER_ADDRESS
-                .set(statement_serde_wrapper_address)
-                .unwrap();
-        }
-
-        sequencer
-    } else {
-        let sequencer = global_setup(None).await;
-        let account = sequencer.account();
-
-        debug!("Declaring & deploying statement serde wrapper contract...");
-        let statement_serde_wrapper_address =
+            debug!("Declaring & deploying statement serde wrapper contract...");
             deploy_statement_serde_wrapper(&account, &artifacts_path).await?;
 
-        if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
-            STATEMENT_SERDE_WRAPPER_ADDRESS
-                .set(statement_serde_wrapper_address)
-                .unwrap();
-        }
+            Ok(sequencer)
+        },
+    )
+    .await?;
 
-        // Dump the state
-        debug!("Dumping statement serde state...");
-        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
-        // Mark the state as initialized
-        STATEMENT_SERDE_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+    let statement_serde_wrapper_address = get_contract_address_from_artifact(
+        &artifacts_path,
+        STATEMENT_SERDE_WRAPPER_CONTRACT_NAME,
+        &[],
+    )?;
 
-        sequencer
-    };
+    if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
+        STATEMENT_SERDE_WRAPPER_ADDRESS
+            .set(statement_serde_wrapper_address)
+            .unwrap();
+    }
 
     if DUMMY_VALID_WALLET_CREATE_STATEMENT.get().is_none() {
         DUMMY_VALID_WALLET_CREATE_STATEMENT

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -5,19 +5,24 @@ use mpc_bulletproof::r1cs::R1CSProof;
 use mpc_stark::algebra::stark_curve::StarkPoint;
 use once_cell::sync::OnceCell;
 use starknet::core::types::FieldElement;
-use starknet_scripts::commands::utils::{deploy_verifier, initialize, ScriptAccount};
-use std::env;
+use starknet_scripts::commands::utils::{deploy_verifier, initialize, ScriptAccount, VERIFIER_CONTRACT_NAME};
+use std::{env, sync::atomic::{AtomicBool, Ordering}};
 use tracing::debug;
 
 use crate::utils::{
     get_dummy_circuit_params, global_setup, invoke_contract, CalldataSerializable,
-    ARTIFACTS_PATH_ENV_VAR,
+    ARTIFACTS_PATH_ENV_VAR, LOAD_STATE_ENV_VAR, dump_state, load_state, get_contract_address_from_artifact,
 };
+
+
+const DEVNET_STATE_PATH_SEPARATOR: &str = "verifier_state";
 
 pub const FUZZ_ROUNDS: usize = 1;
 
 const QUEUE_VERIFICATION_JOB_FN_NAME: &str = "queue_verification_job";
 const STEP_VERIFICATION_FN_NAME: &str = "step_verification";
+
+static VERIFIER_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub static VERIFIER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -28,19 +33,37 @@ pub static VERIFIER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 pub async fn setup_verifier_test() -> Result<TestSequencer> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = global_setup().await;
-    let account = sequencer.account();
+    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
+    || VERIFIER_STATE_INITIALIZED.load(Ordering::Relaxed) {
+        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
+        let verifier_address = get_contract_address_from_artifact(&artifacts_path, VERIFIER_CONTRACT_NAME, &get_dummy_circuit_params().to_calldata())?;
+        if VERIFIER_ADDRESS.get().is_none() {
+            VERIFIER_ADDRESS.set(verifier_address).unwrap();
+        }
 
-    debug!("Declaring & deploying verifier contract...");
-    let (verifier_address, _, _) = deploy_verifier(None, &artifacts_path, &account).await?;
-    if VERIFIER_ADDRESS.get().is_none() {
-        // When running multiple tests, it's possible for the OnceCell to already be set.
-        // However, we still want to deploy the contract, since each test gets its own sequencer.
-        VERIFIER_ADDRESS.set(verifier_address).unwrap();
-    }
+        sequencer
+    } else  {
+        let sequencer = global_setup(None).await;
+        let account = sequencer.account();
 
-    debug!("Initializing verifier contract...");
-    initialize_verifier(&account, verifier_address).await?;
+        debug!("Declaring & deploying verifier contract...");
+        let (verifier_address, _, _) = deploy_verifier(None, &artifacts_path, &account).await?;
+        if VERIFIER_ADDRESS.get().is_none() {
+            VERIFIER_ADDRESS.set(verifier_address).unwrap();
+        }
+    
+        debug!("Initializing verifier contract...");
+        initialize_verifier(&account, verifier_address).await?;
+
+        // Dump the state
+        debug!("Dumping verifier state...");
+        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
+        // Mark the state as initialized
+        VERIFIER_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+
+        sequencer
+    };
+
 
     Ok(sequencer)
 }

--- a/tests/src/verifier_utils/utils.rs
+++ b/tests/src/verifier_utils/utils.rs
@@ -12,17 +12,15 @@ use starknet::core::types::{DeclareTransactionResult, FieldElement};
 use starknet_scripts::commands::utils::{
     calculate_contract_address, declare, deploy, get_artifacts, ScriptAccount,
 };
-use std::{
-    env, iter,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::{env, iter};
+use tokio::sync::Mutex;
 use tracing::debug;
 
 use crate::utils::{
-    call_contract, dump_state, felt_to_scalar, felt_to_u32, get_contract_address_from_artifact,
-    global_setup, load_state, prep_dummy_circuit_verifier, singleprover_prove_dummy_circuit,
+    call_contract, felt_to_scalar, felt_to_u32, get_contract_address_from_artifact, global_setup,
+    prep_dummy_circuit_verifier, setup_sequencer, singleprover_prove_dummy_circuit,
     CalldataSerializable, ARTIFACTS_PATH_ENV_VAR, DUMMY_CIRCUIT_K, DUMMY_CIRCUIT_M,
-    DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS, LOAD_STATE_ENV_VAR,
+    DUMMY_CIRCUIT_N, DUMMY_CIRCUIT_N_PLUS,
 };
 
 const DEVNET_STATE_PATH_SEPARATOR: &str = "verifier_utils_state";
@@ -33,7 +31,7 @@ const CALC_DELTA_FN_NAME: &str = "calc_delta";
 const GET_S_ELEM_FN_NAME: &str = "get_s_elem";
 const SQUEEZE_CHALLENGE_SCALARS_FN_NAME: &str = "squeeze_challenge_scalars";
 
-static VERIFIER_UTILS_STATE_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static VERIFIER_UTILS_STATE_DUMPED: Mutex<bool> = Mutex::const_new(false);
 
 static VERIFIER_UTILS_WRAPPER_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -46,45 +44,32 @@ pub async fn setup_verifier_utils_test<'t, 'g>(
 ) -> Result<(TestSequencer, R1CSProof, Vec<StarkPoint>)> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let sequencer = if env::var(LOAD_STATE_ENV_VAR).is_ok()
-        || VERIFIER_UTILS_STATE_INITIALIZED.load(Ordering::Relaxed)
-    {
-        debug!("Loading verifier utils state...");
-        let sequencer = global_setup(Some(load_state(DEVNET_STATE_PATH_SEPARATOR).await?)).await;
-        let verifier_utils_wrapper_address = get_contract_address_from_artifact(
-            &artifacts_path,
-            VERIFIER_UTILS_WRAPPER_CONTRACT_NAME,
-            &[],
-        )?;
+    let sequencer = setup_sequencer(
+        &VERIFIER_UTILS_STATE_DUMPED,
+        DEVNET_STATE_PATH_SEPARATOR,
+        async {
+            let sequencer = global_setup(None).await;
+            let account = sequencer.account();
 
-        if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
-            VERIFIER_UTILS_WRAPPER_ADDRESS
-                .set(verifier_utils_wrapper_address)
-                .unwrap();
-        }
+            debug!("Declaring & deploying verifier utils wrapper contract...");
+            deploy_verifier_utils_wrapper(&artifacts_path, &account).await?;
 
-        sequencer
-    } else {
-        let sequencer = global_setup(None).await;
-        let account = sequencer.account();
+            Ok(sequencer)
+        },
+    )
+    .await?;
 
-        debug!("Declaring & deploying verifier utils wrapper contract...");
-        let verifier_utils_wrapper_address =
-            deploy_verifier_utils_wrapper(artifacts_path, &account).await?;
-        if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
-            VERIFIER_UTILS_WRAPPER_ADDRESS
-                .set(verifier_utils_wrapper_address)
-                .unwrap();
-        }
+    let verifier_utils_wrapper_address = get_contract_address_from_artifact(
+        &artifacts_path,
+        VERIFIER_UTILS_WRAPPER_CONTRACT_NAME,
+        &[],
+    )?;
 
-        // Dump the state
-        debug!("Dumping verifier utils state...");
-        dump_state(&sequencer, DEVNET_STATE_PATH_SEPARATOR).await?;
-        // Mark the state as initialized
-        VERIFIER_UTILS_STATE_INITIALIZED.store(true, Ordering::Relaxed);
-
-        sequencer
-    };
+    if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
+        VERIFIER_UTILS_WRAPPER_ADDRESS
+            .set(verifier_utils_wrapper_address)
+            .unwrap();
+    }
 
     debug!("Getting example proof & witness commitments...");
     let (proof, witness_commitments) = singleprover_prove_dummy_circuit().unwrap();
@@ -96,11 +81,11 @@ pub async fn setup_verifier_utils_test<'t, 'g>(
 }
 
 pub async fn deploy_verifier_utils_wrapper(
-    artifacts_path: String,
+    artifacts_path: &str,
     account: &ScriptAccount,
 ) -> Result<FieldElement> {
     let (verifier_utils_sierra_path, verifier_utils_casm_path) =
-        get_artifacts(&artifacts_path, VERIFIER_UTILS_WRAPPER_CONTRACT_NAME);
+        get_artifacts(artifacts_path, VERIFIER_UTILS_WRAPPER_CONTRACT_NAME);
     let DeclareTransactionResult { class_hash, .. } = declare(
         verifier_utils_sierra_path,
         verifier_utils_casm_path,

--- a/tests/tests/nullifier_set.rs
+++ b/tests/tests/nullifier_set.rs
@@ -2,15 +2,13 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
-    nullifier_set::utils::{
-        mark_nullifier_used, setup_nullifier_set_test, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS,
-    },
-    utils::{global_teardown, is_nullifier_used},
+    nullifier_set::utils::{mark_nullifier_used, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS},
+    utils::{global_teardown, is_nullifier_used, setup_sequencer, TestConfig},
 };
 
 #[tokio::test]
 async fn test_nullifier_set_fuzz() -> Result<()> {
-    let sequencer = setup_nullifier_set_test().await?;
+    let sequencer = setup_sequencer(TestConfig::NullifierSet).await?;
     let account = sequencer.account();
 
     for _ in 0..FUZZ_ROUNDS {

--- a/tests/tests/poseidon.rs
+++ b/tests/tests/poseidon.rs
@@ -1,12 +1,12 @@
 use eyre::Result;
 use tests::{
-    poseidon::utils::{get_random_input_hashes, setup_poseidon_test, FUZZ_ROUNDS},
-    utils::global_teardown,
+    poseidon::utils::{get_random_input_hashes, FUZZ_ROUNDS},
+    utils::{global_teardown, setup_sequencer, TestConfig},
 };
 
 #[tokio::test]
 async fn test_poseidon_fuzz() -> Result<()> {
-    let sequencer = setup_poseidon_test().await?;
+    let sequencer = setup_sequencer(TestConfig::Poseidon).await?;
     let account = sequencer.account();
 
     for _ in 0..FUZZ_ROUNDS {

--- a/tests/tests/statement_serde.rs
+++ b/tests/tests/statement_serde.rs
@@ -6,14 +6,13 @@ use tests::{
         assert_valid_settle_statement, assert_valid_settle_statement_to_scalars,
         assert_valid_wallet_create_statement, assert_valid_wallet_create_statement_to_scalars,
         assert_valid_wallet_update_statement, assert_valid_wallet_update_statement_to_scalars,
-        setup_statement_serde_test,
     },
-    utils::global_teardown,
+    utils::{global_teardown, setup_sequencer, TestConfig},
 };
 
 #[tokio::test]
 async fn test_valid_wallet_create_statement_serde() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_wallet_create_statement(&sequencer.account()).await?;
 
@@ -24,7 +23,7 @@ async fn test_valid_wallet_create_statement_serde() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_wallet_update_statement_serde() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_wallet_update_statement(&sequencer.account()).await?;
 
@@ -35,7 +34,7 @@ async fn test_valid_wallet_update_statement_serde() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_reblind_statement_serde() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_reblind_statement(&sequencer.account()).await?;
 
@@ -46,7 +45,7 @@ async fn test_valid_reblind_statement_serde() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_commitments_statement_serde() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_commitments_statement(&sequencer.account()).await?;
 
@@ -57,7 +56,7 @@ async fn test_valid_commitments_statement_serde() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_settle_statement_serde() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_settle_statement(&sequencer.account()).await?;
 
@@ -68,7 +67,7 @@ async fn test_valid_settle_statement_serde() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_wallet_create_statement_to_scalars() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_wallet_create_statement_to_scalars(&sequencer.account()).await?;
 
@@ -79,7 +78,7 @@ async fn test_valid_wallet_create_statement_to_scalars() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_wallet_update_statement_to_scalars() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_wallet_update_statement_to_scalars(&sequencer.account()).await?;
 
@@ -90,7 +89,7 @@ async fn test_valid_wallet_update_statement_to_scalars() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_reblind_statement_to_scalars() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_reblind_statement_to_scalars(&sequencer.account()).await?;
 
@@ -101,7 +100,7 @@ async fn test_valid_reblind_statement_to_scalars() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_commitments_statement_to_scalars() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_commitments_statement_to_scalars(&sequencer.account()).await?;
 
@@ -112,7 +111,7 @@ async fn test_valid_commitments_statement_to_scalars() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_settle_statement_to_scalars() -> Result<()> {
-    let sequencer = setup_statement_serde_test().await?;
+    let sequencer = setup_sequencer(TestConfig::StatementSerde).await?;
 
     assert_valid_settle_statement_to_scalars(&sequencer.account()).await?;
 

--- a/tests/tests/verifier.rs
+++ b/tests/tests/verifier.rs
@@ -3,18 +3,15 @@ use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
     utils::{
-        check_verification_job_status, global_teardown, random_felt,
-        singleprover_prove_dummy_circuit,
+        check_verification_job_status, global_teardown, random_felt, setup_sequencer,
+        singleprover_prove_dummy_circuit, TestConfig,
     },
-    verifier::utils::{
-        queue_verification_job, setup_verifier_test, step_verification, FUZZ_ROUNDS,
-        VERIFIER_ADDRESS,
-    },
+    verifier::utils::{queue_verification_job, step_verification, FUZZ_ROUNDS, VERIFIER_ADDRESS},
 };
 
 #[tokio::test]
 async fn test_full_verification_fuzz() -> Result<()> {
-    let sequencer = setup_verifier_test().await?;
+    let sequencer = setup_sequencer(TestConfig::Verifier).await?;
     let account = sequencer.account();
 
     for _ in 0..FUZZ_ROUNDS {
@@ -48,7 +45,7 @@ async fn test_full_verification_fuzz() -> Result<()> {
 
 #[tokio::test]
 async fn test_full_verification_invalid_proof() -> Result<()> {
-    let sequencer = setup_verifier_test().await?;
+    let sequencer = setup_sequencer(TestConfig::Verifier).await?;
     let account = sequencer.account();
 
     let (mut proof, witness_commitments) = singleprover_prove_dummy_circuit()?;


### PR DESCRIPTION
This PR introduces post-contract-initialization state dumping / loading functionality to the e2e tests, in order to speed up dev cycles.

Each e2e test suite gets a different state dump, and all test threads for that suite will either start by loading from the dumped state (if the `LOAD_STATE` env var is set), or will block on the first thread to initialize & dump state, then proceed by loading.

All e2e test suites (except for the darkpool, which is in an unstable state right now pending #68) pass.