### PR TITLE
contracts-core: serde: add `ScalarSerializable` trait & impls for structured statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 name = "contracts-core"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "ark-bn254",
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,10 +860,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
- "ark-serialize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ ark-ff = { version = "0.4.0", features = ["bin-opt"] }
 ark-poly = "0.4.0"
 ark-std = "0.4.0"
 ark-serialize = "0.4.0"
+alloy-primitives = { version = "0.3.1", default-features = false }
 
 [profile.release]
 codegen-units = 1        # prefer efficiency to compile time

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
-ark-serialize = { workspace = true }
+alloy-primitives = { workspace = true }

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -19,6 +19,9 @@ pub const FELT_BYTES: usize = 32;
 /// The number of u64s it takes to represent a field element
 pub const NUM_U64S_FELT: usize = 4;
 
+/// The number of bytes it takes to represent an unsigned 256-bit integer
+pub const NUM_BYTES_U256: usize = 32;
+
 /// The number of public inputs in the verifier testing circuit
 pub const NUM_PUBLIC_INPUTS: usize = 0;
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -21,3 +21,6 @@ pub const NUM_U64S_FELT: usize = 4;
 
 /// The number of public inputs in the verifier testing circuit
 pub const NUM_PUBLIC_INPUTS: usize = 0;
+
+/// The number of secret-shared scalars it takes to represent a wallet
+pub const WALLET_SHARES_LEN: usize = 0;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -100,7 +100,7 @@ pub struct PublicSigningKey {
 pub struct ValidWalletCreateStatement {
     /// The commitment to the private secret shares of the wallet
     pub private_shares_commitment: ScalarField,
-    /// The public secret shares of the wallet
+    /// The blinded public secret shares of the wallet
     pub public_wallet_shares: [ScalarField; WALLET_SHARES_LEN],
 }
 
@@ -110,7 +110,7 @@ pub struct ValidWalletUpdateStatement {
     pub old_shares_nullifier: ScalarField,
     /// A commitment to the new wallet's private secret shares
     pub new_private_shares_commitment: ScalarField,
-    /// The public secret shares of the new wallet
+    /// The blinded public secret shares of the new wallet
     pub new_public_shares: [ScalarField; WALLET_SHARES_LEN],
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to the old wallet's private secret shares
@@ -146,9 +146,9 @@ pub struct ValidCommitmentsStatement {
 
 /// Statement for the `VALID_MATCH_SETTLE` circuit
 pub struct ValidMatchSettleStatement {
-    /// The modified public secret shares of the first party
+    /// The modified blinded public secret shares of the first party
     pub party0_modified_shares: [ScalarField; WALLET_SHARES_LEN],
-    /// The modified public secret shares of the second party
+    /// The modified blinded public secret shares of the second party
     pub party1_modified_shares: [ScalarField; WALLET_SHARES_LEN],
     /// The index of the balance sent by the first party in the settlement
     pub party0_send_balance_index: u64,
@@ -166,9 +166,14 @@ pub struct ValidMatchSettleStatement {
 
 /// Represents the outputs produced by one of the parties in a match
 pub struct MatchPayload {
+    /// The public secret share of the party's wallet-level blinder
     pub wallet_blinder_share: ScalarField,
+    /// The statement for the party's `VALID_COMMITMENTS` proof
     pub valid_commitments_statement: ValidCommitmentsStatement,
+    /// The party's `VALID_COMMITMENTS` proof
     pub valid_commitments_proof: Proof,
+    /// The statement for the party's `VALID_REBLIND` proof
     pub valid_reblind_statement: ValidReblindStatement,
+    /// The party's `VALID_REBLIND` proof
     pub valid_reblind_proof: Proof,
 }

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -10,6 +10,7 @@ ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-poly = { workspace = true }
 ark-serialize = { workspace = true }
+alloy-primitives = { workspace = true }
 num-bigint = { version = "0.4", default-features = false }
 
 


### PR DESCRIPTION
This PR is the first step towards having structured statements for our proofs. This is important as we need to access statement elements in pre- and post-verification functionality, such as verifying ECDSA signatures, or inserting commitments into the Merkle tree. This PR copies over the statement types from the old Cairo repo, and adds a new trait `ScalarSerializable`.

The intended usage is that when calling a wallet interaction method such as `new_wallet`, the serialization of the statement into calldata goes in two stages:
1. Serialize the statement into an array of scalars using `ScalarSerializable`
2. Serialize the array of scalars into an array of bytes using the existing `Serializable` trait

This way, we can deserialize the structured statements from calldata (which is a byte array), but also directly pass the calldata to the verifier (which expects the public inputs to be an array of scalars, serialized into bytes).

I save the implementation of `ScalarDeserializable` and `Deserializable` on the statement types, as well as testing, for a future PR, as this one is growing quite large (albeit quite repetitive)