### PR TITLE
transcript: basic implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +62,123 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown",
+ "itertools",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -191,6 +319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +338,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -223,6 +366,15 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -276,6 +428,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +457,18 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "ppv-lite86"
@@ -330,6 +515,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "rand_chacha",
  "rand_core",
 ]
 
@@ -386,6 +572,18 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "renegade-contracts"
+version = "0.1.0"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "stylus-sdk",
+ "wee_alloc",
+]
 
 [[package]]
 name = "ruint"
@@ -450,14 +648,6 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
-]
-
-[[package]]
-name = "stylus-hello-world-minimal"
-version = "0.1.0"
-dependencies = [
- "stylus-sdk",
- "wee_alloc",
 ]
 
 [[package]]
@@ -614,3 +804,17 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
-name = "stylus-hello-world-minimal"
+name = "renegade-contracts"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 stylus-sdk = "0.4.1"
 wee_alloc = "0.4.5"
+ark-bn254 = "0.4.0"
+ark-ec = "0.4.0"
+ark-serialize = "0.4.0"
+ark-ff = "0.4.0"
 
 [features]
 export-abi = ["stylus-sdk/export-abi"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_main]
 #![no_std]
+
+mod transcript;
+mod types;
+
 extern crate alloc;
 
 #[global_allocator]

--- a/src/transcript/errors.rs
+++ b/src/transcript/errors.rs
@@ -1,0 +1,12 @@
+//! Transcript error types and conversions.
+
+#[derive(Debug)]
+pub enum TranscriptError {
+    SerializationError(ark_serialize::SerializationError),
+}
+
+impl From<ark_serialize::SerializationError> for TranscriptError {
+    fn from(value: ark_serialize::SerializationError) -> Self {
+        TranscriptError::SerializationError(value)
+    }
+}

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -1,0 +1,61 @@
+//! A simple hash-chain based transcript used for computing challenge values via the Fiat-Shamir transformation.
+
+mod errors;
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use ark_ff::PrimeField;
+use ark_serialize::CanonicalSerialize;
+use core::result::Result;
+use stylus_sdk::{alloy_primitives::B256, crypto::keccak};
+
+use crate::types::{G1Affine, ScalarField};
+
+use self::errors::TranscriptError;
+
+pub struct Transcript {
+    state: B256,
+}
+
+impl Transcript {
+    pub fn new(label: &[u8]) -> Self {
+        let state = keccak(label);
+        Transcript { state }
+    }
+
+    pub fn append_message(&mut self, label: &[u8], message: &[u8]) {
+        self.state = keccak([&self.state[..], label, message].concat());
+    }
+
+    pub fn append_scalar(
+        &mut self,
+        label: &[u8],
+        scalar: ScalarField,
+    ) -> Result<(), TranscriptError> {
+        // TODO: Confirm corect serialization length
+        let mut message = Vec::with_capacity(32);
+        scalar.serialize_compressed(&mut message)?;
+        self.append_message(label, &message);
+        Ok(())
+    }
+
+    pub fn append_point(&mut self, label: &[u8], point: &G1Affine) -> Result<(), TranscriptError> {
+        // TODO: Confirm corect serialization length
+        let mut message = Vec::with_capacity(32);
+        point.serialize_compressed(&mut message)?;
+        self.append_message(label, &message);
+        Ok(())
+    }
+
+    pub fn challenge_scalar(&mut self) -> ScalarField {
+        let new_state = keccak(self.state);
+
+        let challenge =
+            ScalarField::from_le_bytes_mod_order(&[&self.state[..], &new_state[..]].concat());
+
+        self.state = new_state;
+
+        challenge
+    }
+}

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -49,10 +49,11 @@ impl Transcript {
     }
 
     pub fn challenge_scalar(&mut self) -> ScalarField {
-        let new_state = keccak(self.state);
+        let intermediate_state = keccak(&self.state[..]);
+        let new_state = keccak(&intermediate_state[..]);
 
         let challenge =
-            ScalarField::from_le_bytes_mod_order(&[&self.state[..], &new_state[..]].concat());
+            ScalarField::from_le_bytes_mod_order(&[&intermediate_state, &new_state].concat());
 
         self.state = new_state;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,7 @@
+//! Common types used throughout the verifier.
+
+use ark_bn254::Bn254;
+use ark_ec::pairing::Pairing;
+
+pub type ScalarField = <Bn254 as Pairing>::ScalarField;
+pub type G1Affine = <Bn254 as Pairing>::G1Affine;


### PR DESCRIPTION
This PR introduces a basic transcript implementation similar to the hash-chain-based transcript we were using previously.

It currently exposes methods for appending arbitrary byte-encoded messages, scalar field elements, and $\mathbb{G}_1$ curve points to the transcript, as well as squeezing challenge scalars from it.

As the verifier gets built out and the transcript gets used, parts of this interface may change, e.g. higher-level methods composed from these or different types to ingest into the transcript state.

This makes use of the `stylus_sdk::keccak` function, which invokes the VM-accelerated (and cheaply-priced) Keccak implementation.

Currently no tests are implemented, as there is not exactly a reference implementation of this transcript to test against and I want to prioritize getting a first-pass of the verifier done.