### PR TITLE
renegade_contracts: darkpool: `update_wallet` total shares commitment

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -83,6 +83,7 @@ struct NewWalletCallbackElems {
 struct UpdateWalletCallbackElems {
     wallet_blinder_share: Scalar,
     old_shares_nullifier: Scalar,
+    new_public_shares: Array<Scalar>,
     new_private_shares_commitment: Scalar,
     external_transfer: Option<ExternalTransfer>,
     tx_hash: felt252,

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -79,11 +79,11 @@ async fn test_update_wallet_root() -> Result<()> {
     let args = get_dummy_update_wallet_args(old_wallet, new_wallet, external_transfer)?;
     poll_update_wallet_to_completion(&account, &args).await?;
 
-    insert_scalar_to_ark_merkle_tree(
-        &args.statement.new_private_shares_commitment,
-        &mut ark_merkle_tree,
-        0,
-    )?;
+    let wallet_commitment = compute_wallet_commitment_from_private(
+        args.statement.new_public_shares,
+        args.statement.new_private_shares_commitment,
+    );
+    insert_scalar_to_ark_merkle_tree(&wallet_commitment, &mut ark_merkle_tree, 0)?;
 
     assert_roots_equal(&account, *DARKPOOL_ADDRESS.get().unwrap(), &ark_merkle_tree).await?;
 


### PR DESCRIPTION
This PR updates the `update_wallet` callback logic to compute the commitment to the total set of wallet shares in the same manner as the circuit, and updates the `test_update_wallet_root` test to do the same (it passes)