### PR TITLE
transcript: implement Plonk transcript protocol

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -15,3 +15,6 @@ pub const NUM_WIRE_TYPES: usize = 3;
 /// - `q_M`: The selector for the multiplication constraints
 /// - `q_C`: The selector for constant constraints
 pub const NUM_SELECTORS: usize = 5;
+
+/// The transcript has a 64 byte state size to accommodate two hash digests.
+pub const TRANSCRIPT_STATE_SIZE: usize = 64;

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -4,13 +4,13 @@ mod errors;
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
 use core::result::Result;
 use stylus_sdk::{alloy_primitives::B256, crypto::keccak};
 
-use crate::types::{G1Affine, ScalarField};
+use crate::types::{Challenges, G1Affine, Proof, ScalarField, VerificationKey};
 
 use self::errors::TranscriptError;
 
@@ -28,28 +28,19 @@ impl Transcript {
         self.state = keccak([&self.state[..], label, message].concat());
     }
 
-    pub fn append_scalar(
+    pub fn append_serializable<T: CanonicalSerialize>(
         &mut self,
         label: &[u8],
-        scalar: ScalarField,
+        message: &T,
     ) -> Result<(), TranscriptError> {
-        // TODO: Confirm corect serialization length
-        let mut message = Vec::with_capacity(32);
-        scalar.serialize_compressed(&mut message)?;
-        self.append_message(label, &message);
+        let mut bytes = Vec::new();
+        message.serialize_compressed(&mut bytes)?;
+        self.append_message(label, &bytes);
         Ok(())
     }
 
-    pub fn append_point(&mut self, label: &[u8], point: &G1Affine) -> Result<(), TranscriptError> {
-        // TODO: Confirm corect serialization length
-        let mut message = Vec::with_capacity(32);
-        point.serialize_compressed(&mut message)?;
-        self.append_message(label, &message);
-        Ok(())
-    }
-
-    pub fn challenge_scalar(&mut self) -> ScalarField {
-        let intermediate_state = keccak(&self.state[..]);
+    pub fn challenge_scalar(&mut self, label: &[u8]) -> ScalarField {
+        let intermediate_state = keccak([&self.state[..], label].concat());
         let new_state = keccak(&intermediate_state[..]);
 
         let challenge =
@@ -59,4 +50,69 @@ impl Transcript {
 
         challenge
     }
+}
+
+/// Computes all the challenges used in the Plonk protocol,
+/// given a verification key, a proof, and a set of public inputs.
+#[inline]
+pub fn compute_challenges(
+    vkey: &VerificationKey,
+    proof: &Proof,
+    public_inputs: &[ScalarField],
+) -> Result<Challenges, TranscriptError> {
+    // Initialize transcript, absorb verification key & public inputs
+    let mut transcript = Transcript::new(b"plonk proof");
+    transcript.append_serializable(b"verification key", vkey)?;
+    for (i, pi) in public_inputs.iter().enumerate() {
+        transcript.append_serializable(format!("public input {i}").as_bytes(), pi)?;
+    }
+
+    // Prover round 1: absorb wire polynomial commitments
+    for (i, wire_comm) in proof.wire_comms.iter().enumerate() {
+        transcript.append_serializable(format!("wire commitment {i}").as_bytes(), wire_comm)?;
+    }
+
+    // Prover round 2: squeeze beta & gamma challenges, absorb grand product polynomial commitment
+    let beta = transcript.challenge_scalar(b"beta");
+    let gamma = transcript.challenge_scalar(b"gamma");
+    transcript.append_serializable(b"grand product commitment", &proof.grand_product_comm)?;
+
+    // Prover round 3: squeeze alpha challenge, absorb split quotient polynomial commitments
+    let alpha = transcript.challenge_scalar(b"alpha");
+    for (i, split_quotient_comm) in proof.split_quotient_comms.iter().enumerate() {
+        transcript.append_serializable(
+            format!("split quotient commitment {i}").as_bytes(),
+            split_quotient_comm,
+        )?;
+    }
+
+    // Prover round 4: squeeze zeta challenge, absorb wire, permutation, and grand product polynomial evaluations
+    let zeta = transcript.challenge_scalar(b"zeta");
+    for (i, wire_eval) in proof.wire_evals.iter().enumerate() {
+        transcript.append_serializable(format!("wire evaluation {i}").as_bytes(), wire_eval)?;
+    }
+    for (i, permutation_eval) in proof.permutation_evals.iter().enumerate() {
+        transcript.append_serializable(
+            format!("permutation evaluation {i}").as_bytes(),
+            permutation_eval,
+        )?;
+    }
+    transcript.append_serializable(b"grand product evaluation", &proof.grand_product_eval)?;
+
+    // Prover round 5: squeeze v challenge, absorb opening proofs
+    let v = transcript.challenge_scalar(b"v");
+    transcript.append_serializable(b"opening proof", &proof.opening_proof)?;
+    transcript.append_serializable(b"shifted opening proof", &proof.shifted_opening_proof)?;
+
+    // Squeeze u challenge
+    let u = transcript.challenge_scalar(b"u");
+
+    Ok(Challenges {
+        beta,
+        gamma,
+        alpha,
+        zeta,
+        v,
+        u,
+    })
 }

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -1,111 +1,118 @@
-//! A simple hash-chain based transcript used for computing challenge values via the Fiat-Shamir transformation.
+//! A simple transcript used for computing challenge values via the Fiat-Shamir transformation.
 
 mod errors;
 
 extern crate alloc;
 
-use alloc::{format, vec::Vec};
+use alloc::vec::Vec;
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
 use core::result::Result;
-use stylus_sdk::{alloy_primitives::B256, crypto::keccak};
+use stylus_sdk::crypto::keccak;
 
-use crate::types::{Challenges, G1Affine, Proof, ScalarField, VerificationKey};
+use crate::{
+    constants::TRANSCRIPT_STATE_SIZE,
+    types::{Challenges, Proof, ScalarField, VerificationKey},
+};
 
 use self::errors::TranscriptError;
 
+/// The transcript state, containing a byte-serialized transcript of prover-verifier communications
+/// and the current state of the Keccak-256 hash used for generating public coin challenges.
 pub struct Transcript {
-    state: B256,
+    transcript: Vec<u8>,
+    state: [u8; TRANSCRIPT_STATE_SIZE],
 }
 
 impl Transcript {
-    pub fn new(label: &[u8]) -> Self {
-        let state = keccak(label);
-        Transcript { state }
+    /// Creates an empty transcript with a zeroed-out hash state.
+    pub fn new() -> Self {
+        Transcript {
+            transcript: Vec::new(),
+            state: [0u8; TRANSCRIPT_STATE_SIZE],
+        }
     }
 
-    pub fn append_message(&mut self, label: &[u8], message: &[u8]) {
-        self.state = keccak([&self.state[..], label, message].concat());
+    /// Appends a message to the transcript.
+    pub fn append_message(&mut self, message: &[u8]) {
+        self.transcript.extend_from_slice(message);
     }
 
     pub fn append_serializable<T: CanonicalSerialize>(
         &mut self,
-        label: &[u8],
         message: &T,
     ) -> Result<(), TranscriptError> {
         let mut bytes = Vec::new();
         message.serialize_compressed(&mut bytes)?;
-        self.append_message(label, &bytes);
+        self.append_message(&bytes);
         Ok(())
     }
 
-    pub fn challenge_scalar(&mut self, label: &[u8]) -> ScalarField {
-        let intermediate_state = keccak([&self.state[..], label].concat());
-        let new_state = keccak(&intermediate_state[..]);
+    pub fn get_and_append_challenge(&mut self) -> ScalarField {
+        let input0 = [self.state.as_ref(), self.transcript.as_ref(), &[0u8]].concat();
+        let input1 = [self.state.as_ref(), self.transcript.as_ref(), &[1u8]].concat();
 
-        let challenge =
-            ScalarField::from_le_bytes_mod_order(&[&intermediate_state, &new_state].concat());
+        let buf0 = keccak(&input0);
+        let buf1 = keccak(&input1);
 
-        self.state = new_state;
+        self.state.copy_from_slice(&[buf0, buf1].concat());
 
+        let challenge = ScalarField::from_le_bytes_mod_order(&self.state[..48]);
         challenge
     }
 }
 
 /// Computes all the challenges used in the Plonk protocol,
 /// given a verification key, a proof, and a set of public inputs.
-#[inline]
 pub fn compute_challenges(
     vkey: &VerificationKey,
     proof: &Proof,
     public_inputs: &[ScalarField],
+    extra_transcript_init_msg: &Option<Vec<u8>>,
 ) -> Result<Challenges, TranscriptError> {
     // Initialize transcript, absorb verification key & public inputs
-    let mut transcript = Transcript::new(b"plonk proof");
-    transcript.append_serializable(b"verification key", vkey)?;
-    for (i, pi) in public_inputs.iter().enumerate() {
-        transcript.append_serializable(format!("public input {i}").as_bytes(), pi)?;
+    let mut transcript = Transcript::new();
+    if let Some(msg) = extra_transcript_init_msg {
+        transcript.append_message(msg);
+    }
+    transcript.append_message(&ScalarField::MODULUS_BIT_SIZE.to_le_bytes());
+    transcript.append_message(&vkey.n.to_le_bytes());
+    transcript.append_message(&vkey.l.to_le_bytes());
+    transcript.append_serializable(&vkey.k)?;
+    transcript.append_serializable(&vkey.selector_comms)?;
+    transcript.append_serializable(&vkey.permutation_comms)?;
+    for pi in public_inputs.iter() {
+        transcript.append_serializable(pi)?;
     }
 
     // Prover round 1: absorb wire polynomial commitments
-    for (i, wire_comm) in proof.wire_comms.iter().enumerate() {
-        transcript.append_serializable(format!("wire commitment {i}").as_bytes(), wire_comm)?;
-    }
+    transcript.append_serializable(&proof.wire_comms)?;
+    // Here, for consistency with the Jellyfish implementation, we squeeze an unused challenge
+    // `tau`, which would be used for Plookup
+    transcript.get_and_append_challenge();
 
     // Prover round 2: squeeze beta & gamma challenges, absorb grand product polynomial commitment
-    let beta = transcript.challenge_scalar(b"beta");
-    let gamma = transcript.challenge_scalar(b"gamma");
-    transcript.append_serializable(b"grand product commitment", &proof.grand_product_comm)?;
+    let beta = transcript.get_and_append_challenge();
+    let gamma = transcript.get_and_append_challenge();
+    transcript.append_serializable(&proof.grand_product_comm)?;
 
     // Prover round 3: squeeze alpha challenge, absorb split quotient polynomial commitments
-    let alpha = transcript.challenge_scalar(b"alpha");
-    for (i, split_quotient_comm) in proof.split_quotient_comms.iter().enumerate() {
-        transcript.append_serializable(
-            format!("split quotient commitment {i}").as_bytes(),
-            split_quotient_comm,
-        )?;
-    }
+    let alpha = transcript.get_and_append_challenge();
+    transcript.append_serializable(&proof.split_quotient_comms)?;
 
     // Prover round 4: squeeze zeta challenge, absorb wire, permutation, and grand product polynomial evaluations
-    let zeta = transcript.challenge_scalar(b"zeta");
-    for (i, wire_eval) in proof.wire_evals.iter().enumerate() {
-        transcript.append_serializable(format!("wire evaluation {i}").as_bytes(), wire_eval)?;
-    }
-    for (i, permutation_eval) in proof.permutation_evals.iter().enumerate() {
-        transcript.append_serializable(
-            format!("permutation evaluation {i}").as_bytes(),
-            permutation_eval,
-        )?;
-    }
-    transcript.append_serializable(b"grand product evaluation", &proof.grand_product_eval)?;
+    let zeta = transcript.get_and_append_challenge();
+    transcript.append_serializable(&proof.wire_evals)?;
+    transcript.append_serializable(&proof.permutation_evals)?;
+    transcript.append_serializable(&proof.grand_product_eval)?;
 
     // Prover round 5: squeeze v challenge, absorb opening proofs
-    let v = transcript.challenge_scalar(b"v");
-    transcript.append_serializable(b"opening proof", &proof.opening_proof)?;
-    transcript.append_serializable(b"shifted opening proof", &proof.shifted_opening_proof)?;
+    let v = transcript.get_and_append_challenge();
+    transcript.append_serializable(&proof.opening_proof)?;
+    transcript.append_serializable(&proof.shifted_opening_proof)?;
 
     // Squeeze u challenge
-    let u = transcript.challenge_scalar(b"u");
+    let u = transcript.get_and_append_challenge();
 
     Ok(Challenges {
         beta,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@
 
 use ark_bn254::Bn254;
 use ark_ec::pairing::Pairing;
+use ark_serialize::CanonicalSerialize;
 
 use crate::constants::{NUM_SELECTORS, NUM_WIRE_TYPES};
 
@@ -15,6 +16,7 @@ pub type G2Affine = <Bn254 as Pairing>::G2Affine;
 /// Preprocessed information derived from the circuit definition and universal SRS
 /// used by the verifier.
 // TODO: Give these variable human-readable names once end-to-end verifier is complete
+#[derive(CanonicalSerialize)]
 pub struct VerificationKey {
     /// The number of gates in the circuit
     pub n: usize,
@@ -53,4 +55,20 @@ pub struct Proof {
     pub permutation_evals: [ScalarField; NUM_WIRE_TYPES - 1],
     /// The evaluation of the grand product polynomial at the challenge point `zeta * omega` (i.e. \bar{z})
     pub grand_product_eval: ScalarField,
+}
+
+/// The public coin challenges used throughout the Plonk protocol, obtained via a Fiat-Shamir transformation.
+pub struct Challenges {
+    /// The first permutation challenge, used in round 2 of the prover algorithm
+    pub beta: ScalarField,
+    /// The second permutation challenge, used in round 2 of the prover algorithm
+    pub gamma: ScalarField,
+    /// The quotient challenge, used in round 3 of the prover algorithm
+    pub alpha: ScalarField,
+    /// The evaluation challenge, used in round 4 of the prover algorithm
+    pub zeta: ScalarField,
+    /// The opening challenge, used in round 5 of the prover algorithm
+    pub v: ScalarField,
+    /// The multipoint evaluation challenge, generated at the end of round 5 of the prover algorithm
+    pub u: ScalarField,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,6 @@
 
 use ark_bn254::Bn254;
 use ark_ec::pairing::Pairing;
-use ark_serialize::CanonicalSerialize;
 
 use crate::constants::{NUM_SELECTORS, NUM_WIRE_TYPES};
 
@@ -16,7 +15,6 @@ pub type G2Affine = <Bn254 as Pairing>::G2Affine;
 /// Preprocessed information derived from the circuit definition and universal SRS
 /// used by the verifier.
 // TODO: Give these variable human-readable names once end-to-end verifier is complete
-#[derive(CanonicalSerialize)]
 pub struct VerificationKey {
     /// The number of gates in the circuit
     pub n: usize,


### PR DESCRIPTION
This PR implements the Plonk transcript protocol, i.e. a single method `compute_challenges` which computes all the challenge values used throughout Plonk for a given circuit + proof.

The ordering of elements absorbed / squeezed is taken from https://github.com/EspressoSystems/jellyfish/blob/main/plonk/src/proof_system/verifier.rs#L260