### PR TITLE
contracts-core: serde: serializing statement types directly to bytes

### DIFF
--- a/contracts-core/src/serde.rs
+++ b/contracts-core/src/serde.rs
@@ -45,6 +45,12 @@ pub struct TranscriptG1(pub G1Affine);
 // | TRAIT IMPLEMENTATIONS |
 // -------------------------
 
+impl Serializable for bool {
+    fn serialize(&self) -> Vec<u8> {
+        vec![*self as u8]
+    }
+}
+
 impl Serializable for u64 {
     fn serialize(&self) -> Vec<u8> {
         self.to_be_bytes().to_vec()
@@ -251,48 +257,94 @@ impl Deserializable for Proof {
     }
 }
 
+impl Serializable for Address {
+    fn serialize(&self) -> Vec<u8> {
+        self.into_array().to_vec()
+    }
+}
+
+impl Serializable for U256 {
+    fn serialize(&self) -> Vec<u8> {
+        let bytes: [u8; NUM_BYTES_U256] = self.to_be_bytes();
+        bytes.to_vec()
+    }
+}
+
+impl Serializable for ExternalTransfer {
+    fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend(self.account_addr.serialize());
+        bytes.extend(self.mint.serialize());
+        bytes.extend(self.amount.serialize());
+        bytes.extend(self.is_withdrawal.serialize());
+        bytes
+    }
+}
+
+impl Serializable for PublicSigningKey {
+    fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend(self.x.as_slice().serialize());
+        bytes.extend(self.y.as_slice().serialize());
+        bytes
+    }
+}
+
 impl Serializable for ValidWalletCreateStatement {
     fn serialize(&self) -> Vec<u8> {
-        self.to_scalars()
-            .iter()
-            .flat_map(Serializable::serialize)
-            .collect()
+        let mut bytes = Vec::new();
+        bytes.extend(self.private_shares_commitment.serialize());
+        bytes.extend(self.public_wallet_shares.as_slice().serialize());
+        bytes
     }
 }
 
 impl Serializable for ValidWalletUpdateStatement {
     fn serialize(&self) -> Vec<u8> {
-        self.to_scalars()
-            .iter()
-            .flat_map(Serializable::serialize)
-            .collect()
+        let mut bytes = Vec::new();
+        bytes.extend(self.old_shares_nullifier.serialize());
+        bytes.extend(self.new_private_shares_commitment.serialize());
+        bytes.extend(self.new_public_shares.as_slice().serialize());
+        bytes.extend(self.merkle_root.serialize());
+        bytes.extend(self.external_transfer.serialize());
+        bytes.extend(self.old_pk_root.serialize());
+        bytes.extend(self.timestamp.serialize());
+        bytes
     }
 }
 
 impl Serializable for ValidReblindStatement {
     fn serialize(&self) -> Vec<u8> {
-        self.to_scalars()
-            .iter()
-            .flat_map(Serializable::serialize)
-            .collect()
+        let mut bytes = Vec::new();
+        bytes.extend(self.original_shares_nullifier.serialize());
+        bytes.extend(self.reblinded_private_shares_commitment.serialize());
+        bytes.extend(self.merkle_root.serialize());
+        bytes
     }
 }
 
 impl Serializable for ValidCommitmentsStatement {
     fn serialize(&self) -> Vec<u8> {
-        self.to_scalars()
-            .iter()
-            .flat_map(Serializable::serialize)
-            .collect()
+        let mut bytes = Vec::new();
+        bytes.extend(self.balance_send_index.serialize());
+        bytes.extend(self.balance_receive_index.serialize());
+        bytes.extend(self.order_index.serialize());
+        bytes
     }
 }
 
 impl Serializable for ValidMatchSettleStatement {
     fn serialize(&self) -> Vec<u8> {
-        self.to_scalars()
-            .iter()
-            .flat_map(Serializable::serialize)
-            .collect()
+        let mut bytes = Vec::new();
+        bytes.extend(self.party0_modified_shares.as_slice().serialize());
+        bytes.extend(self.party1_modified_shares.as_slice().serialize());
+        bytes.extend(self.party0_send_balance_index.serialize());
+        bytes.extend(self.party0_receive_balance_index.serialize());
+        bytes.extend(self.party0_order_index.serialize());
+        bytes.extend(self.party1_send_balance_index.serialize());
+        bytes.extend(self.party1_receive_balance_index.serialize());
+        bytes.extend(self.party1_order_index.serialize());
+        bytes
     }
 }
 


### PR DESCRIPTION
This PR changes the byte-serialization logic of statement types, namely, we no longer first serialize into scalars, and then into bytes.

While this originally seemed convenient for using the same serialization for both calling the verifier contract and deserializing structured statements, when looking ahead to serializing dynamically-sized statements, things become more muddled. We'll have to add vector lengths into the serialization, but it doesn't make sense to serialize those into scalars as well (it wouldn't make sense for the circuits to expect this).

So, instead, we will separately serialize/deserialize statements to/from bytes for calldata, and then before submitting statements to the verifier, serialize them into scalars.

Deserialization logic, along with tests, will come in the next PR.