### PR TITLE
tests: merkle, darkpool: enable feature flags in e2e tests

### DIFF
--- a/src/testing/tests/merkle_tests.cairo
+++ b/src/testing/tests/merkle_tests.cairo
@@ -1,7 +1,9 @@
 use traits::Into;
 
 
-use renegade_contracts::merkle::{Merkle, Merkle::ContractState, IMerkle};
+use renegade_contracts::{
+    merkle::{Merkle, Merkle::ContractState, IMerkle}, darkpool::types::FeatureFlags
+};
 
 
 const TEST_MERKLE_HEIGHT: u8 = 3;
@@ -50,6 +52,10 @@ fn test_multi_insert_root_history() {
 
 fn setup_merkle() -> ContractState {
     let mut merkle = Merkle::contract_state_for_testing();
-    merkle.initialize(TEST_MERKLE_HEIGHT, false);
+    merkle
+        .initialize(
+            TEST_MERKLE_HEIGHT,
+            FeatureFlags { use_base_field_poseidon: true, disable_verification: true }
+        );
     merkle
 }

--- a/starknet_scripts/src/commands/utils.rs
+++ b/starknet_scripts/src/commands/utils.rs
@@ -277,7 +277,11 @@ pub async fn deploy_darkpool(
 
     // Deploy darkpool
     debug!("Deploying darkpool contract...");
-    let calldata = vec![account.address()];
+    let calldata = vec![
+        account.address(),
+        FieldElement::ZERO, /* serialization of boolean `false` indicating that poseidon over the base field should not be used */
+        FieldElement::ZERO, /* serialization of boolean `false` indicating that the verifier should not be disabled */
+    ];
     let InvokeTransactionResult {
         transaction_hash, ..
     } = deploy(account, darkpool_class_hash_felt, &calldata).await?;

--- a/tests/src/merkle/utils.rs
+++ b/tests/src/merkle/utils.rs
@@ -7,12 +7,13 @@ use starknet::core::types::FieldElement;
 use starknet_scripts::commands::utils::{
     deploy_merkle, initialize, ScriptAccount, MERKLE_CONTRACT_NAME,
 };
-use std::env;
+use std::{env, iter};
 use tracing::debug;
 
 use crate::utils::{
     get_contract_address_from_artifact, global_setup, insert_scalar_to_ark_merkle_tree,
-    invoke_contract, setup_sequencer, TestConfig, ARTIFACTS_PATH_ENV_VAR,
+    invoke_contract, setup_sequencer, CalldataSerializable, FeatureFlags, TestConfig,
+    ARTIFACTS_PATH_ENV_VAR,
 };
 
 use super::ark_merkle::{setup_empty_tree, ScalarMerkleTree};
@@ -72,7 +73,11 @@ pub async fn initialize_merkle(
     merkle_address: FieldElement,
     merkle_height: FieldElement,
 ) -> Result<()> {
-    initialize(account, merkle_address, vec![merkle_height])
+    let calldata: Vec<FieldElement> = iter::once(merkle_height)
+        .chain(FeatureFlags::default().to_calldata())
+        .collect();
+
+    initialize(account, merkle_address, calldata)
         .await
         .map(|_| ())
 }

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -579,7 +579,15 @@ pub struct ProcessMatchArgs {
     pub valid_settle_statement: SizedValidSettleStatement,
     pub valid_settle_witness_commitments: Vec<StarkPoint>,
     pub valid_settle_proof: R1CSProof,
-    pub verification_job_ids: Vec<FieldElement>,
+    pub verification_job_id: FieldElement,
+}
+
+#[derive(Default)]
+pub struct FeatureFlags {
+    /// Whether or not to use Poseidon over the base field
+    pub use_base_field_poseidon: bool,
+    /// Whether or not to verify proofs
+    pub disable_verification: bool,
 }
 
 pub trait CalldataSerializable {
@@ -887,8 +895,17 @@ impl CalldataSerializable for ProcessMatchArgs {
             .chain(self.valid_settle_statement.to_calldata())
             .chain(self.valid_settle_witness_commitments.to_calldata())
             .chain(self.valid_settle_proof.to_calldata())
-            .chain(self.verification_job_ids.to_calldata())
+            .chain(self.verification_job_id.to_calldata())
             .collect()
+    }
+}
+
+impl CalldataSerializable for FeatureFlags {
+    fn to_calldata(&self) -> Vec<FieldElement> {
+        vec![
+            FieldElement::from(self.use_base_field_poseidon as u8),
+            FieldElement::from(self.disable_verification as u8),
+        ]
     }
 }
 


### PR DESCRIPTION
This PR updates the merkle and darkpool e2e test suites to properly enable the new feature flags.

Tests pass, as do ad-hoc tests asserting that the contracts behave as expected when the flags are disabled.