### PR TITLE
tests: darkpool, verifier: adopt multiverifier interface

### DIFF
--- a/starknet_scripts/src/commands/deploy.rs
+++ b/starknet_scripts/src/commands/deploy.rs
@@ -7,8 +7,8 @@ use tracing::{debug, info};
 use crate::{
     cli::{Contract, DeployArgs},
     commands::utils::{
-        deploy_darkpool, deploy_merkle, deploy_nullifier_set, deploy_verifier, dump_deployment,
-        initialize, setup_account, MERKLE_HEIGHT,
+        deploy_darkpool, deploy_merkle, deploy_nullifier_set, dump_deployment, initialize,
+        setup_account, MERKLE_HEIGHT,
     },
 };
 
@@ -66,32 +66,19 @@ pub async fn deploy_and_initialize(args: DeployArgs) -> Result<()> {
             );
 
             if should_initialize {
-                // Deploy verifier
-                let verifier_class_hash_hex = if let Some(verifier_class_hash) = verifier_class_hash
-                {
-                    verifier_class_hash
-                } else {
-                    format!("{verifier_class_hash_felt:#64x}")
-                };
-                let (verifier_address, _, _) = deploy_verifier(
-                    Some(verifier_class_hash_hex),
-                    FieldElement::ZERO, /* salt */
-                    &artifacts_path,
-                    &account,
-                )
-                .await?;
-
                 // Initialize darkpool
                 debug!("Initializing darkpool contract...");
                 let calldata = vec![
                     merkle_class_hash_felt,
                     nullifier_set_class_hash_felt,
-                    verifier_address,
+                    verifier_class_hash_felt,
                     FieldElement::from(MERKLE_HEIGHT),
                     // TODO: Need to get circuit params! Prob best to read them in from file.
                 ];
                 let initialization_result =
                     initialize(&account, darkpool_address, calldata).await?;
+
+                // TODO: Parameterize verifiers
 
                 info!(
                     "Darkpool contract initialized!\n\

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -54,12 +54,8 @@ pub async fn init_merkle_test_state() -> Result<TestSequencer> {
 pub fn init_merkle_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let merkle_address = get_contract_address_from_artifact(
-        &artifacts_path,
-        MERKLE_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
-        &[],
-    )?;
+    let merkle_address =
+        get_contract_address_from_artifact(&artifacts_path, MERKLE_CONTRACT_NAME, &[])?;
     if MERKLE_ADDRESS.get().is_none() {
         MERKLE_ADDRESS.set(merkle_address).unwrap();
     }

--- a/tests/src/nullifier_set/utils.rs
+++ b/tests/src/nullifier_set/utils.rs
@@ -41,12 +41,8 @@ pub async fn init_nullifier_set_test_state() -> Result<TestSequencer> {
 pub fn init_nullifier_set_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let nullifier_set_address = get_contract_address_from_artifact(
-        &artifacts_path,
-        NULLIFIER_SET_CONTRACT_NAME,
-        FieldElement::ZERO,
-        &[],
-    )?;
+    let nullifier_set_address =
+        get_contract_address_from_artifact(&artifacts_path, NULLIFIER_SET_CONTRACT_NAME, &[])?;
     if NULLIFIER_SET_ADDRESS.get().is_none() {
         NULLIFIER_SET_ADDRESS.set(nullifier_set_address).unwrap();
     }

--- a/tests/src/poseidon/utils.rs
+++ b/tests/src/poseidon/utils.rs
@@ -47,12 +47,8 @@ pub async fn init_poseidon_test_state() -> Result<TestSequencer> {
 pub fn init_poseidon_test_statics() -> Result<()> {
     let artifacts_path = env::var(ARTIFACTS_PATH_ENV_VAR).unwrap();
 
-    let poseidon_wrapper_address = get_contract_address_from_artifact(
-        &artifacts_path,
-        POSEIDON_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
-        &[],
-    )?;
+    let poseidon_wrapper_address =
+        get_contract_address_from_artifact(&artifacts_path, POSEIDON_WRAPPER_CONTRACT_NAME, &[])?;
     if POSEIDON_WRAPPER_ADDRESS.get().is_none() {
         POSEIDON_WRAPPER_ADDRESS
             .set(poseidon_wrapper_address)
@@ -70,12 +66,8 @@ pub async fn deploy_poseidon_wrapper(
         get_artifacts(artifacts_path, POSEIDON_WRAPPER_CONTRACT_NAME);
     let DeclareTransactionResult { class_hash, .. } =
         declare(poseidon_sierra_path, poseidon_casm_path, account).await?;
-    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &[],
-    ))
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
 }
 
 // --------------------------------

--- a/tests/src/statement_serde/utils.rs
+++ b/tests/src/statement_serde/utils.rs
@@ -78,7 +78,6 @@ pub fn init_statement_serde_test_statics() -> Result<()> {
     let statement_serde_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         STATEMENT_SERDE_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &[],
     )?;
     if STATEMENT_SERDE_WRAPPER_ADDRESS.get().is_none() {
@@ -129,12 +128,8 @@ async fn deploy_statement_serde_wrapper(
     )
     .await?;
 
-    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &[],
-    ))
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
 }
 
 // --------------------------------

--- a/tests/src/transcript/utils.rs
+++ b/tests/src/transcript/utils.rs
@@ -70,7 +70,6 @@ pub fn init_transcript_test_statics() -> Result<()> {
     let transcript_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         TRANSCRIPT_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &calldata,
     )?;
 
@@ -100,18 +99,8 @@ pub async fn deploy_transcript_wrapper(
         declare(transcript_sierra_path, transcript_casm_path, account).await?;
 
     let calldata = get_transcript_wrapper_constructor_calldata()?;
-    deploy(
-        account,
-        class_hash,
-        &calldata,
-        FieldElement::ZERO, /* salt */
-    )
-    .await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &calldata,
-    ))
+    deploy(account, class_hash, &calldata).await?;
+    Ok(calculate_contract_address(class_hash, &calldata))
 }
 
 // --------------------------------

--- a/tests/src/verifier_utils/utils.rs
+++ b/tests/src/verifier_utils/utils.rs
@@ -70,7 +70,6 @@ pub fn init_verifier_utils_test_statics() -> Result<()> {
     let verifier_utils_wrapper_address = get_contract_address_from_artifact(
         &artifacts_path,
         VERIFIER_UTILS_WRAPPER_CONTRACT_NAME,
-        FieldElement::ZERO, /* salt */
         &[],
     )?;
     if VERIFIER_UTILS_WRAPPER_ADDRESS.get().is_none() {
@@ -95,12 +94,8 @@ pub async fn deploy_verifier_utils_wrapper(
     )
     .await?;
 
-    deploy(account, class_hash, &[], FieldElement::ZERO /* salt */).await?;
-    Ok(calculate_contract_address(
-        class_hash,
-        FieldElement::ZERO, /* salt */
-        &[],
-    ))
+    deploy(account, class_hash, &[]).await?;
+    Ok(calculate_contract_address(class_hash, &[]))
 }
 
 // --------------------------------


### PR DESCRIPTION
This PR updates the e2e tests for the darkpool and the verifier to ingest the new `MultiVerifier` interface changes.

The affected test suites (`darkpool`, `verifier`) pass.

As before, updating the deploy scripts to ingest these interface changes is left for a future PR.