### PR TITLE
renegade_contracts: verifier, darkpool: make verifier contract `Ownable`

### DIFF
--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -30,13 +30,11 @@ trait IDarkpool<TContractState> {
         ref self: TContractState,
         merkle_class_hash: ClassHash,
         nullifier_set_class_hash: ClassHash,
+        verifier_class_hash: ClassHash,
         height: u8,
-    );
+    ) -> Array<ContractAddress>;
     fn initialize_verifier(
-        ref self: TContractState,
-        circuit: Circuit,
-        verifier_contract_address: ContractAddress,
-        circuit_params: CircuitParams,
+        ref self: TContractState, circuit: Circuit, circuit_params: CircuitParams, 
     );
     // OZ
     fn upgrade(ref self: TContractState, darkpool_class_hash: ClassHash);
@@ -106,7 +104,7 @@ mod Darkpool {
     use ecdsa::check_ecdsa_signature;
     use starknet::{
         ClassHash, get_caller_address, get_contract_address, get_tx_info, ContractAddress,
-        replace_class_syscall, contract_address::ContractAddressZeroable,
+        replace_class_syscall, contract_address::ContractAddressZeroable, deploy_syscall,
     };
 
     use alexandria_data_structures::array_ext::ArrayTraitExt;
@@ -298,8 +296,9 @@ mod Darkpool {
             ref self: ContractState,
             merkle_class_hash: ClassHash,
             nullifier_set_class_hash: ClassHash,
+            verifier_class_hash: ClassHash,
             height: u8,
-        ) {
+        ) -> Array<ContractAddress> {
             ownable__assert_only_owner(@self);
             initializable__initialize(ref self);
 
@@ -307,25 +306,61 @@ mod Darkpool {
             self.merkle_class_hash.write(merkle_class_hash);
             self.nullifier_set_class_hash.write(nullifier_set_class_hash);
 
+            // Deploy verifier contracts
+
+            // Verifier constructor accepts a `ContractAddress` as the contract owner,
+            // here we make sure that it is the darkpool contract itself
+            let verifier_constructor_calldata = array![get_contract_address().into()].span();
+
+            let circuits = array![
+                Circuit::ValidWalletCreate(()),
+                Circuit::ValidWalletUpdate(()),
+                Circuit::ValidCommitments(()),
+                Circuit::ValidReblind(()),
+                Circuit::ValidMatchMpc(()),
+                Circuit::ValidSettle(()),
+            ];
+
+            let mut i = 0;
+            let mut verifier_addresses = ArrayTrait::new();
+            loop {
+                if i == circuits.len() {
+                    break;
+                }
+
+                let circuit = *circuits[i];
+                // Deploy verifier contract
+                let (verifier_address, _) = deploy_syscall(
+                    verifier_class_hash,
+                    i.into(), // contract_address_salt
+                    verifier_constructor_calldata,
+                    true, // deploy_from_zero
+                )
+                    .unwrap_syscall();
+
+                verifier_addresses.append(verifier_address);
+
+                // Save verifier contract address to storage
+                _write_verifier_address(ref self, circuit, verifier_address);
+
+                i += 1;
+            };
+
             // Initialize the Merkle tree & verifier
             _get_merkle_tree(@self).initialize(height);
+
+            verifier_addresses
         }
 
         /// Initializes a verifier contract
         /// Parameters:
-        /// - `verifier_contract_address`: The address of the deployed verifier contract
         /// - `circuit`: The circuit for which to initialize the verifier contract
         /// - `circuit_params`: The parameters of the circuit
         fn initialize_verifier(
-            ref self: ContractState,
-            circuit: Circuit,
-            verifier_contract_address: ContractAddress,
-            circuit_params: CircuitParams
+            ref self: ContractState, circuit: Circuit, circuit_params: CircuitParams
         ) {
             ownable__assert_only_owner(@self);
 
-            // Save verifier contract address to storage
-            _write_verifier_address(ref self, circuit, verifier_contract_address);
             // Initialize the verifier
             _get_verifier(@self, circuit).initialize(circuit_params);
         }

--- a/src/testing/tests.cairo
+++ b/src/testing/tests.cairo
@@ -2,3 +2,4 @@ mod darkpool_tests;
 mod nullifier_set_tests;
 mod merkle_tests;
 mod utils_tests;
+mod verifier_tests;

--- a/src/testing/tests/darkpool_tests.cairo
+++ b/src/testing/tests/darkpool_tests.cairo
@@ -42,7 +42,7 @@ const DUMMY_CALLER: felt252 = 'DUMMY_CALLER';
 fn test_upgrade_darkpool() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     darkpool.upgrade(DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap());
     // The dummy upgrade target has a hardcoded response for the `get_wallet_blinder_transaction`
@@ -61,7 +61,7 @@ fn test_upgrade_darkpool() {
 fn test_upgrade_merkle() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let original_root = darkpool.get_root();
 
@@ -77,7 +77,7 @@ fn test_upgrade_merkle() {
 fn test_upgrade_nullifier_set() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     darkpool.upgrade_nullifier_set(DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap());
     assert(!darkpool.is_nullifier_available(0.into()), 'upgrade target wrong result');
@@ -89,18 +89,8 @@ fn test_upgrade_nullifier_set() {
 #[test]
 #[available_gas(10000000000)] // 100x
 fn test_upgrade_verifier() {
-    let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
-    set_contract_address(test_caller);
-    let (
-        mut darkpool,
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    ) =
-        setup_darkpool();
+    set_contract_address(contract_address_try_from_felt252(TEST_CALLER).unwrap());
+    let (mut darkpool, verifier_addresses) = setup_darkpool();
 
     let (upgrade_target_address, _) = deploy_syscall(
         DummyUpgradeTarget::TEST_CLASS_HASH.try_into().unwrap(), 0, ArrayTrait::new().span(), false, 
@@ -111,12 +101,24 @@ fn test_upgrade_verifier() {
     // upgrade the verifier, check that it (and it alone) has verified the dummy job,
     // and then upgrade it back to the original verifier contract.
 
+    let valid_wallet_create_verifier_address = *verifier_addresses[0];
+    let valid_wallet_update_verifier_address = *verifier_addresses[1];
+    let valid_commitments_verifier_address = *verifier_addresses[2];
+    let valid_reblind_verifier_address = *verifier_addresses[3];
+    let valid_match_mpc_verifier_address = *verifier_addresses[4];
+    let valid_settle_verifier_address = *verifier_addresses[5];
+
+    // Only the darkpool address can call external functions on the verifier
+    set_contract_address(darkpool.contract_address);
+
     queue_job_direct(valid_wallet_create_verifier_address, 0);
     queue_job_direct(valid_wallet_update_verifier_address, 0);
     queue_job_direct(valid_commitments_verifier_address, 0);
     queue_job_direct(valid_reblind_verifier_address, 0);
     queue_job_direct(valid_match_mpc_verifier_address, 0);
     queue_job_direct(valid_settle_verifier_address, 0);
+
+    set_contract_address(contract_address_try_from_felt252(TEST_CALLER).unwrap());
 
     // VALID WALLET CREATE
     assert_not_verified(ref darkpool, Circuit::ValidWalletCreate(()), 0);
@@ -164,7 +166,7 @@ fn test_upgrade_verifier() {
 fn test_transfer_ownership() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     darkpool.transfer_ownership(dummy_caller);
@@ -177,21 +179,21 @@ fn test_transfer_ownership() {
 // ------------------------
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_initialize_access() {
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
-    let (_, _, _, _, _, _, _) = setup_darkpool();
+    setup_darkpool();
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_upgrade_darkpool_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -200,12 +202,12 @@ fn test_upgrade_darkpool_access() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_upgrade_merkle_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -214,12 +216,12 @@ fn test_upgrade_merkle_access() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_upgrade_nullifier_set_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -228,12 +230,12 @@ fn test_upgrade_nullifier_set_access() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_upgrade_verifier_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -247,12 +249,12 @@ fn test_upgrade_verifier_access() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_transfer_ownership_access() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
     set_contract_address(test_caller);
-    let (mut darkpool, _, _, _, _, _, _) = setup_darkpool();
+    let (mut darkpool, _) = setup_darkpool();
 
     let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
     set_contract_address(dummy_caller);
@@ -264,7 +266,7 @@ fn test_transfer_ownership_access() {
 // ------------------------
 
 #[test]
-#[should_panic(expected: ('Initializable: is initialized', 'ENTRYPOINT_FAILED', ))]
+#[should_panic(expected: ('Initializable: is initialized', 'ENTRYPOINT_FAILED'))]
 #[available_gas(10000000000)] // 100x
 fn test_initialize_twice() {
     let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
@@ -278,51 +280,17 @@ fn test_initialize_twice() {
     )
         .unwrap();
 
-    let (
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    ) =
-        deploy_all_verifier_contracts();
-
     let mut darkpool = IDarkpoolDispatcher { contract_address: darkpool_address };
 
-    initialize_darkpool(
-        ref darkpool,
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    );
-    initialize_darkpool(
-        ref darkpool,
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    );
+    initialize_darkpool(ref darkpool);
+    initialize_darkpool(ref darkpool);
 }
 
 // -----------
 // | HELPERS |
 // -----------
 
-fn setup_darkpool() -> (
-    IDarkpoolDispatcher,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-) {
+fn setup_darkpool() -> (IDarkpoolDispatcher, Array<ContractAddress>) {
     let mut calldata = ArrayTrait::new();
     calldata.append(TEST_CALLER);
 
@@ -331,131 +299,29 @@ fn setup_darkpool() -> (
     )
         .unwrap();
 
-    let (
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    ) =
-        deploy_all_verifier_contracts();
-
     let mut darkpool = IDarkpoolDispatcher { contract_address: darkpool_address };
-    initialize_darkpool(
-        ref darkpool,
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    );
+    let verifier_addresses = initialize_darkpool(ref darkpool);
 
-    (
-        darkpool,
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    )
+    (darkpool, verifier_addresses)
 }
 
-fn initialize_darkpool(
-    ref darkpool: IDarkpoolDispatcher,
-    valid_wallet_create_verifier_address: ContractAddress,
-    valid_wallet_update_verifier_address: ContractAddress,
-    valid_commitments_verifier_address: ContractAddress,
-    valid_reblind_verifier_address: ContractAddress,
-    valid_match_mpc_verifier_address: ContractAddress,
-    valid_settle_verifier_address: ContractAddress,
-) {
-    darkpool
+fn initialize_darkpool(ref darkpool: IDarkpoolDispatcher) -> Array<ContractAddress> {
+    let verifier_addresses = darkpool
         .initialize(
             Merkle::TEST_CLASS_HASH.try_into().unwrap(),
             NullifierSet::TEST_CLASS_HASH.try_into().unwrap(),
+            Verifier::TEST_CLASS_HASH.try_into().unwrap(),
             TEST_MERKLE_HEIGHT,
         );
 
-    darkpool
-        .initialize_verifier(
-            Circuit::ValidWalletCreate(()),
-            valid_wallet_create_verifier_address,
-            get_dummy_circuit_params(),
-        );
-    darkpool
-        .initialize_verifier(
-            Circuit::ValidWalletUpdate(()),
-            valid_wallet_update_verifier_address,
-            get_dummy_circuit_params(),
-        );
-    darkpool
-        .initialize_verifier(
-            Circuit::ValidCommitments(()),
-            valid_commitments_verifier_address,
-            get_dummy_circuit_params(),
-        );
-    darkpool
-        .initialize_verifier(
-            Circuit::ValidReblind(()), valid_reblind_verifier_address, get_dummy_circuit_params(), 
-        );
-    darkpool
-        .initialize_verifier(
-            Circuit::ValidMatchMpc(()),
-            valid_match_mpc_verifier_address,
-            get_dummy_circuit_params(),
-        );
-    darkpool
-        .initialize_verifier(
-            Circuit::ValidSettle(()), valid_settle_verifier_address, get_dummy_circuit_params(), 
-        );
-}
+    darkpool.initialize_verifier(Circuit::ValidWalletCreate(()), get_dummy_circuit_params());
+    darkpool.initialize_verifier(Circuit::ValidWalletUpdate(()), get_dummy_circuit_params());
+    darkpool.initialize_verifier(Circuit::ValidCommitments(()), get_dummy_circuit_params());
+    darkpool.initialize_verifier(Circuit::ValidReblind(()), get_dummy_circuit_params());
+    darkpool.initialize_verifier(Circuit::ValidMatchMpc(()), get_dummy_circuit_params());
+    darkpool.initialize_verifier(Circuit::ValidSettle(()), get_dummy_circuit_params());
 
-fn deploy_all_verifier_contracts() -> (
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-    ContractAddress,
-) {
-    let verifier_class_hash = Verifier::TEST_CLASS_HASH.try_into().unwrap();
-
-    let (valid_wallet_create_verifier_address, _) = deploy_syscall(
-        verifier_class_hash, 0, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
-    let (valid_wallet_update_verifier_address, _) = deploy_syscall(
-        verifier_class_hash, 1, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
-    let (valid_commitments_verifier_address, _) = deploy_syscall(
-        verifier_class_hash, 2, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
-    let (valid_reblind_verifier_address, _) = deploy_syscall(
-        verifier_class_hash, 3, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
-    let (valid_match_mpc_verifier_address, _) = deploy_syscall(
-        verifier_class_hash, 4, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
-    let (valid_settle_verifier_address, _) = deploy_syscall(
-        verifier_class_hash, 5, ArrayTrait::new().span(), false, 
-    )
-        .unwrap();
-
-    (
-        valid_wallet_create_verifier_address,
-        valid_wallet_update_verifier_address,
-        valid_commitments_verifier_address,
-        valid_reblind_verifier_address,
-        valid_match_mpc_verifier_address,
-        valid_settle_verifier_address,
-    )
+    verifier_addresses
 }
 
 fn assert_only_upgraded_circuit_verified(

--- a/src/testing/tests/verifier_tests.cairo
+++ b/src/testing/tests/verifier_tests.cairo
@@ -1,0 +1,83 @@
+use traits::TryInto;
+use option::OptionTrait;
+use result::ResultTrait;
+use array::ArrayTrait;
+use starknet::{deploy_syscall, contract_address_try_from_felt252, testing::set_contract_address};
+
+use renegade_contracts::verifier::{Verifier, IVerifierDispatcher, IVerifierDispatcherTrait};
+
+use super::super::test_utils::{
+    get_dummy_circuit_params, get_dummy_proof, get_dummy_witness_commitments
+};
+
+
+const TEST_CALLER: felt252 = 'TEST_CALLER';
+const DUMMY_CALLER: felt252 = 'DUMMY_CALLER';
+
+// ---------
+// | TESTS |
+// ---------
+
+// ------------------------
+// | ACCESS CONTROL TESTS |
+// ------------------------
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
+#[available_gas(10000000000)] // 100x
+fn test_initialize_access() {
+    let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
+    set_contract_address(dummy_caller);
+    setup_verifier();
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
+#[available_gas(10000000000)] // 100x
+fn test_queue_verification_job_access() {
+    let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
+    set_contract_address(test_caller);
+    let mut verifier = setup_verifier();
+
+    let proof = get_dummy_proof();
+    let witness_commitments = get_dummy_witness_commitments();
+
+    let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
+    set_contract_address(dummy_caller);
+    verifier.queue_verification_job(proof, witness_commitments, 42);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
+#[available_gas(10000000000)] // 100x
+fn test_step_verification_access() {
+    let test_caller = contract_address_try_from_felt252(TEST_CALLER).unwrap();
+    set_contract_address(test_caller);
+    let mut verifier = setup_verifier();
+
+    let proof = get_dummy_proof();
+    let witness_commitments = get_dummy_witness_commitments();
+
+    let dummy_caller = contract_address_try_from_felt252(DUMMY_CALLER).unwrap();
+    set_contract_address(dummy_caller);
+    verifier.step_verification(42);
+}
+
+// -----------
+// | HELPERS |
+// -----------
+
+fn setup_verifier() -> IVerifierDispatcher {
+    let mut calldata = ArrayTrait::new();
+    calldata.append(TEST_CALLER);
+
+    let (verifier_address, _) = deploy_syscall(
+        Verifier::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false
+    )
+        .unwrap();
+
+    let mut verifier = IVerifierDispatcher { contract_address: verifier_address };
+    verifier.initialize(get_dummy_circuit_params());
+
+    verifier
+}

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -7,13 +7,20 @@ mod utils;
 // -------------
 // TODO: Move to separate file / module when extensibility pattern is stabilized
 
+use starknet::ContractAddress;
+
 use renegade_contracts::utils::serde::EcPointSerde;
 
 use types::{CircuitParams, Proof, VerificationJob};
 
 #[starknet::interface]
 trait IVerifier<TContractState> {
+    // OWNERSHIP
+    fn transfer_ownership(ref self: TContractState, new_owner: ContractAddress);
+    fn owner(self: @TContractState) -> ContractAddress;
+    // INITIALIZATION
     fn initialize(ref self: TContractState, circuit_params: CircuitParams);
+    // SETTERS
     fn queue_verification_job(
         ref self: TContractState,
         proof: Proof,
@@ -21,6 +28,7 @@ trait IVerifier<TContractState> {
         verification_job_id: felt252
     );
     fn step_verification(ref self: TContractState, verification_job_id: felt252) -> Option<bool>;
+    // GETTERS
     fn get_pc_gens(self: @TContractState) -> (EcPoint, EcPoint);
     fn check_verification_job_status(
         self: @TContractState, verification_job_id: felt252
@@ -34,6 +42,8 @@ mod Verifier {
     use traits::{Into, TryInto};
     use array::{ArrayTrait, SpanTrait};
     use ec::{EcPoint, ec_point_zero, ec_mul, ec_point_unwrap, ec_point_non_zero};
+    use zeroable::Zeroable;
+    use starknet::{ContractAddress, get_caller_address};
 
     use alexandria_data_structures::array_ext::ArrayTraitExt;
     use alexandria_math::fast_power::fast_power;
@@ -67,6 +77,9 @@ mod Verifier {
 
     #[storage]
     struct Storage {
+        // OWNABLE
+        /// Stores the owner of the contract
+        _owner: ContractAddress,
         /// Queue of in-progress verification jobs
         verification_queue: LegacyMap<felt252, StoreSerdeWrapper<VerificationJob>>,
         /// Map of in-use verification job IDs
@@ -103,7 +116,12 @@ mod Verifier {
     // | EVENTS |
     // ----------
 
-    // TODO: Access / management controls events
+    /// Emitted when ownership of the Darkpool contract is transferred
+    #[derive(Drop, PartialEq, starknet::Event)]
+    struct OwnershipTransfer {
+        previous_owner: ContractAddress,
+        new_owner: ContractAddress,
+    }
 
     #[derive(Drop, PartialEq, starknet::Event)]
     struct Initialized {}
@@ -122,9 +140,20 @@ mod Verifier {
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
     enum Event {
+        OwnershipTransfer: OwnershipTransfer,
         Initialized: Initialized,
         VerificationJobQueued: VerificationJobQueued,
         VerificationJobCompleted: VerificationJobCompleted,
+    }
+
+    // ---------------
+    // | CONSTRUCTOR |
+    // ---------------
+
+    // NOTE: THE OWNER SHOULD BE THE DARKPOOL CONTRACT
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        _ownable_initialize(ref self, owner);
     }
 
     // ----------------------------
@@ -133,10 +162,32 @@ mod Verifier {
 
     #[external(v0)]
     impl IVerifierImpl of super::IVerifier<ContractState> {
+        // -------------
+        // | OWNERSHIP |
+        // -------------
+
+        /// Transfers ownership of the contract to a new address
+        fn transfer_ownership(ref self: ContractState, new_owner: ContractAddress) {
+            assert(!new_owner.is_zero(), 'New owner is the zero address');
+            ownable__assert_only_owner(@self);
+            _ownable__transfer_ownership(ref self, new_owner);
+        }
+
+        /// Returns the owner of the contract
+        fn owner(self: @ContractState) -> ContractAddress {
+            self._owner.read()
+        }
+
+        // ------------------
+        // | INITIALIZATION |
+        // ------------------
+
         /// Initializes the verifier for the given public parameters
         /// Parameters:
         /// - `circuit_params`: The public parameters of the circuit
         fn initialize(ref self: ContractState, circuit_params: CircuitParams) {
+            ownable__assert_only_owner(@self);
+
             // Assert that n_plus = 2^k
             assert(
                 fast_power(2, circuit_params.k.into(), MAX_USIZE.into() + 1) == circuit_params
@@ -176,6 +227,10 @@ mod Verifier {
             self.emit(Event::Initialized(Initialized {}));
         }
 
+        // -----------
+        // | SETTERS |
+        // -----------
+
         /// Enqueues a verification job for the given proof, squeezing out challenge scalars
         /// as necessary.
         /// Parameters:
@@ -187,6 +242,8 @@ mod Verifier {
             mut witness_commitments: Array<EcPoint>,
             verification_job_id: felt252
         ) {
+            ownable__assert_only_owner(@self);
+
             // Assert that the verification job ID is not already in use
             assert(!self.job_id_in_use.read(verification_job_id), 'job ID already in use');
             self.job_id_in_use.write(verification_job_id, true);
@@ -263,6 +320,8 @@ mod Verifier {
         fn step_verification(
             ref self: ContractState, verification_job_id: felt252
         ) -> Option<bool> {
+            ownable__assert_only_owner(@self);
+
             let mut verification_job = self.verification_queue.read(verification_job_id).inner;
             step_verification_inner(ref self, ref verification_job);
 
@@ -728,5 +787,31 @@ mod Verifier {
                 },
             }
         }
+    }
+
+    // -----------
+    // | OWNABLE |
+    // -----------
+    // Adapted from OpenZeppelin's `Ownable` contract
+
+    /// Asserts that the caller is the owner of the contract
+    #[external(v0)]
+    fn ownable__assert_only_owner(self: @ContractState) {
+        let owner = self._owner.read();
+        let caller = get_caller_address();
+        assert(!caller.is_zero(), 'Caller is the zero address');
+        assert(caller == owner, 'Caller is not the owner');
+    }
+
+    /// Initializes the contract with an owner
+    fn _ownable_initialize(ref self: ContractState, owner: ContractAddress) {
+        _ownable__transfer_ownership(ref self, owner)
+    }
+
+    /// Internal function to transfer ownership of the contract to a new address
+    fn _ownable__transfer_ownership(ref self: ContractState, new_owner: ContractAddress) {
+        let previous_owner: ContractAddress = self._owner.read();
+        self._owner.write(new_owner);
+        self.emit(Event::OwnershipTransfer(OwnershipTransfer { previous_owner, new_owner }));
     }
 }

--- a/starknet_scripts/src/commands/deploy.rs
+++ b/starknet_scripts/src/commands/deploy.rs
@@ -7,8 +7,8 @@ use tracing::{debug, info};
 use crate::{
     cli::{Contract, DeployArgs},
     commands::utils::{
-        deploy_darkpool, deploy_merkle, deploy_nullifier_set, deploy_verifier, dump_deployment,
-        initialize, setup_account, MERKLE_HEIGHT,
+        deploy_darkpool, deploy_merkle, deploy_nullifier_set, dump_deployment, initialize,
+        setup_account, MERKLE_HEIGHT,
     },
 };
 
@@ -66,27 +66,12 @@ pub async fn deploy_and_initialize(args: DeployArgs) -> Result<()> {
             );
 
             if should_initialize {
-                // Deploy verifier
-                let verifier_class_hash_hex = if let Some(verifier_class_hash) = verifier_class_hash
-                {
-                    verifier_class_hash
-                } else {
-                    format!("{verifier_class_hash_felt:#64x}")
-                };
-                let (verifier_address, _, _) = deploy_verifier(
-                    Some(verifier_class_hash_hex),
-                    FieldElement::ZERO, /* salt */
-                    &artifacts_path,
-                    &account,
-                )
-                .await?;
-
                 // Initialize darkpool
                 debug!("Initializing darkpool contract...");
                 let calldata = vec![
                     merkle_class_hash_felt,
                     nullifier_set_class_hash_felt,
-                    verifier_address,
+                    verifier_class_hash_felt,
                     FieldElement::from(MERKLE_HEIGHT),
                     // TODO: Need to get circuit params! Prob best to read them in from file.
                 ];

--- a/starknet_scripts/src/commands/utils.rs
+++ b/starknet_scripts/src/commands/utils.rs
@@ -171,11 +171,14 @@ pub async fn deploy(
     account: &ScriptAccount,
     class_hash: FieldElement,
     calldata: &[FieldElement],
-    salt: FieldElement,
 ) -> Result<InvokeTransactionResult> {
     let contract_factory = ContractFactory::new(class_hash, account);
     let deploy_result = contract_factory
-        .deploy(calldata, salt, false /* unique */)
+        .deploy(
+            calldata,
+            FieldElement::ZERO, /* salt */
+            false,              /* unique */
+        )
         .send()
         .await?;
 
@@ -206,13 +209,12 @@ pub async fn initialize(
 // Taken from https://github.com/xJonathanLEI/starknet-rs/blob/master/starknet-accounts/src/factory/mod.rs
 pub fn calculate_contract_address(
     class_hash: FieldElement,
-    salt: FieldElement,
     constructor_calldata: &[FieldElement],
 ) -> FieldElement {
     compute_hash_on_elements(&[
         PREFIX_CONTRACT_ADDRESS,
         FieldElement::ZERO, /* deployer address */
-        salt,
+        FieldElement::ZERO, /* salt */
         class_hash,
         compute_hash_on_elements(constructor_calldata),
     ]) % ADDR_BOUND
@@ -278,19 +280,9 @@ pub async fn deploy_darkpool(
     let calldata = vec![account.address()];
     let InvokeTransactionResult {
         transaction_hash, ..
-    } = deploy(
-        account,
-        darkpool_class_hash_felt,
-        &calldata,
-        FieldElement::ZERO, /* salt */
-    )
-    .await?;
+    } = deploy(account, darkpool_class_hash_felt, &calldata).await?;
 
-    let darkpool_address = calculate_contract_address(
-        darkpool_class_hash_felt,
-        FieldElement::ZERO, /* salt */
-        &calldata,
-    );
+    let darkpool_address = calculate_contract_address(darkpool_class_hash_felt, &calldata);
 
     Ok((
         darkpool_address,
@@ -321,19 +313,9 @@ pub async fn deploy_merkle(
     debug!("Deploying merkle contract...");
     let InvokeTransactionResult {
         transaction_hash, ..
-    } = deploy(
-        account,
-        merkle_class_hash_felt,
-        &[],
-        FieldElement::ZERO, /* salt */
-    )
-    .await?;
+    } = deploy(account, merkle_class_hash_felt, &[]).await?;
 
-    let merkle_address = calculate_contract_address(
-        merkle_class_hash_felt,
-        FieldElement::ZERO, /* salt */
-        &[],
-    );
+    let merkle_address = calculate_contract_address(merkle_class_hash_felt, &[]);
 
     Ok((merkle_address, merkle_class_hash_felt, transaction_hash))
 }
@@ -357,50 +339,13 @@ pub async fn deploy_nullifier_set(
     debug!("Deploying nullifier set contract...");
     let InvokeTransactionResult {
         transaction_hash, ..
-    } = deploy(
-        account,
-        nullifier_set_class_hash_felt,
-        &[],
-        FieldElement::ZERO, /* salt */
-    )
-    .await?;
+    } = deploy(account, nullifier_set_class_hash_felt, &[]).await?;
 
-    let nullifier_set_address = calculate_contract_address(
-        nullifier_set_class_hash_felt,
-        FieldElement::ZERO, /* salt */
-        &[],
-    );
+    let nullifier_set_address = calculate_contract_address(nullifier_set_class_hash_felt, &[]);
 
     Ok((
         nullifier_set_address,
         nullifier_set_class_hash_felt,
         transaction_hash,
     ))
-}
-
-pub async fn deploy_verifier(
-    verifier_class_hash: Option<String>,
-    salt: FieldElement,
-    artifacts_path: &str,
-    account: &ScriptAccount,
-) -> Result<(FieldElement, FieldElement, FieldElement)> {
-    let (verifier_sierra_path, verifier_casm_path) =
-        get_artifacts(artifacts_path, VERIFIER_CONTRACT_NAME);
-    let verifier_class_hash_felt = get_or_declare(
-        verifier_class_hash,
-        verifier_sierra_path,
-        verifier_casm_path,
-        account,
-    )
-    .await?;
-
-    // Deploy verifier
-    debug!("Deploying verifier contract...");
-    let InvokeTransactionResult {
-        transaction_hash, ..
-    } = deploy(account, verifier_class_hash_felt, &[], salt).await?;
-
-    let verifier_address = calculate_contract_address(verifier_class_hash_felt, salt, &[]);
-
-    Ok((verifier_address, verifier_class_hash_felt, transaction_hash))
 }

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -28,8 +28,8 @@ use starknet::{
 };
 use starknet_client::types::StarknetU256;
 use starknet_scripts::commands::utils::{
-    calculate_contract_address, declare, deploy, deploy_darkpool, deploy_verifier, get_artifacts,
-    initialize, ScriptAccount, DARKPOOL_CONTRACT_NAME,
+    calculate_contract_address, declare, deploy, deploy_darkpool, get_artifacts, initialize,
+    ScriptAccount, DARKPOOL_CONTRACT_NAME,
 };
 use std::{env, iter};
 
@@ -114,13 +114,12 @@ pub async fn init_darkpool_test_state() -> Result<TestSequencer> {
         darkpool_address,
         merkle_class_hash,
         nullifier_set_class_hash,
+        verifier_class_hash,
         TEST_MERKLE_HEIGHT.into(),
     )
     .await?;
 
-    let verifier_class_hash_hex = Some(format!("{verifier_class_hash:#64x}"));
-
-    for (i, circuit) in [
+    for circuit in [
         Circuit::ValidWalletCreate(DummyValidWalletCreate {}),
         Circuit::ValidWalletUpdate(DummyValidWalletUpdate {}),
         Circuit::ValidCommitments(DummyValidCommitments {}),
@@ -129,17 +128,8 @@ pub async fn init_darkpool_test_state() -> Result<TestSequencer> {
         Circuit::ValidSettle(DummyValidSettle {}),
     ]
     .into_iter()
-    .enumerate()
     {
-        deploy_and_initialize_verifier(
-            &account,
-            &artifacts_path,
-            circuit,
-            darkpool_address,
-            verifier_class_hash_hex.clone(),
-            FieldElement::from(i), /* salt */
-        )
-        .await?;
+        initialize_verifier(&account, darkpool_address, circuit).await?;
     }
 
     debug!("Declaring & deploying dummy ERC20 contract...");
@@ -167,7 +157,6 @@ pub fn init_darkpool_test_statics(account: &ScriptAccount) -> Result<()> {
     let darkpool_address = get_contract_address_from_artifact(
         &artifacts_path,
         DARKPOOL_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &[account.address()],
     )?;
     if DARKPOOL_ADDRESS.get().is_none() {
@@ -177,7 +166,6 @@ pub fn init_darkpool_test_statics(account: &ScriptAccount) -> Result<()> {
     let erc20_address = get_contract_address_from_artifact(
         &artifacts_path,
         DUMMY_ERC20_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &get_dummy_erc20_calldata(account.address(), darkpool_address)?,
     )?;
     if ERC20_ADDRESS.get().is_none() {
@@ -234,18 +222,8 @@ async fn deploy_dummy_erc20(
 
     let calldata = get_dummy_erc20_calldata(account.address(), darkpool_address)?;
 
-    deploy(
-        account,
-        class_hash,
-        &calldata,
-        FieldElement::ZERO, /* salt */
-    )
-    .await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &calldata,
-    ))
+    deploy(account, class_hash, &calldata).await?;
+    Ok(calculate_contract_address(class_hash, &calldata))
 }
 
 async fn declare_dummy_upgrade_target(
@@ -273,9 +251,15 @@ pub async fn initialize_darkpool(
     darkpool_address: FieldElement,
     merkle_class_hash: FieldElement,
     nullifier_set_class_hash: FieldElement,
+    verifier_class_hash: FieldElement,
     merkle_height: FieldElement,
 ) -> Result<()> {
-    let calldata = vec![merkle_class_hash, nullifier_set_class_hash, merkle_height];
+    let calldata = vec![
+        merkle_class_hash,
+        nullifier_set_class_hash,
+        verifier_class_hash,
+        merkle_height,
+    ];
 
     initialize(account, darkpool_address, calldata)
         .await
@@ -284,10 +268,10 @@ pub async fn initialize_darkpool(
 
 pub async fn initialize_verifier(
     account: &ScriptAccount,
-    circuit: Circuit,
     darkpool_address: FieldElement,
-    verifier_address: FieldElement,
+    circuit: Circuit,
 ) -> Result<()> {
+    debug!("Initializing {circuit:?} verifier contract...");
     let mut statement_scalars = get_dummy_statement_scalars(circuit).into_iter();
 
     let circuit_params = match circuit {
@@ -319,7 +303,6 @@ pub async fn initialize_verifier(
     let calldata = circuit
         .to_calldata()
         .into_iter()
-        .chain(iter::once(verifier_address))
         .chain(circuit_params.to_calldata())
         .collect();
 
@@ -331,29 +314,6 @@ pub async fn initialize_verifier(
     )
     .await
     .map(|_| ())
-}
-
-pub async fn deploy_and_initialize_verifier(
-    account: &ScriptAccount,
-    artifacts_path: &str,
-    circuit: Circuit,
-    darkpool_address: FieldElement,
-    verifier_class_hash_hex: Option<String>,
-    salt: FieldElement,
-) -> Result<()> {
-    debug!("Declaring & deploying {circuit:?} verifier contract...");
-    let (verifier_address, _, _) = deploy_verifier(
-        verifier_class_hash_hex.clone(),
-        salt,
-        artifacts_path,
-        account,
-    )
-    .await?;
-
-    debug!("Initializing {circuit:?} verifier contract...");
-    initialize_verifier(account, circuit, darkpool_address, verifier_address)
-        .await
-        .map(|_| ())
 }
 
 pub async fn get_wallet_blinder_transaction(

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -54,12 +54,8 @@ pub async fn init_merkle_test_state() -> Result<TestSequencer> {
 pub fn init_merkle_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let merkle_address = get_contract_address_from_artifact(
-        &artifacts_path,
-        MERKLE_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
-        &[],
-    )?;
+    let merkle_address =
+        get_contract_address_from_artifact(&artifacts_path, MERKLE_CONTRACT_NAME, &[])?;
     if MERKLE_ADDRESS.get().is_none() {
         MERKLE_ADDRESS.set(merkle_address).unwrap();
     }

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -41,12 +41,8 @@ pub async fn init_nullifier_set_test_state() -> Result<TestSequencer> {
 pub fn init_nullifier_set_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let nullifier_set_address = get_contract_address_from_artifact(
-        &artifacts_path,
-        NULLIFIER_SET_CONTRACT_NAME,
-        FieldElement::ZERO,
-        &[],
-    )?;
+    let nullifier_set_address =
+        get_contract_address_from_artifact(&artifacts_path, NULLIFIER_SET_CONTRACT_NAME, &[])?;
     if NULLIFIER_SET_ADDRESS.get().is_none() {
         NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
     }

--- a/tests/src/poseidon/utils.rs
+++ b/tests/src/poseidon/utils.rs
@@ -47,12 +47,8 @@ pub async fn init_poseidon_test_state() -> Result<TestSequencer> {
 pub fn init_poseidon_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let poseidon_wrapper_address = get_contract_address_from_artifact(
-        &artifacts_path,
-        POSEIDON_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
-        &[],
-    )?;
+    let poseidon_wrapper_address =
+        get_contract_address_from_artifact(&artifacts_path, POSEIDON_WRAPPER_CONTRACT_NAME, &[])?;
     if POSEIDON_WRAPPER_ADDRESS.get().is_none() {
         POSEIDON_WRAPPER_ADDRESS
             .set(poseidon_wrapper_address)
@@ -70,12 +66,8 @@ pub async fn deploy_poseidon_wrapper(
         get_artifacts(artifacts_path, POSEIDON_WRAPPER_CONTRACT_NAME);
     let DeclareTransactionResult { class_hash, .. } =
         declare(poseidon_sierra_path, poseidon_casm_path, account).await?;
-    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &[],
-    ))
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
 }
 
 // --------------------------------

--- a/tests/src/statement_serde/utils.rs
+++ b/tests/src/statement_serde/utils.rs
@@ -78,7 +78,6 @@ pub fn init_statement_serde_test_statics() -> Result<()> {
     let statement_serde_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         STATEMENT_SERDE_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &[],
     )?;
     if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
@@ -129,12 +128,8 @@ async fn deploy_statement_serde_wrapper(
     )
     .await?;
 
-    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &[],
-    ))
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
 }
 
 // --------------------------------

--- a/tests/src/transcript/utils.rs
+++ b/tests/src/transcript/utils.rs
@@ -70,7 +70,6 @@ pub fn init_transcript_test_statics() -> Result<()> {
     let transcript_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         TRANSCRIPT_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &calldata,
     )?;
 
@@ -100,18 +99,8 @@ pub async fn deploy_transcript_wrapper(
         declare(transcript_sierra_path, transcript_casm_path, account).await?;
 
     let calldata = get_transcript_wrapper_constructor_calldata()?;
-    deploy(
-        account,
-        class_hash,
-        &calldata,
-        FieldElement::ZERO, /* salt */
-    )
-    .await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &calldata,
-    ))
+    deploy(account, class_hash, &calldata).await?;
+    Ok(calculate_contract_address(class_hash, &calldata))
 }
 
 // --------------------------------

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -230,15 +230,10 @@ pub fn get_sierra_class_hash_from_artifact(
 pub fn get_contract_address_from_artifact(
     artifacts_path: &str,
     contract_name: &str,
-    salt: FieldElement,
     constructor_calldata: &[FieldElement],
 ) -> Result<FieldElement> {
     let class_hash = get_sierra_class_hash_from_artifact(artifacts_path, contract_name)?;
-    Ok(calculate_contract_address(
-        class_hash,
-        salt,
-        constructor_calldata,
-    ))
+    Ok(calculate_contract_address(class_hash, constructor_calldata))
 }
 
 pub async fn setup_sequencer(test_config: TestConfig) -> Result<TestSequencer> {
@@ -305,7 +300,7 @@ fn init_test_statics(test_config: &TestConfig, sequencer: &TestSequencer) -> Res
         TestConfig::Darkpool => init_darkpool_test_statics(&sequencer.account()),
         TestConfig::Merkle => init_merkle_test_statics(),
         TestConfig::NullifierSet => init_nullifier_set_test_statics(),
-        TestConfig::Verifier => init_verifier_test_statics(),
+        TestConfig::Verifier => init_verifier_test_statics(&sequencer.account()),
         TestConfig::VerifierUtils => init_verifier_utils_test_statics(),
         TestConfig::Transcript => init_transcript_test_statics(),
         TestConfig::Poseidon => init_poseidon_test_statics(),

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -9,9 +9,13 @@ use mpc_bulletproof::{
 use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
 use once_cell::sync::OnceCell;
 use rand::thread_rng;
-use starknet::core::types::FieldElement;
+use starknet::{
+    accounts::Account,
+    core::types::{DeclareTransactionResult, FieldElement},
+};
 use starknet_scripts::commands::utils::{
-    deploy_verifier, initialize, ScriptAccount, VERIFIER_CONTRACT_NAME,
+    calculate_contract_address, declare, deploy, get_artifacts, initialize, ScriptAccount,
+    VERIFIER_CONTRACT_NAME,
 };
 use std::env;
 use tracing::debug;
@@ -40,13 +44,7 @@ pub async fn init_verifier_test_state() -> Result<TestSequencer> {
     let account = sequencer.account();
 
     debug!("Declaring & deploying verifier contract...");
-    let (verifier_address, _, _) = deploy_verifier(
-        None,
-        FieldElement::ZERO, /* salt */
-        &artifacts_path,
-        &account,
-    )
-    .await?;
+    let verifier_address = declare_and_deploy_verifier(&artifacts_path, &account).await?;
 
     debug!("Initializing verifier contract...");
     initialize_verifier(&account, verifier_address).await?;
@@ -54,20 +52,39 @@ pub async fn init_verifier_test_state() -> Result<TestSequencer> {
     Ok(sequencer)
 }
 
-pub fn init_verifier_test_statics() -> Result<()> {
+pub fn init_verifier_test_statics(account: &ScriptAccount) -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
     let verifier_address = get_contract_address_from_artifact(
         &artifacts_path,
         VERIFIER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
-        &[],
+        &[account.address()],
     )?;
     if VERIFIER_ADDRESS.get().is_none() {
         VERIFIER_ADDRESS.set(verifier_address).unwrap();
     }
 
     Ok(())
+}
+
+pub async fn declare_and_deploy_verifier(
+    artifacts_path: &str,
+    account: &ScriptAccount,
+) -> Result<FieldElement> {
+    let (verifier_sierra_path, verifier_casm_path) =
+        get_artifacts(artifacts_path, VERIFIER_CONTRACT_NAME);
+    let DeclareTransactionResult {
+        class_hash: verifier_class_hash,
+        ..
+    } = declare(verifier_sierra_path, verifier_casm_path, account).await?;
+
+    // Deploy verifier
+    debug!("Deploying verifier contract...");
+    deploy(account, verifier_class_hash, &[account.address()]).await?;
+
+    let verifier_address = calculate_contract_address(verifier_class_hash, &[account.address()]);
+
+    Ok(verifier_address)
 }
 
 // --------------------------------

--- a/tests/src/verifier_utils/utils.rs
+++ b/tests/src/verifier_utils/utils.rs
@@ -70,7 +70,6 @@ pub fn init_verifier_utils_test_statics() -> Result<()> {
     let verifier_utils_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         VERIFIER_UTILS_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &[],
     )?;
     if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
@@ -95,12 +94,8 @@ pub async fn deploy_verifier_utils_wrapper(
     )
     .await?;
 
-    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &[],
-    ))
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
 }
 
 // --------------------------------


### PR DESCRIPTION
This PR adds access control to the verifier, guarding the mutating functions (`queue_verification_job` and `step_verifier`) with an assertion that they are being called by the contract owner, which must be the darkpool.

Additionally, this PR changes the deployment pattern of the verifier contracts to be handled by the darkpool contract itself in its initialization. This makes our deployment logic simpler, and ensures that the verifier owner is the darkpool.

Cairo-native access control tests have been added for the verifier, which pass, as do all tests that had to be adapted to fit the new deployment pattern.

Relevant changes to the `starknet_scripts` crate are incomplete, a proper refactor of this crate is left for a future PR pending the completion of the verifier into the darkpool.