### PR TITLE
renegade_contracts: oz: erc20: use camelCase IERC20 interface

### DIFF
--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -1109,7 +1109,7 @@ mod Darkpool {
                 );
         } else {
             // Deposit
-            erc20.transfer_from(transfer.account_addr, contract_address, transfer.amount);
+            erc20.transferFrom(transfer.account_addr, contract_address, transfer.amount);
 
             // Emit event
             self

--- a/src/oz/erc20.cairo
+++ b/src/oz/erc20.cairo
@@ -7,11 +7,11 @@ trait IERC20<TState> {
     fn name(self: @TState) -> felt252;
     fn symbol(self: @TState) -> felt252;
     fn decimals(self: @TState) -> u8;
-    fn total_supply(self: @TState) -> u256;
-    fn balance_of(self: @TState, account: ContractAddress) -> u256;
+    fn totalSupply(self: @TState) -> u256;
+    fn balanceOf(self: @TState, account: ContractAddress) -> u256;
     fn allowance(self: @TState, owner: ContractAddress, spender: ContractAddress) -> u256;
     fn transfer(ref self: TState, recipient: ContractAddress, amount: u256) -> bool;
-    fn transfer_from(
+    fn transferFrom(
         ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
     ) -> bool;
     fn approve(ref self: TState, spender: ContractAddress, amount: u256) -> bool;

--- a/src/testing/test_contracts/dummy_erc20.cairo
+++ b/src/testing/test_contracts/dummy_erc20.cairo
@@ -78,11 +78,11 @@ mod DummyERC20 {
             18
         }
 
-        fn total_supply(self: @ContractState) -> u256 {
+        fn totalSupply(self: @ContractState) -> u256 {
             self._total_supply.read()
         }
 
-        fn balance_of(self: @ContractState, account: ContractAddress) -> u256 {
+        fn balanceOf(self: @ContractState, account: ContractAddress) -> u256 {
             self._balances.read(account)
         }
 
@@ -98,7 +98,7 @@ mod DummyERC20 {
             true
         }
 
-        fn transfer_from(
+        fn transferFrom(
             ref self: ContractState,
             sender: ContractAddress,
             recipient: ContractAddress,

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -66,7 +66,7 @@ const UPDATE_WALLET_FN_NAME: &str = "update_wallet";
 const POLL_UPDATE_WALLET_FN_NAME: &str = "poll_update_wallet";
 const PROCESS_MATCH_FN_NAME: &str = "process_match";
 const POLL_PROCESS_MATCH_FN_NAME: &str = "poll_process_match";
-const BALANCE_OF_FN_NAME: &str = "balance_of";
+const BALANCE_OF_FN_NAME: &str = "balanceOf";
 const APPROVE_FN_NAME: &str = "approve";
 const UPGRADE_FN_NAME: &str = "upgrade";
 


### PR DESCRIPTION
This PR tweaks the ERC20 interface to use camel-casing.

Test helpers have also been updated to reflect this, and the transfer tests pass.