### PR TITLE
verifier: define `VerificationKey` struct

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,17 @@
+//! Constants that parameterize the Plonk proof system
+
+/// The number of different wire types that can be used in the gates of the circuit.
+/// Currently, this value is 3, corresponding to the following wire types:
+/// - Left input wires
+/// - Right input wires
+/// - Output wires
+pub const NUM_WIRE_TYPES: usize = 3;
+
+/// The number of selectors used in each gate of the circuit.
+/// Currently, this value is 5, corresponding to the following selectors:
+/// - `q_L`: The selector for the left input wires
+/// - `q_R`: The selector for the right input wires
+/// - `q_O`: The selector for the output wires
+/// - `q_M`: The selector for the multiplication constraints
+/// - `q_C`: The selector for constant constraints
+pub const NUM_SELECTORS: usize = 5;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_main]
 #![no_std]
 
+mod constants;
 mod transcript;
 mod types;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,5 +3,33 @@
 use ark_bn254::Bn254;
 use ark_ec::pairing::Pairing;
 
+use crate::constants::{NUM_SELECTORS, NUM_WIRE_TYPES};
+
+// TODO: Consider using associated types of the `CurveGroup` trait instead.
+// Docs imply that arithmetic should be more efficient: https://docs.rs/ark-ec/0.4.2/ark_ec/#elliptic-curve-groups
+// Since we don't use the Arkworks implementation of EC arithmetic, nor that of pairings, use whichever is more convenient for precompiles
 pub type ScalarField = <Bn254 as Pairing>::ScalarField;
 pub type G1Affine = <Bn254 as Pairing>::G1Affine;
+pub type G2Affine = <Bn254 as Pairing>::G2Affine;
+
+/// Preprocessed information derived from the circuit definition and universal SRS
+/// used by the verifier.
+// TODO: Give these variable human-readable names once end-to-end verifier is complete
+pub struct VerificationKey {
+    /// The number of gates in the circuit
+    pub n: usize,
+    /// The number of public inputs to the circuit
+    pub l: usize,
+    /// The constants used to generate disjoint cosets of the evaluation domain
+    pub k: [ScalarField; NUM_WIRE_TYPES],
+    /// The commitments to the selector polynomials (q_*) of the circuit
+    pub selector_comms: [G1Affine; NUM_SELECTORS],
+    /// The commitments to the permutation polynomials (S_{\sigma *}) of the circuit
+    pub permutation_comms: [G1Affine; NUM_WIRE_TYPES],
+    /// The generator of the G1 group
+    pub g: G1Affine,
+    /// The generator of the G2 group
+    pub h: G2Affine,
+    /// The G2 commitment to the secret evaluation point
+    pub x_h: G2Affine,
+}


### PR DESCRIPTION
This PR introduces the `VerificationKey` struct, which is comprised of all of the pre-processed, circuit-specific information needed by the verifier to verify a proof.

I didn't include a struct representing the SRS, because the assumption is that all of the circuit preprocessing using the SRS will be done off-chain, and we'll just initialize the verifier with `VerificationKey`s for any circuits it verifies.