### PR TITLE
verifier, types: initialize Verifier smart contract

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,4 +5,10 @@ target = "wasm32-unknown-unknown"
 rustflags = [
   "-C", "link-arg=-zstack-size=32768",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
     

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock -diff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
+ "ark-poly",
  "ark-serialize",
  "stylus-sdk",
  "wee_alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,21 @@ ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
 ark-serialize = "0.4.0"
 ark-ff = "0.4.0"
+ark-poly = "0.4.0"
 
 [features]
 export-abi = ["stylus-sdk/export-abi"]
 
 [profile.release]
-codegen-units = 1
-strip = true
-lto = true
-panic = "abort"
-opt-level = "s"
+codegen-units = 1        # prefer efficiency to compile time
+panic = "abort"          # use simple panics
+opt-level = "z"          # optimize for size ("s" may also work)
+strip = true             # remove debug info
+lto = true               # link time optimization
+debug = false            # no debug data
+rpath = false            # no run-time search path
+debug-assertions = false # prune debug assertions
+incremental = false      # no incremental builds
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,9 @@
 mod constants;
 mod transcript;
 mod types;
+mod verifier;
 
 extern crate alloc;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
-use alloc::vec::Vec;
-
-use stylus_sdk::stylus_proc::entrypoint;
-
-#[entrypoint]
-fn user_main(input: Vec<u8>) -> Result<Vec<u8>, Vec<u8>> {
-    Ok(input)
-}

--- a/src/transcript/errors.rs
+++ b/src/transcript/errors.rs
@@ -1,12 +1,14 @@
 //! Transcript error types and conversions.
 
+/// Errors stemming from transcript operations
 #[derive(Debug)]
 pub enum TranscriptError {
-    SerializationError(ark_serialize::SerializationError),
+    /// An error that occured while serializing a value into the transcript
+    Serialization,
 }
 
 impl From<ark_serialize::SerializationError> for TranscriptError {
-    fn from(value: ark_serialize::SerializationError) -> Self {
-        TranscriptError::SerializationError(value)
+    fn from(_value: ark_serialize::SerializationError) -> Self {
+        TranscriptError::Serialization
     }
 }

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -1,0 +1,23 @@
+//! Errors stemming from conversions between types used throughout the system.
+
+use stylus_sdk::alloy_primitives::ruint::FromUintError;
+
+/// Errors stemming from working with Solidity-ABI-compatible storage types
+pub enum StorageError {
+    /// An error that occurred while converting between a Solidity-ABI-compatible storage type and a Rust type
+    TypeConversion,
+    /// An error that occurred while serializing Rust types before conversion, or deserializing after conversion
+    Serialization,
+}
+
+impl<T> From<FromUintError<T>> for StorageError {
+    fn from(_value: FromUintError<T>) -> Self {
+        StorageError::TypeConversion
+    }
+}
+
+impl From<ark_serialize::SerializationError> for StorageError {
+    fn from(_value: ark_serialize::SerializationError) -> Self {
+        StorageError::Serialization
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,5 +1,8 @@
 //! Common types used throughout the verifier.
 
+mod errors;
+pub mod solidity_types;
+
 use ark_bn254::Bn254;
 use ark_ec::pairing::Pairing;
 
@@ -17,9 +20,9 @@ pub type G2Affine = <Bn254 as Pairing>::G2Affine;
 // TODO: Give these variable human-readable names once end-to-end verifier is complete
 pub struct VerificationKey {
     /// The number of gates in the circuit
-    pub n: usize,
+    pub n: u64,
     /// The number of public inputs to the circuit
-    pub l: usize,
+    pub l: u64,
     /// The constants used to generate disjoint cosets of the evaluation domain
     pub k: [ScalarField; NUM_WIRE_TYPES],
     /// The commitments to the selector polynomials (q_*) of the circuit

--- a/src/types/solidity_types.rs
+++ b/src/types/solidity_types.rs
@@ -1,0 +1,78 @@
+//! Solidity-ABI-compatible analogues of other types used throughout the Plonk proof system,
+//! along with their conversion to and from the corresponding Rust types.
+//! For Arkworks types (e.g. `ScalarField` and `G1Affine`), we represent them with Solidity `bytes` types
+//! for straightforward usage of `CanonicalSerialize` and `CanonicalDeserialize`.
+
+use alloc::vec::Vec;
+use ark_serialize::CanonicalDeserialize;
+use core::result::Result;
+use stylus_sdk::{
+    storage::{StorageArray, StorageBytes, StorageU64},
+    stylus_proc::solidity_storage,
+};
+
+use crate::{
+    constants::{NUM_SELECTORS, NUM_WIRE_TYPES},
+    types::G1Affine,
+};
+
+use super::{errors::StorageError, G2Affine, ScalarField, VerificationKey};
+
+fn deserialize_storage_bytes_array<T: CanonicalDeserialize, const N: usize>(
+    storage_array: &StorageArray<StorageBytes, N>,
+) -> Result<[T; N], StorageError> {
+    (0..N)
+        .map(|i| {
+            let array_i_bytes = storage_array.get(i).ok_or(StorageError::TypeConversion)?;
+            T::deserialize_uncompressed_unchecked(array_i_bytes.get_bytes().as_slice())
+                .map_err(|_| StorageError::Serialization)
+        })
+        .collect::<Result<Vec<T>, StorageError>>()?
+        .try_into()
+        .map_err(|_| StorageError::Serialization)
+}
+
+/// A Solidity-ABI-compatible analogue of [`VerificationKey`].
+/// See [`VerificationKey`] for more details.
+#[solidity_storage]
+pub struct StorageVerificationKey {
+    pub n: StorageU64,
+    pub l: StorageU64,
+    pub k: StorageArray<StorageBytes, NUM_WIRE_TYPES>,
+    pub selector_comms: StorageArray<StorageBytes, NUM_SELECTORS>,
+    pub permutation_comms: StorageArray<StorageBytes, NUM_WIRE_TYPES>,
+    pub g: StorageBytes,
+    pub h: StorageBytes,
+    pub x_h: StorageBytes,
+}
+
+impl TryFrom<StorageVerificationKey> for VerificationKey {
+    type Error = StorageError;
+
+    fn try_from(value: StorageVerificationKey) -> Result<Self, StorageError> {
+        let n: u64 = (*value.n).try_into()?;
+        let l: u64 = (*value.l).try_into()?;
+        let k: [ScalarField; NUM_WIRE_TYPES] = deserialize_storage_bytes_array(&value.k)?;
+        let selector_comms: [G1Affine; NUM_SELECTORS] =
+            deserialize_storage_bytes_array(&value.selector_comms)?;
+        let permutation_comms: [G1Affine; NUM_WIRE_TYPES] =
+            deserialize_storage_bytes_array(&value.permutation_comms)?;
+        let g: G1Affine =
+            G1Affine::deserialize_compressed_unchecked(value.g.get_bytes().as_slice())?;
+        let h: G2Affine =
+            G2Affine::deserialize_compressed_unchecked(value.h.get_bytes().as_slice())?;
+        let x_h: G2Affine =
+            G2Affine::deserialize_compressed_unchecked(value.x_h.get_bytes().as_slice())?;
+
+        Ok(VerificationKey {
+            n,
+            l,
+            k,
+            selector_comms,
+            permutation_comms,
+            g,
+            h,
+            x_h,
+        })
+    }
+}

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -1,0 +1,15 @@
+//! The verifier smart contract, responsible for verifying Plonk proofs.
+
+use stylus_sdk::prelude::*;
+
+use crate::types::solidity_types::StorageVerificationKey;
+
+#[solidity_storage]
+#[entrypoint]
+struct Verifier {
+    /// The verification key for the circuit
+    vkey: StorageVerificationKey,
+}
+
+#[external]
+impl Verifier {}


### PR DESCRIPTION
This PR defines a smart contract for the verifier, including a Solidity ABI-compatible type for the `VerificationKey` that can be kept in contract storage.