### PR TITLE
contracts-core: simplify serde using arkworks patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,8 +237,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+source = "git+https://github.com/renegade-fi/algebra.git?branch=bin-opt-feature#e28d6efd1460eb76b142a97ef09cfb2921eb976f"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
@@ -258,8 +257,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+source = "git+https://github.com/renegade-fi/algebra.git?branch=bin-opt-feature#e28d6efd1460eb76b142a97ef09cfb2921eb976f"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -268,8 +266,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+source = "git+https://github.com/renegade-fi/algebra.git?branch=bin-opt-feature#e28d6efd1460eb76b142a97ef09cfb2921eb976f"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -349,8 +346,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+source = "git+https://github.com/renegade-fi/algebra.git?branch=bin-opt-feature#e28d6efd1460eb76b142a97ef09cfb2921eb976f"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
@@ -361,8 +357,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+source = "git+https://github.com/renegade-fi/algebra.git?branch=bin-opt-feature#e28d6efd1460eb76b142a97ef09cfb2921eb976f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -799,6 +794,8 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "byteorder",
  "jf-plonk",
  "jf-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ members = ["contracts-stylus", "contracts-core", "integration"]
 [workspace.dependencies]
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
-ark-ff = "0.4.0"
+ark-ff = { version = "0.4.0", features = ["bin-opt"] }
 ark-poly = "0.4.0"
+ark-std = "0.4.0"
+ark-serialize = "0.4.0"
 
 [profile.release]
 codegen-units = 1        # prefer efficiency to compile time
@@ -17,3 +19,16 @@ debug = false            # no debug data
 rpath = false            # no run-time search path
 debug-assertions = false # prune debug assertions
 incremental = false      # no incremental builds
+
+[profile.dev]
+codegen-units = 1   # prefer efficiency to compile time
+panic = "abort"     # use simple panics
+opt-level = "z"     # optimize for size ("s" may also work)
+lto = true          # link time optimization
+rpath = false       # no run-time search path
+incremental = false # no incremental builds
+
+
+[patch.crates-io]
+ark-ff = { git = "https://github.com/renegade-fi/algebra.git", branch = "bin-opt-feature" }
+ark-serialize = { git = "https://github.com/renegade-fi/algebra.git", branch = "bin-opt-feature" }

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -8,9 +8,11 @@ ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-poly = { workspace = true }
+ark-serialize = { workspace = true }
 num-bigint = { version = "0.4", default-features = false }
 
 [dev-dependencies]
+ark-std = { workspace = true }
 sha3 = { version = "^0.10", default-features = false }
 jf-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", features = [
     "test-srs",

--- a/contracts-core/src/constants.rs
+++ b/contracts-core/src/constants.rs
@@ -15,3 +15,9 @@ pub const HASH_OUTPUT_SIZE: usize = 32;
 /// The number of bytes to represent field elements of the base or scalar fields for the G1 curve group,
 /// as well as the base field which is extended for the G2 curve group
 pub const FELT_BYTES: usize = 32;
+
+/// The number of u64s it takes to represent a field element
+pub const NUM_U64S_FELT: usize = 4;
+
+/// The number of public inputs in the verifier testing circuit
+pub const NUM_PUBLIC_INPUTS: usize = 0;

--- a/contracts-core/src/types/mod.rs
+++ b/contracts-core/src/types/mod.rs
@@ -1,9 +1,12 @@
 //! Common types used throughout the verifier.
 
-use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fr};
+use alloc::vec::Vec;
+use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fr};
 use ark_ec::short_weierstrass::Affine;
+use ark_ff::{Fp256, MontBackend};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
-use crate::constants::{NUM_SELECTORS, NUM_WIRE_TYPES};
+use crate::constants::{NUM_SELECTORS, NUM_U64S_FELT, NUM_WIRE_TYPES};
 
 // TODO: Consider using associated types of the `CurveGroup` trait instead.
 // Docs imply that arithmetic should be more efficient: https://docs.rs/ark-ec/0.4.2/ark_ec/#elliptic-curve-groups
@@ -11,11 +14,14 @@ use crate::constants::{NUM_SELECTORS, NUM_WIRE_TYPES};
 pub type ScalarField = Fr;
 pub type G1Affine = Affine<G1Config>;
 pub type G2Affine = Affine<G2Config>;
+pub type G1BaseField = Fq;
+pub type G2BaseField = Fq2;
+pub type MontFp256<P> = Fp256<MontBackend<P, NUM_U64S_FELT>>;
 
 /// Preprocessed information derived from the circuit definition and universal SRS
 /// used by the verifier.
 // TODO: Give these variable human-readable names once end-to-end verifier is complete
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerificationKey {
     /// The number of gates in the circuit
     pub n: u64,
@@ -36,7 +42,7 @@ pub struct VerificationKey {
 }
 
 /// A Plonk proof, using the "fast prover" strategy described in the paper.
-#[derive(Default)]
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof {
     /// The commitments to the wire polynomials
     pub wire_comms: [G1Affine; NUM_WIRE_TYPES],

--- a/contracts-stylus/src/utils.rs
+++ b/contracts-stylus/src/utils.rs
@@ -1,10 +1,7 @@
 //! Common utilities used throughout the smart contracts, including testing contracts.
 
 use contracts_core::{
-    serde::{
-        Deserializable, PrecompileG1, PrecompileG2, PrecompileScalar,
-        Serializable,
-    },
+    serde::{Deserializable, Serializable},
     types::{G1Affine, G2Affine, ScalarField},
     verifier::{errors::VerifierError, G1ArithmeticBackend},
 };
@@ -27,8 +24,8 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
     /// Calls the `ecAdd` precompile with the given points, handling de/serialization
     fn ec_add(&mut self, a: G1Affine, b: G1Affine) -> Result<G1Affine, VerifierError> {
         // Serialize the points
-        let a_data = PrecompileG1(a).serialize();
-        let b_data = PrecompileG1(b).serialize();
+        let a_data = a.serialize();
+        let b_data = b.serialize();
 
         // Call the `ecAdd` precompile
         let res_xy_bytes = static_call(
@@ -39,14 +36,14 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Deserialize the affine coordinates returned from the precompile
-        Ok(PrecompileG1::deserialize(&res_xy_bytes).0)
+        G1Affine::deserialize(&res_xy_bytes).map_err(|_| VerifierError::ArithmeticBackend)
     }
 
     /// Calls the `ecMul` precompile with the given scalar and point, handling de/serialization
     fn ec_scalar_mul(&mut self, a: ScalarField, b: G1Affine) -> Result<G1Affine, VerifierError> {
         // Serialize the point and scalar
-        let a_data = PrecompileScalar(a).serialize();
-        let b_data = PrecompileG1(b).serialize();
+        let a_data = a.serialize();
+        let b_data = b.serialize();
 
         // Call the `ecMul` precompile
         let res_xy_bytes = static_call(
@@ -57,7 +54,7 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Deserialize the affine coordinates returned from the precompile
-        Ok(PrecompileG1::deserialize(&res_xy_bytes).0)
+        G1Affine::deserialize(&res_xy_bytes).map_err(|_| VerifierError::ArithmeticBackend)
     }
 
     /// Calls the `ecPairing` precompile with the given points, handling de/serialization
@@ -69,10 +66,10 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         b_2: G2Affine,
     ) -> Result<bool, VerifierError> {
         // Serialize the points
-        let a_1_data = PrecompileG1(a_1).serialize();
-        let b_1_data = PrecompileG2(b_1).serialize();
-        let a_2_data = PrecompileG1(a_2).serialize();
-        let b_2_data = PrecompileG2(b_2).serialize();
+        let a_1_data = a_1.serialize();
+        let b_1_data = b_1.serialize();
+        let a_2_data = a_2.serialize();
+        let b_2_data = b_2.serialize();
 
         // Call the `ecPairing` precompile
         let res = static_call(

--- a/contracts-stylus/src/verifier.rs
+++ b/contracts-stylus/src/verifier.rs
@@ -2,42 +2,38 @@
 
 use alloc::vec::Vec;
 use contracts_core::{
+    constants::NUM_PUBLIC_INPUTS,
     serde::Deserializable,
     types::{Proof, ScalarField, VerificationKey},
     verifier::Verifier,
 };
-use stylus_sdk::{abi::Bytes, prelude::*, storage::StorageBytes};
+use stylus_sdk::{abi::Bytes, prelude::*};
 
 use crate::{transcript::StylusHasher, utils::EvmPrecompileBackend};
 
 #[solidity_storage]
 #[entrypoint]
-struct VerifierContract {
-    /// The serialized verification key for the circuit
-    vkey: StorageBytes,
-}
+struct VerifierContract {}
 
 #[external]
 impl VerifierContract {
-    /// Initialize the verification key for the circuit
-    pub fn init_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
-        // TODO: Validate well-formedness of the verification key
-        self.vkey.set_bytes(&vkey);
-        Ok(())
-    }
-
     /// Verify the given proof, using the given public inputs and the stored verification key
-    pub fn verify(&mut self, proof: Bytes, public_inputs: Bytes) -> Result<bool, Vec<u8>> {
-        let vkey_bytes = self.vkey.get_bytes();
-        let vkey: VerificationKey = Deserializable::deserialize(vkey_bytes.as_slice());
+    pub fn verify(
+        &mut self,
+        vkey: Bytes,
+        proof: Bytes,
+        public_inputs: Bytes,
+    ) -> Result<bool, Vec<u8>> {
+        let vkey: VerificationKey = Deserializable::deserialize(vkey.as_slice()).unwrap();
 
         let backend = EvmPrecompileBackend { contract: self };
 
         let mut verifier = Verifier::<EvmPrecompileBackend<_>, StylusHasher>::new(vkey, backend);
 
-        let proof: Proof = Deserializable::deserialize(proof.as_slice());
+        let proof: Proof = Deserializable::deserialize(proof.as_slice()).unwrap();
 
-        let public_inputs: Vec<ScalarField> = Deserializable::deserialize(public_inputs.as_slice());
+        let public_inputs: [ScalarField; NUM_PUBLIC_INPUTS] =
+            Deserializable::deserialize(public_inputs.as_slice()).unwrap();
 
         Ok(verifier.verify(&proof, &public_inputs, &None).unwrap())
     }


### PR DESCRIPTION
This PR simplifies the `Serializable` and `Deserializable` trait implementations after patching Arkworks with a [fork](https://github.com/renegade-fi/algebra/tree/bin-opt-feature) that removes all inlining and loop unrolling (if the `bin-opt` feature is enabled)