### PR TITLE
renegade_contracts: verifier: break up circuit parameterization

### DIFF
--- a/src/testing/test_utils.cairo
+++ b/src/testing/test_utils.cairo
@@ -5,7 +5,7 @@ use traits::Into;
 use ec::{ec_point_from_x, ec_mul, ec_point_new, stark_curve};
 
 use renegade_contracts::verifier::types::{
-    Proof, SparseWeightMatrix, SparseWeightVec, CircuitParams
+    Proof, SparseWeightMatrix, SparseWeightVec, CircuitParams, CircuitSizeParams
 };
 
 const DUMMY_ROOT_INNER: felt252 = 'DUMMY_ROOT';
@@ -176,16 +176,18 @@ fn get_dummy_circuit_size_params() -> (usize, usize, usize, usize, usize) {
     (n, n_plus, k, q, m)
 }
 
-fn get_dummy_circuit_pc_gens() -> (EcPoint, EcPoint) {
-    let gen = ec_point_new(stark_curve::GEN_X, stark_curve::GEN_Y);
-
-    (gen, gen)
-}
-
-fn get_dummy_circuit_params() -> CircuitParams {
+fn get_dummy_circuit_params() -> (
+    CircuitParams, CircuitParams, CircuitParams, CircuitParams, CircuitParams, CircuitParams, 
+) {
     let (n, n_plus, k, q, m) = get_dummy_circuit_size_params();
-    let (B, B_blind) = get_dummy_circuit_pc_gens();
     let (W_L, W_R, W_O, W_V, c) = get_dummy_circuit_weights();
 
-    CircuitParams { n, n_plus, k, q, m, B, B_blind, W_L, W_R, W_O, W_V, c }
+    (
+        CircuitParams::SizeParams(CircuitSizeParams { n, n_plus, k, q, m }),
+        CircuitParams::W_L(W_L),
+        CircuitParams::W_R(W_R),
+        CircuitParams::W_O(W_O),
+        CircuitParams::W_V(W_V),
+        CircuitParams::C(c),
+    )
 }

--- a/src/testing/tests/darkpool_tests.cairo
+++ b/src/testing/tests/darkpool_tests.cairo
@@ -288,12 +288,23 @@ fn initialize_darkpool(ref darkpool: IDarkpoolDispatcher) {
             Breakpoint::None,
         );
 
-    darkpool.parameterize_circuit(Circuit::ValidWalletCreate(()), get_dummy_circuit_params());
-    darkpool.parameterize_circuit(Circuit::ValidWalletUpdate(()), get_dummy_circuit_params());
-    darkpool.parameterize_circuit(Circuit::ValidCommitments(()), get_dummy_circuit_params());
-    darkpool.parameterize_circuit(Circuit::ValidReblind(()), get_dummy_circuit_params());
-    darkpool.parameterize_circuit(Circuit::ValidMatchMpc(()), get_dummy_circuit_params());
-    darkpool.parameterize_circuit(Circuit::ValidSettle(()), get_dummy_circuit_params());
+    fully_parameterize_circuit(ref darkpool, Circuit::ValidWalletCreate(()));
+    fully_parameterize_circuit(ref darkpool, Circuit::ValidWalletUpdate(()));
+    fully_parameterize_circuit(ref darkpool, Circuit::ValidCommitments(()));
+    fully_parameterize_circuit(ref darkpool, Circuit::ValidReblind(()));
+    fully_parameterize_circuit(ref darkpool, Circuit::ValidMatchMpc(()));
+    fully_parameterize_circuit(ref darkpool, Circuit::ValidSettle(()));
+}
+
+fn fully_parameterize_circuit(ref darkpool: IDarkpoolDispatcher, circuit: Circuit) {
+    let (size_params, w_l, w_r, w_o, w_v, c) = get_dummy_circuit_params();
+
+    darkpool.parameterize_circuit(circuit, size_params);
+    darkpool.parameterize_circuit(circuit, w_l);
+    darkpool.parameterize_circuit(circuit, w_r);
+    darkpool.parameterize_circuit(circuit, w_o);
+    darkpool.parameterize_circuit(circuit, w_v);
+    darkpool.parameterize_circuit(circuit, c);
 }
 
 fn assert_not_verified(ref darkpool: IDarkpoolDispatcher, verification_job_id: felt252) {

--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -111,6 +111,18 @@ mod MultiVerifier {
         W_V: LegacyMap<felt252, StoreSerdeWrapper<SparseWeightMatrix>>,
         /// Mapping from circuit ID -> sparse-reduced vector of constants for the circuit
         c: LegacyMap<felt252, StoreSerdeWrapper<SparseWeightVec>>,
+        /// Mapping from circuit ID -> boolean indicating if the circuit's size params have been set
+        size_params_set: LegacyMap<felt252, bool>,
+        /// Mapping from circuit ID -> boolean indicating if the circuit's W_L weights have been set
+        W_L_set: LegacyMap<felt252, bool>,
+        /// Mapping from circuit ID -> boolean indicating if the circuit's W_R weights have been set
+        W_R_set: LegacyMap<felt252, bool>,
+        /// Mapping from circuit ID -> boolean indicating if the circuit's W_O weights have been set
+        W_O_set: LegacyMap<felt252, bool>,
+        /// Mapping from circuit ID -> boolean indicating if the circuit's W_V weights have been set
+        W_V_set: LegacyMap<felt252, bool>,
+        /// Mapping from circuit ID -> boolean indicating if the circuit's c weights have been set
+        c_set: LegacyMap<felt252, bool>,
     }
 
     // ----------
@@ -185,41 +197,94 @@ mod MultiVerifier {
             // Assert that the circuit ID is in use
             assert(self.circuit_id_in_use.read(circuit_id), 'circuit ID not in use');
 
-            // Assert that n_plus = 2^k
+            // Assert that circuit is not already fully parameterized
             assert(
-                fast_power(2, circuit_params.k.into(), MAX_USIZE.into() + 1) == circuit_params
-                    .n_plus
-                    .into(),
-                'n_plus != 2^k'
+                !_is_circuit_fully_parameterized(@self, circuit_id), 'circuit already parameterized'
             );
 
-            // Assert that all weight matrices are have `q` rows
-            assert(circuit_params.W_L.len() == circuit_params.q, 'W_L has wrong number of rows');
-            assert(circuit_params.W_R.len() == circuit_params.q, 'W_R has wrong number of rows');
-            assert(circuit_params.W_O.len() == circuit_params.q, 'W_O has wrong number of rows');
-            assert(circuit_params.W_V.len() == circuit_params.q, 'W_V has wrong number of rows');
+            match circuit_params {
+                CircuitParams::SizeParams(circuit_size_params) => {
+                    // Assert that n_plus = 2^k
+                    assert(
+                        fast_power(
+                            2, circuit_size_params.k.into(), MAX_USIZE.into() + 1
+                        ) == circuit_size_params
+                            .n_plus
+                            .into(),
+                        'n_plus != 2^k'
+                    );
 
-            // Assert that all weight matrices have correct max number of columns
-            circuit_params.W_L.assert_width(circuit_params.n);
-            circuit_params.W_R.assert_width(circuit_params.n);
-            circuit_params.W_O.assert_width(circuit_params.n);
-            circuit_params.W_V.assert_width(circuit_params.m);
+                    self.n.write(circuit_id, circuit_size_params.n);
+                    self.n_plus.write(circuit_id, circuit_size_params.n_plus);
+                    self.k.write(circuit_id, circuit_size_params.k);
+                    self.q.write(circuit_id, circuit_size_params.q);
+                    self.m.write(circuit_id, circuit_size_params.m);
 
-            // Assert that `c` vector is not too wide
-            assert(circuit_params.c.len() <= circuit_params.q, 'c too wide');
+                    self.size_params_set.write(circuit_id, true);
+                },
+                CircuitParams::W_L(w_l) => {
+                    // Assert size params have been set
+                    assert(self.size_params_set.read(circuit_id), 'size params not set');
+                    // Assert weight matrix has `q` rows
+                    assert(w_l.len() == self.q.read(circuit_id), 'W_L has wrong number of rows');
+                    // Assert weight matrix has correct max number of columns
+                    w_l.assert_width(self.n.read(circuit_id));
 
-            self.n.write(circuit_id, circuit_params.n);
-            self.n_plus.write(circuit_id, circuit_params.n_plus);
-            self.k.write(circuit_id, circuit_params.k);
-            self.q.write(circuit_id, circuit_params.q);
-            self.m.write(circuit_id, circuit_params.m);
-            self.W_L.write(circuit_id, StoreSerdeWrapper { inner: circuit_params.W_L });
-            self.W_R.write(circuit_id, StoreSerdeWrapper { inner: circuit_params.W_R });
-            self.W_O.write(circuit_id, StoreSerdeWrapper { inner: circuit_params.W_O });
-            self.W_V.write(circuit_id, StoreSerdeWrapper { inner: circuit_params.W_V });
-            self.c.write(circuit_id, StoreSerdeWrapper { inner: circuit_params.c });
+                    self.W_L.write(circuit_id, StoreSerdeWrapper { inner: w_l });
 
-            self.emit(Event::CircuitParameterized(CircuitParameterized { circuit_id }));
+                    self.W_L_set.write(circuit_id, true);
+                },
+                CircuitParams::W_R(w_r) => {
+                    // Assert size params have been set
+                    assert(self.size_params_set.read(circuit_id), 'size params not set');
+                    // Assert weight matrix has `q` rows
+                    assert(w_r.len() == self.q.read(circuit_id), 'W_R has wrong number of rows');
+                    // Assert weight matrix has correct max number of columns
+                    w_r.assert_width(self.n.read(circuit_id));
+
+                    self.W_R.write(circuit_id, StoreSerdeWrapper { inner: w_r });
+
+                    self.W_R_set.write(circuit_id, true);
+                },
+                CircuitParams::W_O(w_o) => {
+                    // Assert size params have been set
+                    assert(self.size_params_set.read(circuit_id), 'size params not set');
+                    // Assert weight matrix has `q` rows
+                    assert(w_o.len() == self.q.read(circuit_id), 'W_O has wrong number of rows');
+                    // Assert weight matrix has correct max number of columns
+                    w_o.assert_width(self.n.read(circuit_id));
+
+                    self.W_O.write(circuit_id, StoreSerdeWrapper { inner: w_o });
+
+                    self.W_O_set.write(circuit_id, true);
+                },
+                CircuitParams::W_V(w_v) => {
+                    // Assert size params have been set
+                    assert(self.size_params_set.read(circuit_id), 'size params not set');
+                    // Assert weight matrix has `q` rows
+                    assert(w_v.len() == self.q.read(circuit_id), 'W_V has wrong number of rows');
+                    // Assert weight matrix has correct max number of columns
+                    w_v.assert_width(self.n.read(circuit_id));
+
+                    self.W_V.write(circuit_id, StoreSerdeWrapper { inner: w_v });
+
+                    self.W_V_set.write(circuit_id, true);
+                },
+                CircuitParams::C(c) => {
+                    // Assert size params have been set
+                    assert(self.size_params_set.read(circuit_id), 'size params not set');
+                    // Assert that `c` vector is not too wide
+                    assert(c.len() <= self.q.read(circuit_id), 'c too wide');
+
+                    self.c.write(circuit_id, StoreSerdeWrapper { inner: c });
+
+                    self.c_set.write(circuit_id, true);
+                },
+            };
+
+            if _is_circuit_fully_parameterized(@self, circuit_id) {
+                self.emit(Event::CircuitParameterized(CircuitParameterized { circuit_id }));
+            }
         }
 
         /// Enqueues a verification job for the given proof, squeezing out challenge scalars
@@ -238,6 +303,9 @@ mod MultiVerifier {
         ) {
             // Assert that the circuit ID is in use
             assert(self.circuit_id_in_use.read(circuit_id), 'circuit ID not in use');
+
+            // Assert that circuit is fully parameterized
+            assert(_is_circuit_fully_parameterized(@self, circuit_id), 'circuit not parameterized');
 
             // Assert that the verification job ID is not already in use
             assert(!self.job_id_in_use.read(verification_job_id), 'job ID already in use');
@@ -390,6 +458,17 @@ mod MultiVerifier {
     // -----------
     // | HELPERS |
     // -----------
+
+    fn _is_circuit_fully_parameterized(self: @ContractState, circuit_id: felt252) -> bool {
+        let size_params_set = self.size_params_set.read(circuit_id);
+        let W_L_set = self.W_L_set.read(circuit_id);
+        let W_R_set = self.W_R_set.read(circuit_id);
+        let W_O_set = self.W_O_set.read(circuit_id);
+        let W_V_set = self.W_V_set.read(circuit_id);
+        let c_set = self.c_set.read(circuit_id);
+
+        size_params_set && W_L_set && W_R_set && W_O_set && W_V_set && c_set
+    }
 
     fn prep_rem_gens(n_plus: usize) -> (RemainingGenerators, RemainingGenerators) {
         (

--- a/src/verifier/types.cairo
+++ b/src/verifier/types.cairo
@@ -479,9 +479,9 @@ impl SparseWeightMatrixImpl of SparseWeightMatrixTrait {
     }
 }
 
-/// The public parameters of the circuit
+/// The public sizing parameters of the circuit
 #[derive(Drop, Clone, Serde, PartialEq)]
-struct CircuitParams {
+struct CircuitSizeParams {
     /// The number of multiplication gates in the circuit
     n: usize,
     /// The number of multiplication gates in the circuit, padded to the next power of 2
@@ -492,10 +492,13 @@ struct CircuitParams {
     q: usize,
     /// The size of the witness
     m: usize,
-    /// Generator used for Pedersen commitments
-    B: EcPoint,
-    /// Generator used for blinding in Pedersen commitments
-    B_blind: EcPoint,
+}
+
+/// The public parameters of the circuit
+#[derive(Drop, Clone, Serde, PartialEq)]
+enum CircuitParams {
+    /// Sizing parameters for the circuit
+    SizeParams: CircuitSizeParams,
     /// Sparse-reduced matrix of left input weights for the circuit
     W_L: SparseWeightMatrix,
     /// Sparse-reduced matrix of right input weights for the circuit
@@ -505,5 +508,5 @@ struct CircuitParams {
     /// Sparse-reduced matrix of witness weights for the circuit
     W_V: SparseWeightMatrix,
     /// Sparse-reduced vector of constants for the circuit
-    c: SparseWeightVec,
+    C: SparseWeightVec,
 }

--- a/tests/src/darkpool/utils.rs
+++ b/tests/src/darkpool/utils.rs
@@ -33,13 +33,14 @@ use crate::{
         utils::TEST_MERKLE_HEIGHT,
     },
     utils::{
-        call_contract, check_verification_job_status, felt_to_u128, get_circuit_params,
-        get_contract_address_from_artifact, get_sierra_class_hash_from_artifact, global_setup,
-        invoke_contract, parameterize_circuit, random_felt, scalar_to_felt, setup_sequencer,
-        singleprover_prove, Breakpoint, CalldataSerializable, Circuit, DummyValidCommitments,
-        DummyValidMatchMpc, DummyValidReblind, DummyValidSettle, DummyValidWalletCreate,
-        DummyValidWalletUpdate, MatchPayload, NewWalletArgs, ProcessMatchArgs, TestConfig,
-        UpdateWalletArgs, ARTIFACTS_PATH_ENV_VAR, DUMMY_VALUE, SK_ROOT,
+        call_contract, check_verification_job_status, felt_to_u128, fully_parameterize_circuit,
+        get_circuit_params, get_contract_address_from_artifact,
+        get_sierra_class_hash_from_artifact, global_setup, invoke_contract, random_felt,
+        scalar_to_felt, setup_sequencer, singleprover_prove, Breakpoint, CalldataSerializable,
+        Circuit, DummyValidCommitments, DummyValidMatchMpc, DummyValidReblind, DummyValidSettle,
+        DummyValidWalletCreate, DummyValidWalletUpdate, MatchPayload, NewWalletArgs,
+        ProcessMatchArgs, TestConfig, UpdateWalletArgs, ARTIFACTS_PATH_ENV_VAR, DUMMY_VALUE,
+        SK_ROOT,
     },
 };
 
@@ -139,7 +140,7 @@ pub async fn init_darkpool_test_state() -> Result<TestSequencer> {
             Circuit::ValidSettle(_) => get_circuit_params::<DummyValidSettle>(),
         };
 
-        parameterize_circuit(
+        fully_parameterize_circuit(
             &account,
             darkpool_address,
             circuit.to_calldata()[0],

--- a/tests/src/profiling/utils.rs
+++ b/tests/src/profiling/utils.rs
@@ -44,9 +44,10 @@ use crate::{
     darkpool::utils::{initialize_darkpool, DARKPOOL_ADDRESS},
     merkle::utils::TEST_MERKLE_HEIGHT,
     utils::{
-        get_circuit_params, get_contract_address_from_artifact, global_setup, parameterize_circuit,
-        random_felt, Breakpoint, CalldataSerializable, Circuit, MatchPayload, NewWalletArgs,
-        ProcessMatchArgs, UpdateWalletArgs, ARTIFACTS_PATH_ENV_VAR, SK_ROOT, TRANSCRIPT_SEED,
+        fully_parameterize_circuit, get_circuit_params, get_contract_address_from_artifact,
+        global_setup, random_felt, Breakpoint, CalldataSerializable, Circuit, MatchPayload,
+        NewWalletArgs, ProcessMatchArgs, UpdateWalletArgs, ARTIFACTS_PATH_ENV_VAR, SK_ROOT,
+        TRANSCRIPT_SEED,
     },
 };
 
@@ -125,6 +126,8 @@ pub async fn init_profiling_test_state() -> Result<TestSequencer> {
     ]
     .into_iter()
     {
+        debug!("Parameterizing circuit {circuit}");
+
         let circuit_params = match circuit {
             Circuit::ValidWalletCreate(_) => get_circuit_params::<SizedValidWalletCreate>(),
             Circuit::ValidWalletUpdate(_) => get_circuit_params::<SizedValidWalletUpdate>(),
@@ -134,11 +137,7 @@ pub async fn init_profiling_test_state() -> Result<TestSequencer> {
             Circuit::ValidSettle(_) => get_circuit_params::<SizedValidSettle>(),
         };
 
-        debug!(
-            "Parameterizing {circuit} (n_plus = {}, q = {}, m = {})",
-            circuit_params.n_plus, circuit_params.q, circuit_params.m
-        );
-        parameterize_circuit(
+        fully_parameterize_circuit(
             &account,
             darkpool_address,
             circuit.to_calldata()[0],

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -138,6 +138,8 @@ lazy_static! {
 /// Label with which to seed the Fiat-Shamir transcript
 pub const TRANSCRIPT_SEED: &str = "merlin seed";
 
+pub const NUM_CIRCUITS: usize = 6;
+
 /// Number of bytes to represent a FieldElement
 const N_BYTES_FELT: usize = 32;
 /// Number of bytes to represent a u128
@@ -186,7 +188,7 @@ pub async fn global_setup(init_state: Option<SerializableState>) -> TestSequence
     TRACING_INIT.call_once(|| {
         fmt()
             .with_env_filter(EnvFilter::from_default_env())
-            .with_ansi(false)
+            // .with_ansi(false)
             .init();
     });
 
@@ -412,6 +414,19 @@ pub async fn parameterize_circuit(
     .map(|_| ())
 }
 
+pub async fn fully_parameterize_circuit(
+    account: &ScriptAccount,
+    contract_address: FieldElement,
+    circuit_id: FieldElement,
+    circuit_params: [CircuitParams; NUM_CIRCUITS],
+) -> Result<()> {
+    for circuit_param in circuit_params {
+        parameterize_circuit(account, contract_address, circuit_id, circuit_param).await?;
+    }
+
+    Ok(())
+}
+
 // ----------------
 // | MISC HELPERS |
 // ----------------
@@ -615,31 +630,32 @@ where
     }
 }
 
-pub struct CircuitParams {
-    /// Number of multiplication gates in the circuit
+pub struct CircuitSizeParams {
+    /// The number of multiplication gates in the circuit
     pub n: usize,
-    /// Number of multiplication gates in the circuit, padded to the next power of 2
+    /// The number of multiplication gates in the circuit, padded to the next power of 2
     pub n_plus: usize,
-    /// log2(n_plus)
+    /// log_2(n_plus)
     pub k: usize,
-    /// Number of linear constraints in the circuit
+    /// The number of linear constraints in the circuit
     pub q: usize,
-    /// Number of witness elements for the circuit
+    /// The size of the witness
     pub m: usize,
-    /// Generator for Pedersen commitments
-    pub b: StarkPoint,
-    /// Generator for blinding in Pedersen commitments
-    pub b_blind: StarkPoint,
-    /// Sparse-reduced matrix of left input weights in the circuit
-    pub w_l: SparseReducedMatrix,
-    /// Sparse-reduced matrix of right input weights in the circuit
-    pub w_r: SparseReducedMatrix,
-    /// Sparse-reduced matrix of output weights in the circuit
-    pub w_o: SparseReducedMatrix,
-    /// Sparse-reduced matrix of witness weights in the circuit
-    pub w_v: SparseReducedMatrix,
-    /// Sparse-reduced vector of constants in the circuit
-    pub c: SparseWeightRow,
+}
+
+pub enum CircuitParams {
+    /// Sizing parameters for the circuit
+    SizeParams(CircuitSizeParams),
+    /// Sparse-reduced matrix of left input weights for the circuit
+    Wl(SparseReducedMatrix),
+    /// Sparse-reduced matrix of right input weights for the circuit
+    Wr(SparseReducedMatrix),
+    /// Sparse-reduced matrix of output weights for the circuit
+    Wo(SparseReducedMatrix),
+    /// Sparse-reduced matrix of witness weights for the circuit
+    Wv(SparseReducedMatrix),
+    /// Sparse-reduced vector of constants for the circuit
+    C(SparseWeightRow),
 }
 
 pub struct NewWalletArgs {
@@ -818,19 +834,28 @@ impl CalldataSerializable for R1CSProof {
     }
 }
 
-impl CalldataSerializable for CircuitParams {
+impl CalldataSerializable for CircuitSizeParams {
     fn to_calldata(&self) -> Vec<FieldElement> {
         [self.n, self.n_plus, self.k, self.q, self.m]
-            .iter()
-            .flat_map(|s| s.to_calldata())
-            .chain([self.b, self.b_blind].iter().flat_map(|s| s.to_calldata()))
-            .chain(
-                [&self.w_l, &self.w_r, &self.w_o, &self.w_v]
-                    .iter()
-                    .flat_map(|s| s.to_calldata()),
-            )
-            .chain(self.c.to_calldata())
+            .into_iter()
+            .map(FieldElement::from)
             .collect()
+    }
+}
+
+impl CalldataSerializable for CircuitParams {
+    fn to_calldata(&self) -> Vec<FieldElement> {
+        match self {
+            CircuitParams::SizeParams(size_params) => {
+                iter::once(FieldElement::from(0_u8)).chain(size_params.to_calldata())
+            }
+            CircuitParams::Wl(w_l) => iter::once(FieldElement::from(1_u8)).chain(w_l.to_calldata()),
+            CircuitParams::Wr(w_r) => iter::once(FieldElement::from(2_u8)).chain(w_r.to_calldata()),
+            CircuitParams::Wo(w_o) => iter::once(FieldElement::from(3_u8)).chain(w_o.to_calldata()),
+            CircuitParams::Wv(w_v) => iter::once(FieldElement::from(4_u8)).chain(w_v.to_calldata()),
+            CircuitParams::C(c) => iter::once(FieldElement::from(5_u8)).chain(c.to_calldata()),
+        }
+        .collect()
     }
 }
 
@@ -1087,7 +1112,7 @@ pub fn singleprover_prove<C: SingleProverCircuit>(
 
 /// Generates circuit parameters for the given circuit
 // TODO: Upstream this into `SingleProverCircuit` trait?
-pub fn get_circuit_params<C: SingleProverCircuit>() -> CircuitParams {
+pub fn get_circuit_params<C: SingleProverCircuit>() -> [CircuitParams; NUM_CIRCUITS] {
     let mut transcript = HashChainTranscript::new(TRANSCRIPT_SEED.as_bytes());
     let pc_gens = PedersenGens::default();
     let mut prover = Prover::new(&pc_gens, &mut transcript);
@@ -1109,8 +1134,9 @@ pub fn get_circuit_params<C: SingleProverCircuit>() -> CircuitParams {
     let k = n_plus.ilog2() as usize;
     let q = prover.num_constraints();
     let m = witness.to_scalars().len() + statement.to_scalars().len();
-    let b = pc_gens.B;
-    let b_blind = pc_gens.B_blinding;
+
+    debug!("n_plus = {n_plus}, q = {q}, m = {m}",);
+
     let CircuitWeights {
         w_l,
         w_r,
@@ -1119,20 +1145,14 @@ pub fn get_circuit_params<C: SingleProverCircuit>() -> CircuitParams {
         c,
     } = prover.get_weights();
 
-    CircuitParams {
-        n,
-        n_plus,
-        k,
-        q,
-        m,
-        b,
-        b_blind,
-        w_l,
-        w_o,
-        w_r,
-        w_v,
-        c,
-    }
+    [
+        CircuitParams::SizeParams(CircuitSizeParams { n, n_plus, k, q, m }),
+        CircuitParams::Wl(w_l),
+        CircuitParams::Wr(w_r),
+        CircuitParams::Wo(w_o),
+        CircuitParams::Wv(w_v),
+        CircuitParams::C(c),
+    ]
 }
 
 /// Defines the constraints of the dummy circuits below, which takes in a single

--- a/tests/src/verifier/utils.rs
+++ b/tests/src/verifier/utils.rs
@@ -18,8 +18,9 @@ use std::{env, iter};
 use tracing::debug;
 
 use crate::utils::{
-    get_contract_address_from_artifact, global_setup, invoke_contract, parameterize_circuit,
-    Breakpoint, CalldataSerializable, CircuitParams, ARTIFACTS_PATH_ENV_VAR, TRANSCRIPT_SEED,
+    fully_parameterize_circuit, get_contract_address_from_artifact, global_setup, invoke_contract,
+    Breakpoint, CalldataSerializable, CircuitParams, CircuitSizeParams, ARTIFACTS_PATH_ENV_VAR,
+    NUM_CIRCUITS, TRANSCRIPT_SEED,
 };
 
 pub const FUZZ_ROUNDS: usize = 1;
@@ -45,7 +46,7 @@ pub async fn init_verifier_test_state() -> Result<TestSequencer> {
 
     debug!("Initializing verifier contract...");
     add_circuit(&account, verifier_address).await?;
-    parameterize_circuit(
+    fully_parameterize_circuit(
         &account,
         verifier_address,
         DUMMY_CIRCUIT_ID,
@@ -267,21 +268,20 @@ fn get_dummy_circuit_weights() -> CircuitWeights {
     prover.get_weights()
 }
 
-fn get_dummy_circuit_params() -> CircuitParams {
+fn get_dummy_circuit_params() -> [CircuitParams; NUM_CIRCUITS] {
     let circuit_weights = get_dummy_circuit_weights();
-    let pc_gens = PedersenGens::default();
-    CircuitParams {
-        n: DUMMY_CIRCUIT_N,
-        n_plus: DUMMY_CIRCUIT_N_PLUS,
-        k: DUMMY_CIRCUIT_K,
-        q: DUMMY_CIRCUIT_Q,
-        m: DUMMY_CIRCUIT_M,
-        b: pc_gens.B,
-        b_blind: pc_gens.B_blinding,
-        w_l: circuit_weights.w_l,
-        w_o: circuit_weights.w_o,
-        w_r: circuit_weights.w_r,
-        w_v: circuit_weights.w_v,
-        c: circuit_weights.c,
-    }
+    [
+        CircuitParams::SizeParams(CircuitSizeParams {
+            n: DUMMY_CIRCUIT_N,
+            n_plus: DUMMY_CIRCUIT_N_PLUS,
+            k: DUMMY_CIRCUIT_K,
+            q: DUMMY_CIRCUIT_Q,
+            m: DUMMY_CIRCUIT_M,
+        }),
+        CircuitParams::Wl(circuit_weights.w_l),
+        CircuitParams::Wr(circuit_weights.w_r),
+        CircuitParams::Wo(circuit_weights.w_o),
+        CircuitParams::Wv(circuit_weights.w_v),
+        CircuitParams::C(circuit_weights.c),
+    ]
 }

--- a/tests/tests/darkpool.rs
+++ b/tests/tests/darkpool.rs
@@ -1,3 +1,6 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
 use circuit_types::{
     balance::Balance,
     native_helpers::compute_wallet_commitment_from_private,

--- a/tests/tests/verifier.rs
+++ b/tests/tests/verifier.rs
@@ -1,3 +1,6 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
 use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;


### PR DESCRIPTION
This PR breaks apart circuit parameterization across multiple transactions, one for each of: the circuit size parameters, $W_L$, $W_R$, $W_O$, $W_V$, & $\vec{c}$. The reason for this is that circuit calldata is too big for the JSON RPC endpoint to accept in a request.

Tests have been updated and pass.