### PR TITLE
renegade_contracts: darkpool: `new_wallet` total wallet shares commitment

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -71,9 +71,10 @@ struct MatchPayload {
 // | CALLBACK ELEMENT TYPES |
 // --------------------------
 
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Clone)]
 struct NewWalletCallbackElems {
     wallet_blinder_share: Scalar,
+    public_wallet_shares: Array<Scalar>,
     private_shares_commitment: Scalar,
     tx_hash: felt252,
 }

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -1,5 +1,6 @@
 use circuit_types::{
     balance::Balance,
+    native_helpers::compute_wallet_commitment_from_private,
     order::Order,
     transfers::{ExternalTransfer, ExternalTransferDirection},
 };
@@ -52,11 +53,11 @@ async fn test_new_wallet_root() -> Result<()> {
     let args = get_dummy_new_wallet_args()?;
     poll_new_wallet_to_completion(&account, &args).await?;
 
-    insert_scalar_to_ark_merkle_tree(
-        &args.statement.private_shares_commitment,
-        &mut ark_merkle_tree,
-        0,
-    )?;
+    let wallet_commitment = compute_wallet_commitment_from_private(
+        args.statement.public_wallet_shares,
+        args.statement.private_shares_commitment,
+    );
+    insert_scalar_to_ark_merkle_tree(&wallet_commitment, &mut ark_merkle_tree, 0)?;
 
     assert_roots_equal(&account, *DARKPOOL_ADDRESS.get().unwrap(), &ark_merkle_tree).await?;
 


### PR DESCRIPTION
This PR updates the implementation of `new_wallet` to compute the commitment to the full set of wallet secret shares in the same manner as is done in the circuits, and insert this into the merkle tree.

The `test_new_wallet_root` test has been updated to also compute the total commitment (using the existing helper function from the relayer repo), and passes.