### PR TITLE
contracts-stylus: add verification to darkpool, set up tests through wrapper contract

### DIFF
--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -16,6 +16,7 @@ ark-std = { version = "0.4.0", optional = true }
 [features]
 darkpool = []
 verifier = []
+darkpool-test-contract = []
 precompile-test-contract = ["dep:ark-std"]
 export-abi = ["stylus-sdk/export-abi"]
 

--- a/contracts-stylus/src/darkpool.rs
+++ b/contracts-stylus/src/darkpool.rs
@@ -3,30 +3,82 @@
 
 use alloc::vec::Vec;
 use stylus_sdk::{
-    alloy_primitives::aliases::B256,
+    abi::Bytes,
+    alloy_primitives::{aliases::B256, Address},
     prelude::*,
-    storage::{StorageBool, StorageMap},
+    storage::{StorageAddress, StorageBool, StorageBytes, StorageMap},
 };
 
+use crate::interfaces::IVerifier;
+
 #[solidity_storage]
-#[entrypoint]
-struct DarkpoolContract {
+#[cfg_attr(feature = "darkpool", entrypoint)]
+pub struct DarkpoolContract {
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
     /// boolean indicating whether or not the nullifier is spent
     nullifier_set: StorageMap<B256, StorageBool>,
+
+    /// The set of verification keys, representing a mapping from a circuit id
+    /// to a serialized verification key
+    verification_keys: StorageMap<u8, StorageBytes>,
+
+    /// The address of the verifier contract
+    verifier_address: StorageAddress,
 }
 
 #[external]
 impl DarkpoolContract {
+    /// Stores the given address for the verifier contract
+    pub fn set_verifier_address(&mut self, address: Address) -> Result<(), Vec<u8>> {
+        self.verifier_address.set(address);
+        Ok(())
+    }
+
+    /// Stores the given verification key with the given circuit id
+    pub fn add_verification_key(&mut self, circuit_id: u8, vkey: Bytes) -> Result<(), Vec<u8>> {
+        // TODO: Assert well-formedness of the verification key
+        assert!(
+            self.verification_keys.get(circuit_id).is_empty(),
+            "Verification key ID in use"
+        );
+
+        let mut slot = self.verification_keys.setter(circuit_id);
+        slot.set_bytes(vkey);
+
+        Ok(())
+    }
+
     /// Checks whether the given nullifier is spent
     pub fn is_nullifier_spent(&self, nullifier: B256) -> Result<bool, Vec<u8>> {
         Ok(self.nullifier_set.get(nullifier))
     }
+}
 
+/// Internal helper methods
+impl DarkpoolContract {
     /// Marks the given nullifier as spent
     pub fn mark_nullifier_spent(&mut self, nullifier: B256) -> Result<(), Vec<u8>> {
         self.nullifier_set.insert(nullifier, true);
         Ok(())
+    }
+
+    /// Verifies the given proof using the given public inputs,
+    /// and using the stored verification key associated with the circuit id
+    pub fn verify(
+        &mut self,
+        circuit_id: u8,
+        proof: Bytes,
+        public_inputs: Bytes,
+    ) -> Result<bool, Vec<u8>> {
+        let verifier = IVerifier::new(self.verifier_address.get());
+        let vkey_bytes = self.verification_keys.get(circuit_id).get_bytes();
+
+        assert!(
+            !vkey_bytes.is_empty(),
+            "No verification key for circuit ID"
+        );
+
+        Ok(verifier.verify(self, vkey_bytes, proof.into(), public_inputs.into())?)
     }
 }

--- a/contracts-stylus/src/darkpool_test_contract.rs
+++ b/contracts-stylus/src/darkpool_test_contract.rs
@@ -1,0 +1,46 @@
+use alloc::vec::Vec;
+use stylus_sdk::{
+    abi::Bytes,
+    alloy_primitives::B256,
+    call::{CallContext, StaticCallContext},
+    prelude::*,
+};
+
+use crate::darkpool::DarkpoolContract;
+
+// We implement the `CallContext` & `StaticCallContext` traits manually
+// for the `DarkpoolContract` because it is not the entrypoint when
+// building the `DarkpoolTestContract`, and as such doesn't have these
+// traits implemented for it by the `#[entrypoint]` macro.`
+impl CallContext for &mut DarkpoolContract {
+    fn gas(&self) -> u64 {
+        u64::MAX
+    }
+}
+
+impl StaticCallContext for &mut DarkpoolContract {}
+
+#[solidity_storage]
+#[entrypoint]
+struct DarkpoolTestContract {
+    #[borrow]
+    darkpool: DarkpoolContract,
+}
+
+// Expose the internal helper methods of the Darkpool contract as external for testing purposes
+#[external]
+#[inherit(DarkpoolContract)]
+impl DarkpoolTestContract {
+    pub fn mark_nullifier_spent(&mut self, nullifier: B256) -> Result<(), Vec<u8>> {
+        self.darkpool.mark_nullifier_spent(nullifier)
+    }
+
+    pub fn verify(
+        &mut self,
+        circuit_id: u8,
+        proof: Bytes,
+        public_inputs: Bytes,
+    ) -> Result<bool, Vec<u8>> {
+        self.darkpool.verify(circuit_id, proof, public_inputs)
+    }
+}

--- a/contracts-stylus/src/interfaces.rs
+++ b/contracts-stylus/src/interfaces.rs
@@ -1,0 +1,9 @@
+//! Definitions of Solidity interfaces called by contracts in the Renegade protocol
+
+use stylus_sdk::stylus_proc::sol_interface;
+
+sol_interface! {
+    interface IVerifier {
+        function verify(bytes memory vkey, bytes memory proof, bytes memory public_inputs) external view returns (bool);
+    }
+}

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -2,9 +2,10 @@
 #![no_std]
 
 mod constants;
+mod interfaces;
 mod utils;
 
-#[cfg(feature = "darkpool")]
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
 mod darkpool;
 
 #[cfg(feature = "verifier")]
@@ -12,6 +13,9 @@ mod verifier;
 
 #[cfg(feature = "precompile-test-contract")]
 mod precompile_test_contract;
+
+#[cfg(feature = "darkpool-test-contract")]
+mod darkpool_test_contract;
 
 extern crate alloc;
 

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -3,10 +3,13 @@
 use ethers::prelude::abigen;
 
 abigen!(
-    DarkpoolContract,
+    DarkpoolTestContract,
     r#"[
         function isNullifierSpent(bytes32 memory nullifier) external view returns (bool)
         function markNullifierSpent(bytes32 memory nullifier) external
+        function setVerifierAddress(address memory _address) external
+        function addVerificationKey(uint8 memory circuit_id, bytes memory vkey) external
+        function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)
     ]"#
 );
 

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -30,4 +30,5 @@ pub(crate) enum Tests {
     NullifierSet,
     Verifier,
     Precompile,
+    DarkpoolVerification,
 }

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -16,5 +16,5 @@ pub(crate) const PRECOMPILE_TEST_CONTRACT_KEY: &str = "precompile_test_contract"
 /// The verifier contract key in the `deployments.json` file
 pub(crate) const VERIFIER_CONTRACT_KEY: &str = "verifier_contract";
 
-/// The darkpool contract key in the `deployments.json` file
-pub(crate) const DARKPOOL_CONTRACT_KEY: &str = "darkpool_contract";
+/// The darkpool test contract key in the `deployments.json` file
+pub(crate) const DARKPOOL_TEST_CONTRACT_KEY: &str = "darkpool_test_contract";

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,10 +1,10 @@
 //! Basic tests for Stylus programs. These assume that a devnet is already running locally.
 
-use abis::{DarkpoolContract, PrecompileTestContract, VerifierContract};
+use abis::{DarkpoolTestContract, PrecompileTestContract, VerifierContract};
 use clap::Parser;
 use cli::{Cli, Tests};
 use eyre::Result;
-use tests::{test_nullifier_set, test_precompile_backend, test_verifier};
+use tests::{test_nullifier_set, test_precompile_backend, test_verifier, test_darkpool_verification};
 use utils::{get_test_contract_address, setup_client};
 
 mod abis;
@@ -23,13 +23,18 @@ async fn main() -> Result<()> {
     } = Cli::parse();
 
     let client = setup_client(priv_key, rpc_url).await?;
-    let contract_address = get_test_contract_address(test, deployments_file)?;
+    let contract_address = get_test_contract_address(test, deployments_file.clone())?;
 
     match test {
         Tests::NullifierSet => {
-            let contract = DarkpoolContract::new(contract_address, client);
+            let contract = DarkpoolTestContract::new(contract_address, client);
 
             test_nullifier_set(contract).await?;
+        }
+        Tests::DarkpoolVerification => {
+            let contract = DarkpoolTestContract::new(contract_address, client);
+
+            test_darkpool_verification(contract, deployments_file).await?;
         }
         Tests::Verifier => {
             let contract = VerifierContract::new(contract_address, client);

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -9,7 +9,11 @@ use eyre::Result;
 use rand::thread_rng;
 use test_helpers::{convert_jf_proof_and_vkey, gen_jf_proof_and_vkey};
 
-use crate::abis::{DarkpoolContract, PrecompileTestContract, VerifierContract};
+use crate::{
+    abis::{DarkpoolTestContract, PrecompileTestContract, VerifierContract},
+    constants::VERIFIER_CONTRACT_KEY,
+    utils::parse_addr_from_deployments_file,
+};
 
 pub(crate) async fn test_precompile_backend(
     contract: PrecompileTestContract<impl Middleware + 'static>,
@@ -50,7 +54,7 @@ pub(crate) async fn test_verifier(
 }
 
 pub(crate) async fn test_nullifier_set(
-    contract: DarkpoolContract<impl Middleware + 'static>,
+    contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
     let mut rng = thread_rng();
     let nullifier = ScalarField::rand(&mut rng);
@@ -70,6 +74,50 @@ pub(crate) async fn test_nullifier_set(
     let nullifier_spent = contract.is_nullifier_spent(nullifier_bytes).call().await?;
 
     assert!(nullifier_spent, "Nullifier not spent");
+
+    Ok(())
+}
+
+pub(crate) async fn test_darkpool_verification(
+    contract: DarkpoolTestContract<impl Middleware + 'static>,
+    deployments_file: String,
+) -> Result<()> {
+    let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(8192)?;
+    let (mut proof, vkey) = convert_jf_proof_and_vkey(jf_proof, jf_vkey);
+    let vkey_bytes: Bytes = vkey.serialize().into();
+    let proof_bytes: Bytes = proof.serialize().into();
+    let public_input_bytes = Bytes::new();
+
+    let verifier_contract_address =
+        parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
+    let circuit_id = rand::random();
+
+    contract
+        .set_verifier_address(verifier_contract_address)
+        .send()
+        .await?
+        .await?;
+    contract
+        .add_verification_key(circuit_id, vkey_bytes)
+        .send()
+        .await?
+        .await?;
+
+    let successful_res = contract
+        .verify(circuit_id, proof_bytes, public_input_bytes.clone())
+        .call()
+        .await?;
+
+    assert!(successful_res, "Valid proof did not verify");
+
+    proof.z_bar += ScalarField::one();
+    let proof_bytes: Bytes = proof.serialize().into();
+    let unsuccessful_res = contract
+        .verify(circuit_id, proof_bytes, public_input_bytes)
+        .call()
+        .await?;
+
+    assert!(!unsuccessful_res, "Invalid proof verified");
 
     Ok(())
 }

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -13,7 +13,8 @@ use eyre::{eyre, Result};
 use crate::{
     cli::Tests,
     constants::{
-        DARKPOOL_CONTRACT_KEY, DEPLOYMENTS_KEY, PRECOMPILE_TEST_CONTRACT_KEY, VERIFIER_CONTRACT_KEY,
+        DARKPOOL_TEST_CONTRACT_KEY, DEPLOYMENTS_KEY, PRECOMPILE_TEST_CONTRACT_KEY,
+        VERIFIER_CONTRACT_KEY,
     },
 };
 
@@ -35,7 +36,7 @@ pub(crate) async fn setup_client(
     Ok(client)
 }
 
-fn parse_addr_from_deployments_file(
+pub(crate) fn parse_addr_from_deployments_file(
     file_path: String,
     contract_key: &'static str,
 ) -> Result<Address> {
@@ -53,7 +54,10 @@ fn parse_addr_from_deployments_file(
 pub(crate) fn get_test_contract_address(test: Tests, deployments_file: String) -> Result<Address> {
     Ok(match test {
         Tests::NullifierSet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+        }
+        Tests::DarkpoolVerification => {
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
         Tests::Verifier => {
             parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?


### PR DESCRIPTION
This PR adds verification functionality to the darkpool contract, enabling it to store a verifier contract address and verification keys, as well as call the verifier contract with a given proof and public inputs.

Additionally, a test was written (and passes) for checking that verification works as expected when invoked through the darkpool.