### PR TITLE
renegade_contracts: darkpool: ensure that historical merkle roots are used

### DIFF
--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -563,6 +563,10 @@ mod Darkpool {
             proof: Proof,
             verification_job_id: felt252,
         ) {
+            // Assert that the merkle root for which inclusion is proven in `VALID WALLET UPDATE`
+            // is a valid historical root
+            assert(_get_merkle_tree(@self).root_in_history(statement.merkle_root), 'invalid statement merkle root');
+
             // Mark the `old_shares_nullifier` as in use
             _get_nullifier_set(@self).mark_nullifier_in_use(statement.old_shares_nullifier);
 

--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -565,7 +565,10 @@ mod Darkpool {
         ) {
             // Assert that the merkle root for which inclusion is proven in `VALID WALLET UPDATE`
             // is a valid historical root
-            assert(_get_merkle_tree(@self).root_in_history(statement.merkle_root), 'invalid statement merkle root');
+            assert(
+                _get_merkle_tree(@self).root_in_history(statement.merkle_root),
+                'invalid statement merkle root'
+            );
 
             // Mark the `old_shares_nullifier` as in use
             _get_nullifier_set(@self).mark_nullifier_in_use(statement.old_shares_nullifier);
@@ -685,6 +688,18 @@ mod Darkpool {
             valid_settle_proof: Proof,
             verification_job_ids: Array<felt252>,
         ) {
+            // Assert that the merkle roots for which inclusion is proven in `VALID REBLIND`
+            // are valid historical roots
+            let merkle_tree = _get_merkle_tree(@self);
+            assert(
+                merkle_tree.root_in_history(party_0_payload.valid_reblind_statement.merkle_root),
+                'invalid statement merkle root'
+            );
+            assert(
+                merkle_tree.root_in_history(party_1_payload.valid_reblind_statement.merkle_root),
+                'invalid statement merkle root'
+            );
+
             // Mark the `original_shares_nullifier`s as in use
             let nullifier_set = _get_nullifier_set(@self);
             nullifier_set

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -662,16 +662,18 @@ pub fn get_dummy_update_wallet_args(
     old_wallet: SizedWallet,
     new_wallet: SizedWallet,
     external_transfer: ExternalTransfer,
+    merkle_root: Scalar,
 ) -> Result<UpdateWalletArgs> {
     debug!("Generating dummy update_wallet args...");
     let wallet_blinder_share = Scalar::random(&mut thread_rng());
 
-    let (_, statement) = construct_witness_statement::<
+    let (_, mut statement) = construct_witness_statement::<
         MAX_BALANCES,
         MAX_ORDERS,
         MAX_FEES,
         TEST_MERKLE_HEIGHT,
     >(old_wallet, new_wallet, external_transfer);
+    statement.merkle_root = merkle_root;
 
     let (_, proof) = singleprover_prove::<DummyValidWalletUpdate>((), statement.clone())?;
 

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -692,10 +692,11 @@ pub fn get_dummy_process_match_args(
     party0_wallet: SizedWallet,
     party1_wallet: SizedWallet,
     match_res: MatchResult,
+    merkle_root: Scalar,
 ) -> Result<ProcessMatchArgs> {
     debug!("Generating dummy process_match args...");
-    let party_0_match_payload = MatchPayload::dummy(&party0_wallet)?;
-    let party_1_match_payload = MatchPayload::dummy(&party1_wallet)?;
+    let party_0_match_payload = MatchPayload::dummy(&party0_wallet, merkle_root)?;
+    let party_1_match_payload = MatchPayload::dummy(&party1_wallet, merkle_root)?;
     let (valid_match_mpc_witness, valid_match_mpc_proof) =
         singleprover_prove::<DummyValidMatchMpc>(Scalar::from(DUMMY_VALUE), ())?;
     let (_, valid_settle_statement) =

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -431,14 +431,15 @@ pub struct MatchPayload {
 }
 
 impl MatchPayload {
-    pub fn dummy(wallet: &SizedWallet) -> Result<Self> {
+    pub fn dummy(wallet: &SizedWallet, merkle_root: Scalar) -> Result<Self> {
         let (_, valid_commitments_statement) = create_witness_and_statement(wallet);
-        let (_, valid_reblind_statement) = construct_valid_reblind_witness_statement::<
+        let (_, mut valid_reblind_statement) = construct_valid_reblind_witness_statement::<
             MAX_BALANCES,
             MAX_ORDERS,
             MAX_FEES,
             TEST_MERKLE_HEIGHT,
         >(wallet);
+        valid_reblind_statement.merkle_root = merkle_root;
         let (_, valid_commitments_proof) =
             singleprover_prove::<DummyValidCommitments>((), valid_commitments_statement.clone())?;
         let (_, valid_reblind_proof) =


### PR DESCRIPTION
This PR adds checks in `update_wallet` and `process_match` that the respective statements (`VALID WALLET UPDATE`, `VALID REBLIND`) contain historical merkle roots.

e2e tests were updated to provide valid historic roots, and new tests were added ensuring that contract execution fails with invalid roots.