### PR TITLE
renegade_contracts: darkpool, merkle: verifier & poseidon feature flags

### DIFF
--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -93,6 +93,16 @@ struct Signature {
     s: Scalar,
 }
 
+/// Represents which optional features to enable in the darkpool
+#[derive(Drop, Serde, Copy)]
+struct FeatureFlags {
+    /// Whether or not to use Poseidon over the scalar field
+    /// (the alternative is the Pedersen builtin)
+    poseidon_hash: bool,
+    /// Whether or not to verify proofs
+    verifier: bool,
+}
+
 // --------------------------
 // | CALLBACK ELEMENT TYPES |
 // --------------------------

--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -94,11 +94,10 @@ struct Signature {
 }
 
 /// Represents which optional features to enable in the darkpool
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Copy, starknet::Store)]
 struct FeatureFlags {
     /// Whether or not to use Poseidon over the scalar field
-    /// (the alternative is the Pedersen builtin)
-    poseidon_hash: bool,
+    non_native_poseidon: bool,
     /// Whether or not to verify proofs
     verifier: bool,
 }

--- a/src/darkpool/types.cairo
+++ b/src/darkpool/types.cairo
@@ -96,10 +96,10 @@ struct Signature {
 /// Represents which optional features to enable in the darkpool
 #[derive(Drop, Serde, Copy, starknet::Store)]
 struct FeatureFlags {
-    /// Whether or not to use Poseidon over the scalar field
-    non_native_poseidon: bool,
+    /// Whether or not to use Poseidon over the base field
+    use_base_field_poseidon: bool,
     /// Whether or not to verify proofs
-    verifier: bool,
+    disable_verification: bool,
 }
 
 // --------------------------

--- a/src/testing/tests/merkle_tests.cairo
+++ b/src/testing/tests/merkle_tests.cairo
@@ -50,6 +50,6 @@ fn test_multi_insert_root_history() {
 
 fn setup_merkle() -> ContractState {
     let mut merkle = Merkle::contract_state_for_testing();
-    merkle.initialize(TEST_MERKLE_HEIGHT);
+    merkle.initialize(TEST_MERKLE_HEIGHT, false);
     merkle
 }


### PR DESCRIPTION
This PR introduces an initial set of feature flags to be used in testing for the darkpool. Currently the feature flags toggle whether or not to invoke the verifier, and whether to use our implementation of poseidon hashing over the scalar field, or the native poseidon builtin.

Cairo tests have been updated to ingest these changes, and pass. Applying these changes to the e2e tests is left for the next PR.