### PR TITLE
renegade_contracts: darkpool: `process_match` total wallet shares commitment

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -89,13 +89,15 @@ struct UpdateWalletCallbackElems {
     tx_hash: felt252,
 }
 
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Clone)]
 struct ProcessMatchCallbackElems {
     party_0_wallet_blinder_share: Scalar,
     party_0_reblinded_private_shares_commitment: Scalar,
+    party_0_modified_shares: Array<Scalar>,
     party_0_original_shares_nullifier: Scalar,
     party_1_wallet_blinder_share: Scalar,
     party_1_reblinded_private_shares_commitment: Scalar,
+    party_1_modified_shares: Array<Scalar>,
     party_1_original_shares_nullifier: Scalar,
     tx_hash: felt252,
 }

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -135,22 +135,20 @@ async fn test_process_match_root() -> Result<()> {
     )?;
     poll_process_match_to_completion(&account, &args).await?;
 
-    insert_scalar_to_ark_merkle_tree(
-        &args
-            .party_0_match_payload
+    let party_0_wallet_commitment = compute_wallet_commitment_from_private(
+        args.valid_settle_statement.party0_modified_shares,
+        args.party_0_match_payload
             .valid_reblind_statement
             .reblinded_private_share_commitment,
-        &mut ark_merkle_tree,
-        0,
-    )?;
-    insert_scalar_to_ark_merkle_tree(
-        &args
-            .party_1_match_payload
+    );
+    insert_scalar_to_ark_merkle_tree(&party_0_wallet_commitment, &mut ark_merkle_tree, 0)?;
+    let party_1_wallet_commitment = compute_wallet_commitment_from_private(
+        args.valid_settle_statement.party1_modified_shares,
+        args.party_1_match_payload
             .valid_reblind_statement
             .reblinded_private_share_commitment,
-        &mut ark_merkle_tree,
-        1,
-    )?;
+    );
+    insert_scalar_to_ark_merkle_tree(&party_1_wallet_commitment, &mut ark_merkle_tree, 1)?;
 
     assert_roots_equal(&account, *DARKPOOL_ADDRESS.get().unwrap(), &ark_merkle_tree).await?;
 


### PR DESCRIPTION
This PR computes commitments to the total set of wallet shares in post-match wallets (private shares commitment from `VALID REBLIND` statement, public shares from `VALID SETTLE` statement) in a manner consistent with what is done in the circuits, and inserts these commitments into the merkle tree.

The `process_match` tests have been updated to calculate these commitments accordingly as well, and pass.