### PR TITLE
tests: darkpool, nullifier_set: in-progress nullifier set e2e tests

### DIFF
--- a/src/testing/tests/nullifier_set_tests.cairo
+++ b/src/testing/tests/nullifier_set_tests.cairo
@@ -24,7 +24,7 @@ fn test_valid_nullifier_basic() {
 
 #[test]
 #[available_gas(300000)]
-fn test_valid_nullifier_in_progress_basic() {
+fn test_valid_nullifier_in_use_basic() {
     let mut nullifier_set = NullifierSet::contract_state_for_testing();
 
     let nullifier = 1.into();
@@ -57,7 +57,7 @@ fn test_invalid_nullifier_basic() {
 #[test]
 #[available_gas(300000)]
 #[should_panic]
-fn test_invalid_nullifier_in_progress_basic() {
+fn test_invalid_nullifier_in_use_basic() {
     let mut nullifier_set = NullifierSet::contract_state_for_testing();
 
     let nullifier = 1.into();

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -16,8 +16,8 @@ use crate::utils::{
 
 pub const FUZZ_ROUNDS: usize = 100;
 
-pub const IS_NULLIFIER_SPENT_FN_NAME: &str = "is_nullifier_spent";
-const MARK_NULLIFIER_SPENT_FN_NAME: &str = "mark_nullifier_spent";
+const MARK_NULLIFIER_USED_FN_NAME: &str = "mark_nullifier_used";
+const MARK_NULLIFIER_IN_PROGRESS_FN_NAME: &str = "mark_nullifier_in_progress";
 
 pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -78,6 +78,18 @@ pub async fn mark_nullifier_spent(account: &ScriptAccount, nullifier: Scalar) ->
         account,
         *NULLIFIER_SET_ADDRESS.get().unwrap(),
         MARK_NULLIFIER_SPENT_FN_NAME,
+        vec![nullifier_felt],
+    )
+    .await
+    .map(|_| ())
+}
+
+pub async fn mark_nullifier_in_progress(account: &ScriptAccount, nullifier: Scalar) -> Result<()> {
+    let nullifier_felt = scalar_to_felt(&nullifier);
+    invoke_contract(
+        account,
+        *NULLIFIER_SET_ADDRESS.get().unwrap(),
+        MARK_NULLIFIER_IN_PROGRESS_FN_NAME,
         vec![nullifier_felt],
     )
     .await

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -16,8 +16,10 @@ use crate::utils::{
 
 pub const FUZZ_ROUNDS: usize = 100;
 
-const MARK_NULLIFIER_USED_FN_NAME: &str = "mark_nullifier_used";
-const MARK_NULLIFIER_IN_PROGRESS_FN_NAME: &str = "mark_nullifier_in_progress";
+const IS_NULLIFIER_SPENT_FN_NAME: &str = "is_nullifier_spent";
+const IS_NULLIFIER_IN_USE_FN_NAME: &str = "is_nullifier_in_use";
+const MARK_NULLIFIER_SPENT_FN_NAME: &str = "mark_nullifier_spent";
+const MARK_NULLIFIER_IN_USE_FN_NAME: &str = "mark_nullifier_in_use";
 
 pub static NULLIFIER_SET_ADDRESS: OnceCell<FieldElement> = OnceCell::new();
 
@@ -72,6 +74,22 @@ pub async fn is_nullifier_spent(
     .map(|r| r[0] == FieldElement::ONE)
 }
 
+pub async fn is_nullifier_in_use(
+    account: &ScriptAccount,
+    contract_address: FieldElement,
+    nullifier: Scalar,
+) -> Result<bool> {
+    let nullifier_felt = scalar_to_felt(&nullifier);
+    call_contract(
+        account,
+        contract_address,
+        IS_NULLIFIER_IN_USE_FN_NAME,
+        vec![nullifier_felt],
+    )
+    .await
+    .map(|r| r[0] == FieldElement::ONE)
+}
+
 pub async fn mark_nullifier_spent(account: &ScriptAccount, nullifier: Scalar) -> Result<()> {
     let nullifier_felt = scalar_to_felt(&nullifier);
     invoke_contract(
@@ -84,12 +102,12 @@ pub async fn mark_nullifier_spent(account: &ScriptAccount, nullifier: Scalar) ->
     .map(|_| ())
 }
 
-pub async fn mark_nullifier_in_progress(account: &ScriptAccount, nullifier: Scalar) -> Result<()> {
+pub async fn mark_nullifier_in_use(account: &ScriptAccount, nullifier: Scalar) -> Result<()> {
     let nullifier_felt = scalar_to_felt(&nullifier);
     invoke_contract(
         account,
         *NULLIFIER_SET_ADDRESS.get().unwrap(),
-        MARK_NULLIFIER_IN_PROGRESS_FN_NAME,
+        MARK_NULLIFIER_IN_USE_FN_NAME,
         vec![nullifier_felt],
     )
     .await

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -298,6 +298,8 @@ fn init_test_statics(test_config: &TestConfig, sequencer: &TestSequencer) -> Res
 // | CONTRACT INTERACTION HELPERS |
 // --------------------------------
 
+pub const IS_NULLIFIER_USED_FN_NAME: &str = "is_nullifier_used";
+pub const IS_NULLIFIER_IN_PROGRESS_FN_NAME: &str = "is_nullifier_in_progress";
 pub const GET_ROOT_FN_NAME: &str = "get_root";
 
 pub async fn call_contract(
@@ -343,6 +345,38 @@ pub async fn get_root(account: &ScriptAccount, contract_address: FieldElement) -
     call_contract(account, contract_address, GET_ROOT_FN_NAME, vec![])
         .await
         .map(|r| felt_to_scalar(&r[0]))
+}
+
+pub async fn is_nullifier_used(
+    account: &ScriptAccount,
+    contract_address: FieldElement,
+    nullifier: Scalar,
+) -> Result<bool> {
+    let nullifier_felt = scalar_to_felt(&nullifier);
+    call_contract(
+        account,
+        contract_address,
+        IS_NULLIFIER_USED_FN_NAME,
+        vec![nullifier_felt],
+    )
+    .await
+    .map(|r| r[0] == FieldElement::ONE)
+}
+
+pub async fn is_nullifier_in_progress(
+    account: &ScriptAccount,
+    contract_address: FieldElement,
+    nullifier: Scalar,
+) -> Result<bool> {
+    let nullifier_felt = scalar_to_felt(&nullifier);
+    call_contract(
+        account,
+        contract_address,
+        IS_NULLIFIER_IN_PROGRESS_FN_NAME,
+        vec![nullifier_felt],
+    )
+    .await
+    .map(|r| r[0] == FieldElement::ONE)
 }
 
 // ----------------

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -298,8 +298,6 @@ fn init_test_statics(test_config: &TestConfig, sequencer: &TestSequencer) -> Res
 // | CONTRACT INTERACTION HELPERS |
 // --------------------------------
 
-pub const IS_NULLIFIER_USED_FN_NAME: &str = "is_nullifier_used";
-pub const IS_NULLIFIER_IN_PROGRESS_FN_NAME: &str = "is_nullifier_in_progress";
 pub const GET_ROOT_FN_NAME: &str = "get_root";
 
 pub async fn call_contract(
@@ -345,38 +343,6 @@ pub async fn get_root(account: &ScriptAccount, contract_address: FieldElement) -
     call_contract(account, contract_address, GET_ROOT_FN_NAME, vec![])
         .await
         .map(|r| felt_to_scalar(&r[0]))
-}
-
-pub async fn is_nullifier_used(
-    account: &ScriptAccount,
-    contract_address: FieldElement,
-    nullifier: Scalar,
-) -> Result<bool> {
-    let nullifier_felt = scalar_to_felt(&nullifier);
-    call_contract(
-        account,
-        contract_address,
-        IS_NULLIFIER_USED_FN_NAME,
-        vec![nullifier_felt],
-    )
-    .await
-    .map(|r| r[0] == FieldElement::ONE)
-}
-
-pub async fn is_nullifier_in_progress(
-    account: &ScriptAccount,
-    contract_address: FieldElement,
-    nullifier: Scalar,
-) -> Result<bool> {
-    let nullifier_felt = scalar_to_felt(&nullifier);
-    call_contract(
-        account,
-        contract_address,
-        IS_NULLIFIER_IN_PROGRESS_FN_NAME,
-        vec![nullifier_felt],
-    )
-    .await
-    .map(|r| r[0] == FieldElement::ONE)
 }
 
 // ----------------

--- a/tests/tests/nullifier_set.rs
+++ b/tests/tests/nullifier_set.rs
@@ -3,11 +3,10 @@ use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
     nullifier_set::utils::{
-        mark_nullifier_in_progress, mark_nullifier_used, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS,
+        is_nullifier_in_use, is_nullifier_spent, mark_nullifier_in_use, mark_nullifier_spent,
+        FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS,
     },
-    utils::{
-        global_teardown, is_nullifier_in_progress, is_nullifier_used, setup_sequencer, TestConfig,
-    },
+    utils::{global_teardown, setup_sequencer, TestConfig},
 };
 
 #[tokio::test]
@@ -32,20 +31,19 @@ async fn test_nullifier_set_fuzz() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_in_progress_nullifier_set_fuzz() -> Result<()> {
+async fn test_in_use_nullifier_set_fuzz() -> Result<()> {
     let sequencer = setup_sequencer(TestConfig::NullifierSet).await?;
     let account = sequencer.account();
 
     for _ in 0..FUZZ_ROUNDS {
         let nullifier = Scalar::random(&mut thread_rng());
         assert!(
-            !is_nullifier_in_progress(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier)
+            !is_nullifier_in_use(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier)
                 .await?
         );
-        mark_nullifier_in_progress(&account, nullifier).await?;
+        mark_nullifier_in_use(&account, nullifier).await?;
         assert!(
-            is_nullifier_in_progress(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier)
-                .await?
+            is_nullifier_in_use(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier).await?
         );
     }
 

--- a/tests/tests/nullifier_set.rs
+++ b/tests/tests/nullifier_set.rs
@@ -3,9 +3,11 @@ use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use tests::{
     nullifier_set::utils::{
-        is_nullifier_spent, mark_nullifier_spent, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS,
+        mark_nullifier_in_progress, mark_nullifier_used, FUZZ_ROUNDS, NULLIFIER_SET_ADDRESS,
     },
-    utils::{global_teardown, setup_sequencer, TestConfig},
+    utils::{
+        global_teardown, is_nullifier_in_progress, is_nullifier_used, setup_sequencer, TestConfig,
+    },
 };
 
 #[tokio::test]
@@ -21,6 +23,29 @@ async fn test_nullifier_set_fuzz() -> Result<()> {
         mark_nullifier_spent(&account, nullifier).await?;
         assert!(
             is_nullifier_spent(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier).await?
+        );
+    }
+
+    global_teardown(sequencer);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_in_progress_nullifier_set_fuzz() -> Result<()> {
+    let sequencer = setup_sequencer(TestConfig::NullifierSet).await?;
+    let account = sequencer.account();
+
+    for _ in 0..FUZZ_ROUNDS {
+        let nullifier = Scalar::random(&mut thread_rng());
+        assert!(
+            !is_nullifier_in_progress(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier)
+                .await?
+        );
+        mark_nullifier_in_progress(&account, nullifier).await?;
+        assert!(
+            is_nullifier_in_progress(&account, *NULLIFIER_SET_ADDRESS.get().unwrap(), nullifier)
+                .await?
         );
     }
 


### PR DESCRIPTION
This PR introduces tests for the in-progress nullifier set, including a basic fuzz test, and tests asserting that double-calling `update_wallet` and `process_match` with the same nullifiers will fail. The new tests pass.