### PR TITLE
renegade_contracts: verifier, darkpool: multiverifier contract

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -141,3 +141,16 @@ enum Circuit {
     ValidMatchMpc: (),
     ValidSettle: (),
 }
+
+impl CircuitIntoFelt of Into<Circuit, felt252> {
+    fn into(self: Circuit) -> felt252 {
+        match self {
+            Circuit::ValidWalletCreate(()) => 0,
+            Circuit::ValidWalletUpdate(()) => 1,
+            Circuit::ValidCommitments(()) => 2,
+            Circuit::ValidReblind(()) => 3,
+            Circuit::ValidMatchMpc(()) => 4,
+            Circuit::ValidSettle(()) => 5,
+        }
+    }
+}

--- a/src/testing/tests/merkle_tests.cairo
+++ b/src/testing/tests/merkle_tests.cairo
@@ -4,8 +4,8 @@ use traits::Into;
 use renegade_contracts::merkle::{Merkle, Merkle::ContractState, IMerkle};
 
 
-const TEST_MERKLE_HEIGHT: u8 = 5;
-const TEST_MERKLE_CAPACITY: u8 = 32;
+const TEST_MERKLE_HEIGHT: u8 = 3;
+const TEST_MERKLE_CAPACITY: u8 = 8;
 
 #[test]
 #[available_gas(1000000000)] // 10x

--- a/src/verifier/types.cairo
+++ b/src/verifier/types.cairo
@@ -18,8 +18,9 @@ use super::scalar::{Scalar, ScalarTrait};
 /// Tracks the verification of a single proof
 #[derive(Drop, Serde, PartialEq)]
 struct VerificationJob {
+    /// The ID of the circuit being verified
+    circuit_id: felt252,
     /// The challenge scalars remaining to be used for verification
-    // TODO: This may just have to be a pointer (StorageBaseAddress) to the array
     rem_scalar_polys: Array<VecPoly3>,
     /// Represents the base y^-1 challenge scalar & the last computed power of y^-1
     y_inv_power: (Scalar, Scalar),
@@ -45,6 +46,7 @@ struct VerificationJob {
 #[generate_trait]
 impl VerificationJobImpl of VerificationJobTrait {
     fn new(
+        circuit_id: felt252,
         rem_scalar_polys: Array<VecPoly3>,
         y_inv_power: (Scalar, Scalar),
         z: Scalar,
@@ -55,6 +57,7 @@ impl VerificationJobImpl of VerificationJobTrait {
         rem_commitments: Array<EcPoint>,
     ) -> VerificationJob {
         VerificationJob {
+            circuit_id,
             rem_scalar_polys,
             y_inv_power,
             z,


### PR DESCRIPTION
This PR refactors the verifier to manage multiple circuits in a single contract, which bubbles up to the darkpool such that the verifier can be invoked via library calls as opposed to needing to deploy multiple verifier contracts.

All Cairo tests pass, but e2e tests still need to be updated to reflect these changes.

Also, I removed Pedersen generators from contract storage since we consistently use the STARK ECDSA generator everywhere