### PR TITLE
renegade_contracts: darkpool: align parameterize_circuit & add_circuit functions

### DIFF
--- a/src/darkpool.cairo
+++ b/src/darkpool.cairo
@@ -33,7 +33,8 @@ trait IDarkpool<TContractState> {
         verifier_class_hash: ClassHash,
         height: u8,
     );
-    fn parameterize_verifier(
+    fn add_circuit(ref self: TContractState, circuit: Circuit);
+    fn parameterize_circuit(
         ref self: TContractState, circuit: Circuit, circuit_params: CircuitParams, 
     );
     // OZ
@@ -321,16 +322,24 @@ mod Darkpool {
             _get_merkle_tree(@self).initialize(height);
         }
 
-        /// Parameterizes the verifier for a given circuit
+        /// Adds a circuit to the verifier
         /// Parameters:
-        /// - `circuit`: The circuit for which to initialize the verifier contract
+        /// - `circuit`: The circuit to add
+        fn add_circuit(ref self: ContractState, circuit: Circuit) {
+            ownable__assert_only_owner(@self);
+            _get_verifier(@self).add_circuit(circuit.into());
+        }
+
+        /// Parameterizes the given circuit within the verifier
+        /// Parameters:
+        /// - `circuit`: The circuit to parameterize
         /// - `circuit_params`: The parameters of the circuit
-        fn parameterize_verifier(
+        fn parameterize_circuit(
             ref self: ContractState, circuit: Circuit, circuit_params: CircuitParams
         ) {
             ownable__assert_only_owner(@self);
 
-            // Initialize the verifier
+            // Parameterize the circuit
             _get_verifier(@self).parameterize_circuit(circuit.into(), circuit_params);
         }
 

--- a/src/testing/tests/darkpool_tests.cairo
+++ b/src/testing/tests/darkpool_tests.cairo
@@ -260,12 +260,12 @@ fn initialize_darkpool(ref darkpool: IDarkpoolDispatcher, ) {
             TEST_MERKLE_HEIGHT,
         );
 
-    darkpool.parameterize_verifier(Circuit::ValidWalletCreate(()), get_dummy_circuit_params());
-    darkpool.parameterize_verifier(Circuit::ValidWalletUpdate(()), get_dummy_circuit_params());
-    darkpool.parameterize_verifier(Circuit::ValidCommitments(()), get_dummy_circuit_params());
-    darkpool.parameterize_verifier(Circuit::ValidReblind(()), get_dummy_circuit_params());
-    darkpool.parameterize_verifier(Circuit::ValidMatchMpc(()), get_dummy_circuit_params());
-    darkpool.parameterize_verifier(Circuit::ValidSettle(()), get_dummy_circuit_params());
+    darkpool.parameterize_circuit(Circuit::ValidWalletCreate(()), get_dummy_circuit_params());
+    darkpool.parameterize_circuit(Circuit::ValidWalletUpdate(()), get_dummy_circuit_params());
+    darkpool.parameterize_circuit(Circuit::ValidCommitments(()), get_dummy_circuit_params());
+    darkpool.parameterize_circuit(Circuit::ValidReblind(()), get_dummy_circuit_params());
+    darkpool.parameterize_circuit(Circuit::ValidMatchMpc(()), get_dummy_circuit_params());
+    darkpool.parameterize_circuit(Circuit::ValidSettle(()), get_dummy_circuit_params());
 }
 
 fn assert_not_verified(ref darkpool: IDarkpoolDispatcher, verification_job_id: felt252) {

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -312,6 +312,7 @@ fn init_test_statics(test_config: &TestConfig, sequencer: &TestSequencer) -> Res
 // | CONTRACT INTERACTION HELPERS |
 // --------------------------------
 
+pub const PARAMETERIZE_CIRCUIT_FN_NAME: &str = "parameterize_circuit";
 pub const GET_ROOT_FN_NAME: &str = "get_root";
 pub const CHECK_VERIFICATION_JOB_STATUS_FN_NAME: &str = "check_verification_job_status";
 
@@ -382,6 +383,26 @@ pub async fn check_verification_job_status(
             Some(r[1] == FieldElement::ONE)
         }
     })
+}
+
+pub async fn parameterize_circuit(
+    account: &ScriptAccount,
+    contract_address: FieldElement,
+    circuit_id: FieldElement,
+    circuit_params: CircuitParams,
+) -> Result<()> {
+    let calldata = iter::once(circuit_id)
+        .chain(circuit_params.to_calldata())
+        .collect();
+
+    invoke_contract(
+        account,
+        contract_address,
+        PARAMETERIZE_CIRCUIT_FN_NAME,
+        calldata,
+    )
+    .await
+    .map(|_| ())
 }
 
 // ----------------


### PR DESCRIPTION
This PR exposes the same function selectors (`parameterize_circuit`, `add_circuit`) on the darkpool as on the verifier.

The former is for consistency, the latter is to ensure that we can actually add circuits to the darkpool contract. However, since the function on the darkpool accepts a `Circuit` enum as a parameter instead a `circuit_id` felt, it means that in practice, adding a circuit to the darkpool would first entail upgrading the darkpool (after having added the new circuit as a variant to the enum), and then calling `add_circuit`. I think this is fine though, for the sake of readability and type safety around circuit variants.

Cairo & e2e tests pass.