### PR TITLE
renegade_contracts: nullifier_set, darkpool: add in-progress nullifier set

### DIFF
--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -552,6 +552,15 @@ mod Darkpool {
             proof: Proof,
             verification_job_id: felt252,
         ) {
+            // Assert that the `old_shares_nullifier` is not already spent
+            let nullifier_set = _get_nullifier_set(@self);
+            assert(
+                !nullifier_set.is_nullifier_used(statement.old_shares_nullifier),
+                'nullifier already used'
+            );
+            // Insert the `old_shares_nullifier` into the in-progress nullifier set
+            nullifier_set.mark_nullifier_in_progress(statement.old_shares_nullifier);
+
             let verifier = _get_verifier(@self, Circuit::ValidWalletUpdate(()));
 
             // Inject witness
@@ -658,6 +667,32 @@ mod Darkpool {
             valid_settle_proof: Proof,
             verification_job_ids: Array<felt252>,
         ) {
+            // Assert that the `original_shares_nullifier`s are not already spent
+            let nullifier_set = _get_nullifier_set(@self);
+            assert(
+                !nullifier_set
+                    .is_nullifier_used(
+                        party_0_payload.valid_reblind_statement.original_shares_nullifier
+                    ),
+                'nullifier already used'
+            );
+            assert(
+                !nullifier_set
+                    .is_nullifier_used(
+                        party_1_payload.valid_reblind_statement.original_shares_nullifier
+                    ),
+                'nullifier already used'
+            );
+            // Insert the `original_shares_nullifier`s into the in-progress nullifier set
+            nullifier_set
+                .mark_nullifier_in_progress(
+                    party_0_payload.valid_reblind_statement.original_shares_nullifier
+                );
+            nullifier_set
+                .mark_nullifier_in_progress(
+                    party_1_payload.valid_reblind_statement.original_shares_nullifier
+                );
+
             // Inject witnesses & queue verifications
             // TODO: This probably won't fit in a transaction... think about how to handle this
 

--- a/src/nullifier_set.cairo
+++ b/src/nullifier_set.cairo
@@ -4,7 +4,9 @@ use renegade_contracts::verifier::scalar::Scalar;
 #[starknet::interface]
 trait INullifierSet<TContractState> {
     fn is_nullifier_used(self: @TContractState, nullifier: Scalar) -> bool;
+    fn is_nullifier_in_progress(self: @TContractState, nullifier: Scalar) -> bool;
     fn mark_nullifier_used(ref self: TContractState, nullifier: Scalar);
+    fn mark_nullifier_in_progress(ref self: TContractState, nullifier: Scalar);
 }
 
 #[starknet::contract]
@@ -18,7 +20,10 @@ mod NullifierSet {
     #[storage]
     struct Storage {
         /// Mapping from nullifier to bool indicating if the nullifier is spent
-        nullifier_spent_set: LegacyMap::<Scalar, bool>
+        nullifier_spent_set: LegacyMap::<Scalar, bool>,
+        /// Mapping from nullifier to bool indicating if the nullifier is being
+        /// used in an in-progress verification job
+        nullifier_in_progress_set: LegacyMap::<Scalar, bool>,
     }
 
     // ----------
@@ -30,10 +35,16 @@ mod NullifierSet {
         nullifier: Scalar, 
     }
 
+    #[derive(Drop, PartialEq, starknet::Event)]
+    struct NullifierInProgress {
+        nullifier: Scalar, 
+    }
+
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
     enum Event {
-        NullifierSpent: NullifierSpent, 
+        NullifierSpent: NullifierSpent,
+        NullifierInProgress: NullifierInProgress,
     }
 
     // ----------------------------
@@ -52,18 +63,48 @@ mod NullifierSet {
             self.nullifier_spent_set.read(nullifier)
         }
 
+        /// Returns whether the given nullifier is being used in an in-progress verification job.
+        /// The default value in a `LegacyMap` is `0`, which is interpreted as `false`.
+        /// Parameters:
+        /// - `nullifier`: The nullifier value to check
+        /// Returns:
+        /// - A boolean indicating whether the nullifier is being used in an in-progress verification job
+        fn is_nullifier_in_progress(self: @ContractState, nullifier: Scalar) -> bool {
+            self.nullifier_in_progress_set.read(nullifier)
+        }
+
         /// Marks the given nullifier as used, asserts that it has not already been used
+        /// or is being used in an in-progress verification job
         /// Parameters:
         /// - `nullifier`: The nullifier value to mark as used
         fn mark_nullifier_used(ref self: ContractState, nullifier: Scalar) {
             // Assert that the nullifier hasn't already been used
             assert(!self.nullifier_spent_set.read(nullifier), 'nullifier already spent');
+            // Assert that the nullifier isn't being used in an in-progress verification job
+            assert(!self.nullifier_in_progress_set.read(nullifier), 'nullifier in progress');
 
             // Add to set
             self.nullifier_spent_set.write(nullifier, true);
 
             // Emit event
             self.emit(Event::NullifierSpent(NullifierSpent { nullifier }));
+        }
+
+        /// Marks the given nullifier as used, asserts that it has not already been used
+        /// or is being used in an in-progress verification job
+        /// Parameters:
+        /// - `nullifier`: The nullifier value to mark as in-progress
+        fn mark_nullifier_in_progress(ref self: ContractState, nullifier: Scalar) {
+            // Assert that the nullifier hasn't already been used
+            assert(!self.nullifier_spent_set.read(nullifier), 'nullifier already spent');
+            // Assert that the nullifier isn't being used in an in-progress verification job
+            assert(!self.nullifier_in_progress_set.read(nullifier), 'nullifier in progress');
+
+            // Add to set
+            self.nullifier_in_progress_set.write(nullifier, true);
+
+            // Emit event
+            self.emit(Event::NullifierInProgress(NullifierInProgress { nullifier }));
         }
     }
 }

--- a/src/nullifier_set.cairo
+++ b/src/nullifier_set.cairo
@@ -3,11 +3,11 @@ use renegade_contracts::verifier::scalar::Scalar;
 
 #[starknet::interface]
 trait INullifierSet<TContractState> {
-    fn is_nullifier_used(self: @TContractState, nullifier: Scalar) -> bool;
-    fn is_nullifier_in_progress(self: @TContractState, nullifier: Scalar) -> bool;
-    fn mark_nullifier_used(ref self: TContractState, nullifier: Scalar);
-    fn mark_nullifier_in_progress(ref self: TContractState, nullifier: Scalar);
-    fn mark_nullifier_not_in_progress(ref self: TContractState, nullifier: Scalar);
+    fn is_nullifier_spent(self: @TContractState, nullifier: Scalar) -> bool;
+    fn is_nullifier_in_use(self: @TContractState, nullifier: Scalar) -> bool;
+    fn mark_nullifier_spent(ref self: TContractState, nullifier: Scalar);
+    fn mark_nullifier_in_use(ref self: TContractState, nullifier: Scalar);
+    fn mark_nullifier_unused(ref self: TContractState, nullifier: Scalar);
 }
 
 #[starknet::contract]
@@ -24,7 +24,7 @@ mod NullifierSet {
         nullifier_spent_set: LegacyMap::<Scalar, bool>,
         /// Mapping from nullifier to bool indicating if the nullifier is being
         /// used in an in-progress verification job
-        nullifier_in_progress_set: LegacyMap::<Scalar, bool>,
+        nullifier_in_use_set: LegacyMap::<Scalar, bool>,
     }
 
     // ----------
@@ -37,7 +37,12 @@ mod NullifierSet {
     }
 
     #[derive(Drop, PartialEq, starknet::Event)]
-    struct NullifierInProgress {
+    struct NullifierInUse {
+        nullifier: Scalar, 
+    }
+
+    #[derive(Drop, PartialEq, starknet::Event)]
+    struct NullifierUnused {
         nullifier: Scalar, 
     }
 
@@ -45,7 +50,8 @@ mod NullifierSet {
     #[derive(Drop, PartialEq, starknet::Event)]
     enum Event {
         NullifierSpent: NullifierSpent,
-        NullifierInProgress: NullifierInProgress,
+        NullifierInUse: NullifierInUse,
+        NullifierUnused: NullifierUnused,
     }
 
     // ----------------------------
@@ -54,13 +60,13 @@ mod NullifierSet {
 
     #[external(v0)]
     impl INullifierSetImpl of super::INullifierSet<ContractState> {
-        /// Returns whether the given nullifier has already been used in a previous transaction.
+        /// Returns whether the given nullifier has already been spent in a previous transaction.
         /// The default value in a `LegacyMap` is `0`, which is interpreted as `false`.
         /// Parameters:
         /// - `nullifier`: The nullifier value to check
         /// Returns:
         /// - A boolean indicating whether the nullifier is spent already
-        fn is_nullifier_used(self: @ContractState, nullifier: Scalar) -> bool {
+        fn is_nullifier_spent(self: @ContractState, nullifier: Scalar) -> bool {
             self.nullifier_spent_set.read(nullifier)
         }
 
@@ -70,53 +76,56 @@ mod NullifierSet {
         /// - `nullifier`: The nullifier value to check
         /// Returns:
         /// - A boolean indicating whether the nullifier is being used in an in-progress verification job
-        fn is_nullifier_in_progress(self: @ContractState, nullifier: Scalar) -> bool {
-            self.nullifier_in_progress_set.read(nullifier)
+        fn is_nullifier_in_use(self: @ContractState, nullifier: Scalar) -> bool {
+            self.nullifier_in_use_set.read(nullifier)
         }
 
-        /// Marks the given nullifier as used and no longer in progress, asserts that it has not
+        /// Marks the given nullifier as spent and no longer in use, asserts that it has not
         /// already been used or is being used in an in-progress verification job
         /// Parameters:
         /// - `nullifier`: The nullifier value to mark as used
-        fn mark_nullifier_used(ref self: ContractState, nullifier: Scalar) {
-            // Assert that the nullifier hasn't already been used
+        fn mark_nullifier_spent(ref self: ContractState, nullifier: Scalar) {
+            // Assert that the nullifier hasn't already been spent
             assert(!self.nullifier_spent_set.read(nullifier), 'nullifier already spent');
 
             // Add to spent set
             self.nullifier_spent_set.write(nullifier, true);
-            // Remove from in-progress set
-            self.nullifier_in_progress_set.write(nullifier, false);
+            // Remove from in-use set
+            self.nullifier_in_use_set.write(nullifier, false);
 
             // Emit event
             self.emit(Event::NullifierSpent(NullifierSpent { nullifier }));
         }
 
-        /// Marks the given nullifier as used, asserts that it has not already been used
+        /// Marks the given nullifier as in use, asserts that it has not already been spent
         /// or is being used in an in-progress verification job
         /// Parameters:
-        /// - `nullifier`: The nullifier value to mark as in progress
-        fn mark_nullifier_in_progress(ref self: ContractState, nullifier: Scalar) {
+        /// - `nullifier`: The nullifier value to mark as in use
+        fn mark_nullifier_in_use(ref self: ContractState, nullifier: Scalar) {
             // Assert that the nullifier hasn't already been used
             assert(!self.nullifier_spent_set.read(nullifier), 'nullifier already spent');
             // Assert that the nullifier isn't being used in an in-progress verification job
-            assert(!self.nullifier_in_progress_set.read(nullifier), 'nullifier in progress');
+            assert(!self.nullifier_in_use_set.read(nullifier), 'nullifier in use');
 
             // Add to set
-            self.nullifier_in_progress_set.write(nullifier, true);
+            self.nullifier_in_use_set.write(nullifier, true);
 
             // Emit event
-            self.emit(Event::NullifierInProgress(NullifierInProgress { nullifier }));
+            self.emit(Event::NullifierInUse(NullifierInUse { nullifier }));
         }
 
-        /// Marks the given nullifier as no longer in progress.
+        /// Marks the given nullifier as no longer in use
         /// Parameters:
-        /// - `nullifier`: The nullifier value to mark as not in progress
-        fn mark_nullifier_not_in_progress(ref self: ContractState, nullifier: Scalar) {
-            // Assert that the nullifier hasn't already been used
+        /// - `nullifier`: The nullifier value to mark as unused
+        fn mark_nullifier_unused(ref self: ContractState, nullifier: Scalar) {
+            // Assert that the nullifier hasn't already been spent
             assert(!self.nullifier_spent_set.read(nullifier), 'nullifier already spent');
 
             // Remove from set
-            self.nullifier_in_progress_set.write(nullifier, false);
+            self.nullifier_in_use_set.write(nullifier, false);
+
+            // Emit event
+            self.emit(Event::NullifierUnused(NullifierUnused { nullifier }));
         }
     }
 }

--- a/src/testing/test_contracts/dummy_upgrade_target.cairo
+++ b/src/testing/test_contracts/dummy_upgrade_target.cairo
@@ -9,7 +9,8 @@ trait IUpgradeTarget<TContractState> {
         self: @TContractState, wallet_blinder_share: Scalar
     ) -> felt252;
     fn get_root(self: @TContractState) -> Scalar;
-    fn is_nullifier_used(self: @TContractState, nullifier: Scalar) -> bool;
+    fn is_nullifier_spent(self: @TContractState, nullifier: Scalar) -> bool;
+    fn is_nullifier_in_use(self: @TContractState, nullifier: Scalar) -> bool;
     fn check_verification_job_status(
         self: @TContractState, verification_job_id: felt252
     ) -> Option<bool>;
@@ -39,7 +40,11 @@ mod DummyUpgradeTarget {
             DUMMY_ROOT_INNER.into()
         }
 
-        fn is_nullifier_used(self: @ContractState, nullifier: Scalar) -> bool {
+        fn is_nullifier_spent(self: @ContractState, nullifier: Scalar) -> bool {
+            true
+        }
+
+        fn is_nullifier_in_use(self: @ContractState, nullifier: Scalar) -> bool {
             true
         }
 

--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -11,18 +11,6 @@ use renegade_contracts::verifier::types::{
 const DUMMY_ROOT_INNER: felt252 = 'DUMMY_ROOT';
 const DUMMY_WALLET_BLINDER_TX: felt252 = 'DUMMY_WALLET_BLINDER_TX';
 
-fn serialized_element<T, impl TSerde: Serde<T>, impl TDestruct: Destruct<T>>(
-    value: T
-) -> Span<felt252> {
-    let mut arr = Default::default();
-    value.serialize(ref arr);
-    arr.span()
-}
-
-fn single_deserialize<T, impl TSerde: Serde<T>>(ref data: Span<felt252>) -> T {
-    Serde::deserialize(ref data).expect('missing data')
-}
-
 fn get_dummy_proof() -> Proof {
     let basepoint = ec_point_from_x(1).unwrap();
 

--- a/src/testing/tests/darkpool_tests.cairo
+++ b/src/testing/tests/darkpool_tests.cairo
@@ -80,10 +80,10 @@ fn test_upgrade_nullifier_set() {
     let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
 
     darkpool.upgrade_nullifier_set(DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap());
-    assert(darkpool.is_nullifier_used(0.into()), 'upgrade target wrong result');
+    assert(!darkpool.is_nullifier_available(0.into()), 'upgrade target wrong result');
 
     darkpool.upgrade_nullifier_set(NullifierSet::TEST_CLASS_HASH.try_into().unwrap());
-    assert(!darkpool.is_nullifier_used(0.into()), 'original target wrong result');
+    assert(darkpool.is_nullifier_available(0.into()), 'original target wrong result');
 }
 
 #[test]

--- a/src/testing/tests/nullifier_set_tests.cairo
+++ b/src/testing/tests/nullifier_set_tests.cairo
@@ -1,42 +1,70 @@
-use renegade_contracts::nullifier_set::NullifierSet;
 use traits::Into;
 use option::OptionTrait;
 use array::ArrayTrait;
 
-use renegade_contracts::testing::test_utils;
+use renegade_contracts::nullifier_set::{NullifierSet, INullifierSet};
 
-
-fn is_nullifier_used_helper(nullifier: felt252) -> bool {
-    let mut nullifier_used = NullifierSet::__external::is_nullifier_used(
-        test_utils::serialized_element(nullifier)
-    );
-    test_utils::single_deserialize(ref nullifier_used)
-}
 
 #[test]
 #[available_gas(300000)]
 fn test_valid_nullifier_basic() {
-    let nullifier = 1;
+    let mut nullifier_set = NullifierSet::contract_state_for_testing();
+
+    let nullifier = 1.into();
 
     // Check that nullifier is initially unused
-    assert(!is_nullifier_used_helper(nullifier), 'nullifier should be unused');
+    assert(!nullifier_set.is_nullifier_used(nullifier), 'nullifier should be unused');
 
     // Mark nullifier as used
-    NullifierSet::__external::mark_nullifier_used(test_utils::serialized_element(nullifier));
+    nullifier_set.mark_nullifier_used(nullifier);
 
     // Check that nullifier is now used
-    assert(is_nullifier_used_helper(nullifier), 'nullifier should be used');
+    assert(nullifier_set.is_nullifier_used(nullifier), 'nullifier should be used');
+}
+
+#[test]
+#[available_gas(300000)]
+fn test_valid_nullifier_in_progress_basic() {
+    let mut nullifier_set = NullifierSet::contract_state_for_testing();
+
+    let nullifier = 1.into();
+
+    // Check that nullifier is initially not in progress
+    assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier already in progress');
+
+    // Mark nullifier as used
+    nullifier_set.mark_nullifier_in_progress(nullifier);
+
+    // Check that nullifier is now used
+    assert(nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier not in progress');
 }
 
 #[test]
 #[available_gas(300000)]
 #[should_panic]
 fn test_invalid_nullifier_basic() {
-    let nullifier = 1;
+    let mut nullifier_set = NullifierSet::contract_state_for_testing();
+
+    let nullifier = 1.into();
 
     // Mark nullifier as used
-    NullifierSet::__external::mark_nullifier_used(test_utils::serialized_element(nullifier));
+    nullifier_set.mark_nullifier_used(nullifier);
 
     // Try marking nullifier as used (again)
-    NullifierSet::__external::mark_nullifier_used(test_utils::serialized_element(nullifier));
+    nullifier_set.mark_nullifier_used(nullifier);
+}
+
+#[test]
+#[available_gas(300000)]
+#[should_panic]
+fn test_invalid_nullifier_in_progress_basic() {
+    let mut nullifier_set = NullifierSet::contract_state_for_testing();
+
+    let nullifier = 1.into();
+
+    // Mark nullifier as used
+    nullifier_set.mark_nullifier_in_progress(nullifier);
+
+    // Try marking nullifier as used (again)
+    nullifier_set.mark_nullifier_in_progress(nullifier);
 }

--- a/src/testing/tests/nullifier_set_tests.cairo
+++ b/src/testing/tests/nullifier_set_tests.cairo
@@ -32,10 +32,10 @@ fn test_valid_nullifier_in_progress_basic() {
     // Check that nullifier is initially not in progress
     assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier already in progress');
 
-    // Mark nullifier as used
+    // Mark nullifier as in progress
     nullifier_set.mark_nullifier_in_progress(nullifier);
 
-    // Check that nullifier is now used
+    // Check that nullifier is now in progress
     assert(nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier not in progress');
 }
 
@@ -62,9 +62,35 @@ fn test_invalid_nullifier_in_progress_basic() {
 
     let nullifier = 1.into();
 
-    // Mark nullifier as used
+    // Mark nullifier as in progress
     nullifier_set.mark_nullifier_in_progress(nullifier);
 
-    // Try marking nullifier as used (again)
+    // Try marking nullifier as in progress (again)
     nullifier_set.mark_nullifier_in_progress(nullifier);
+}
+
+#[test]
+#[available_gas(3000000)]
+fn test_valid_nullifier_in_progress_to_spent_basic() {
+    let mut nullifier_set = NullifierSet::contract_state_for_testing();
+
+    let nullifier = 1.into();
+
+    // Check that nullifier is initially not spent or in progress
+    assert(!nullifier_set.is_nullifier_used(nullifier), 'nullifier already spent');
+    assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier already in progress');
+
+    // Mark nullifier as in progress
+    nullifier_set.mark_nullifier_in_progress(nullifier);
+
+    // Check that nullifier is in progress, and not spent
+    assert(nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier not in progress');
+    assert(!nullifier_set.is_nullifier_used(nullifier), 'nullifier already spent');
+
+    // Mark nullifier as spent
+    nullifier_set.mark_nullifier_used(nullifier);
+
+    // Check that nullifier is spent, and not in progress
+    assert(nullifier_set.is_nullifier_used(nullifier), 'nullifier not spent');
+    assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier still in progress');
 }

--- a/src/testing/tests/nullifier_set_tests.cairo
+++ b/src/testing/tests/nullifier_set_tests.cairo
@@ -12,14 +12,14 @@ fn test_valid_nullifier_basic() {
 
     let nullifier = 1.into();
 
-    // Check that nullifier is initially unused
-    assert(!nullifier_set.is_nullifier_used(nullifier), 'nullifier should be unused');
+    // Check that nullifier is initially unspent
+    assert(!nullifier_set.is_nullifier_spent(nullifier), 'nullifier should be unspent');
 
-    // Mark nullifier as used
-    nullifier_set.mark_nullifier_used(nullifier);
+    // Mark nullifier as spent
+    nullifier_set.mark_nullifier_spent(nullifier);
 
-    // Check that nullifier is now used
-    assert(nullifier_set.is_nullifier_used(nullifier), 'nullifier should be used');
+    // Check that nullifier is now spent
+    assert(nullifier_set.is_nullifier_spent(nullifier), 'nullifier should be spent');
 }
 
 #[test]
@@ -29,14 +29,14 @@ fn test_valid_nullifier_in_progress_basic() {
 
     let nullifier = 1.into();
 
-    // Check that nullifier is initially not in progress
-    assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier already in progress');
+    // Check that nullifier is initially not in use
+    assert(!nullifier_set.is_nullifier_in_use(nullifier), 'nullifier already in use');
 
-    // Mark nullifier as in progress
-    nullifier_set.mark_nullifier_in_progress(nullifier);
+    // Mark nullifier as in use
+    nullifier_set.mark_nullifier_in_use(nullifier);
 
-    // Check that nullifier is now in progress
-    assert(nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier not in progress');
+    // Check that nullifier is now in use
+    assert(nullifier_set.is_nullifier_in_use(nullifier), 'nullifier not in use');
 }
 
 #[test]
@@ -47,11 +47,11 @@ fn test_invalid_nullifier_basic() {
 
     let nullifier = 1.into();
 
-    // Mark nullifier as used
-    nullifier_set.mark_nullifier_used(nullifier);
+    // Mark nullifier as spent
+    nullifier_set.mark_nullifier_spent(nullifier);
 
-    // Try marking nullifier as used (again)
-    nullifier_set.mark_nullifier_used(nullifier);
+    // Try marking nullifier as spent (again)
+    nullifier_set.mark_nullifier_spent(nullifier);
 }
 
 #[test]
@@ -62,11 +62,11 @@ fn test_invalid_nullifier_in_progress_basic() {
 
     let nullifier = 1.into();
 
-    // Mark nullifier as in progress
-    nullifier_set.mark_nullifier_in_progress(nullifier);
+    // Mark nullifier as in use
+    nullifier_set.mark_nullifier_in_use(nullifier);
 
-    // Try marking nullifier as in progress (again)
-    nullifier_set.mark_nullifier_in_progress(nullifier);
+    // Try marking nullifier as in use (again)
+    nullifier_set.mark_nullifier_in_use(nullifier);
 }
 
 #[test]
@@ -76,21 +76,21 @@ fn test_valid_nullifier_in_progress_to_spent_basic() {
 
     let nullifier = 1.into();
 
-    // Check that nullifier is initially not spent or in progress
-    assert(!nullifier_set.is_nullifier_used(nullifier), 'nullifier already spent');
-    assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier already in progress');
+    // Check that nullifier is initially not spent or in use
+    assert(!nullifier_set.is_nullifier_spent(nullifier), 'nullifier already spent');
+    assert(!nullifier_set.is_nullifier_in_use(nullifier), 'nullifier already in use');
 
-    // Mark nullifier as in progress
-    nullifier_set.mark_nullifier_in_progress(nullifier);
+    // Mark nullifier as in use
+    nullifier_set.mark_nullifier_in_use(nullifier);
 
-    // Check that nullifier is in progress, and not spent
-    assert(nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier not in progress');
-    assert(!nullifier_set.is_nullifier_used(nullifier), 'nullifier already spent');
+    // Check that nullifier is in use, and not spent
+    assert(nullifier_set.is_nullifier_in_use(nullifier), 'nullifier not in use');
+    assert(!nullifier_set.is_nullifier_spent(nullifier), 'nullifier already spent');
 
     // Mark nullifier as spent
-    nullifier_set.mark_nullifier_used(nullifier);
+    nullifier_set.mark_nullifier_spent(nullifier);
 
-    // Check that nullifier is spent, and not in progress
-    assert(nullifier_set.is_nullifier_used(nullifier), 'nullifier not spent');
-    assert(!nullifier_set.is_nullifier_in_progress(nullifier), 'nullifier still in progress');
+    // Check that nullifier is spent, and not in use
+    assert(nullifier_set.is_nullifier_spent(nullifier), 'nullifier not spent');
+    assert(!nullifier_set.is_nullifier_in_use(nullifier), 'nullifier still in use');
 }

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -58,6 +58,7 @@ pub const TRANSFER_AMOUNT: u64 = 100;
 
 const INITIALIZE_VERIFIER_FN_NAME: &str = "initialize_verifier";
 const GET_WALLET_BLINDER_TRANSACTION_FN_NAME: &str = "get_wallet_blinder_transaction";
+const IS_NULLIFIER_AVAILABLE_FN_NAME: &str = "is_nullifier_available";
 const CHECK_VERIFICATION_JOB_STATUS_FN_NAME: &str = "check_verification_job_status";
 const NEW_WALLET_FN_NAME: &str = "new_wallet";
 const POLL_NEW_WALLET_FN_NAME: &str = "poll_new_wallet";
@@ -366,6 +367,17 @@ pub async fn get_wallet_blinder_transaction(
     )
     .await
     .map(|r| r[0])
+}
+
+pub async fn is_nullifier_available(account: &ScriptAccount, nullifier: Scalar) -> Result<bool> {
+    call_contract(
+        account,
+        *DARKPOOL_ADDRESS.get().unwrap(),
+        IS_NULLIFIER_AVAILABLE_FN_NAME,
+        vec![scalar_to_felt(&nullifier)],
+    )
+    .await
+    .map(|r| r[0] == FieldElement::ONE)
 }
 
 pub async fn check_verification_job_status(

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -10,13 +10,14 @@ use std::env;
 use tracing::debug;
 
 use crate::utils::{
-    get_contract_address_from_artifact, global_setup, invoke_contract, scalar_to_felt,
-    ARTIFACTS_PATH_ENV_VAR,
+    call_contract, get_contract_address_from_artifact, global_setup, invoke_contract,
+    scalar_to_felt, ARTIFACTS_PATH_ENV_VAR,
 };
 
 pub const FUZZ_ROUNDS: usize = 100;
 
-const MARK_NULLIFIER_USED_FN_NAME: &str = "mark_nullifier_used";
+pub const IS_NULLIFIER_SPENT_FN_NAME: &str = "is_nullifier_spent";
+const MARK_NULLIFIER_SPENT_FN_NAME: &str = "mark_nullifier_spent";
 
 pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -55,12 +56,28 @@ pub fn init_nullifier_set_test_statics() -> Result<()> {
 // | CONTRACT INTERACTION HELPERS |
 // --------------------------------
 
-pub async fn mark_nullifier_used(account: &ScriptAccount, nullifier: Scalar) -> Result<()> {
+pub async fn is_nullifier_spent(
+    account: &ScriptAccount,
+    contract_address: FieldElement,
+    nullifier: Scalar,
+) -> Result<bool> {
+    let nullifier_felt = scalar_to_felt(&nullifier);
+    call_contract(
+        account,
+        contract_address,
+        IS_NULLIFIER_SPENT_FN_NAME,
+        vec![nullifier_felt],
+    )
+    .await
+    .map(|r| r[0] == FieldElement::ONE)
+}
+
+pub async fn mark_nullifier_spent(account: &ScriptAccount, nullifier: Scalar) -> Result<()> {
     let nullifier_felt = scalar_to_felt(&nullifier);
     invoke_contract(
         account,
         *NULLIFIER_SET_ADDRESS.get().unwrap(),
-        MARK_NULLIFIER_USED_FN_NAME,
+        MARK_NULLIFIER_SPENT_FN_NAME,
         vec![nullifier_felt],
     )
     .await

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -298,7 +298,6 @@ fn init_test_statics(test_config: &TestConfig, sequencer: &TestSequencer) -> Res
 // | CONTRACT INTERACTION HELPERS |
 // --------------------------------
 
-pub const IS_NULLIFIER_USED_FN_NAME: &str = "is_nullifier_used";
 pub const GET_ROOT_FN_NAME: &str = "get_root";
 
 pub async fn call_contract(
@@ -344,22 +343,6 @@ pub async fn get_root(account: &ScriptAccount, contract_address: FieldElement) -
     call_contract(account, contract_address, GET_ROOT_FN_NAME, vec![])
         .await
         .map(|r| felt_to_scalar(&r[0]))
-}
-
-pub async fn is_nullifier_used(
-    account: &ScriptAccount,
-    contract_address: FieldElement,
-    nullifier: Scalar,
-) -> Result<bool> {
-    let nullifier_felt = scalar_to_felt(&nullifier);
-    call_contract(
-        account,
-        contract_address,
-        IS_NULLIFIER_USED_FN_NAME,
-        vec![nullifier_felt],
-    )
-    .await
-    .map(|r| r[0] == FieldElement::ONE)
 }
 
 // ----------------

--- a/tests/tests/nullifier_set.rs
+++ b/tests/tests/nullifier_set.rs
@@ -2,8 +2,10 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
-    nullifier_set::utils::{mark_nullifier_used, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS},
-    utils::{global_teardown, is_nullifier_used, setup_sequencer, TestConfig},
+    nullifier_set::utils::{
+        is_nullifier_spent, mark_nullifier_spent, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS,
+    },
+    utils::{global_teardown, setup_sequencer, TestConfig},
 };
 
 #[tokio::test]
@@ -14,11 +16,11 @@ async fn test_nullifier_set_fuzz() -> Result<()> {
     for _ in 0..FUZZ_ROUNDS {
         let nullifier = Scalar::random(&mut thread_rng());
         assert!(
-            !is_nullifier_used(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier).await?
+            !is_nullifier_spent(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier).await?
         );
-        mark_nullifier_used(&account, nullifier).await?;
+        mark_nullifier_spent(&account, nullifier).await?;
         assert!(
-            is_nullifier_used(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier).await?
+            is_nullifier_spent(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier).await?
         );
     }
 


### PR DESCRIPTION
This PR introduces an "in-progress nullifiers" set to the `NullifierSet` contract, which is used to track nullifiers that are currently in use in a verification job (preventing, for example, races of two different matches being settled simultaneously).

This PR also adds a couple basic unit tests for the new functionality, but tests in the e2e suite ensuring that this prevents a double `process_match` or `update_wallet` are left for the next PR.