### PR TITLE
common, contracts-core, contracts-stylus: derive Serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "coins-bip32"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +870,8 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -905,6 +913,7 @@ dependencies = [
  "common",
  "jf-utils",
  "num-bigint",
+ "postcard",
  "sha3",
  "test-helpers",
 ]
@@ -919,6 +928,7 @@ dependencies = [
  "ark-std",
  "common",
  "contracts-core",
+ "postcard",
  "stylus-sdk",
  "wee_alloc",
 ]
@@ -1123,6 +1133,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1349,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "ena"
@@ -2109,6 +2160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2269,7 @@ dependencies = [
  "ethers",
  "eyre",
  "json",
+ "postcard",
  "rand",
  "test-helpers",
  "tokio",
@@ -2962,6 +3020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "serde",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,6 +3762,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ ark-poly = "0.4.0"
 ark-std = "0.4.0"
 ark-serialize = "0.4.0"
 alloy-primitives = { version = "0.3.1", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_with = { version = "3.4", default-features = false, features = [
+    "macros",
+] }
+postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
 
 [profile.release]
 codegen-units = 1        # prefer efficiency to compile time

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,3 +8,5 @@ ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 alloy-primitives = { workspace = true }
+serde = { workspace = true }
+serde_with = { workspace = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -4,4 +4,5 @@
 extern crate alloc;
 
 pub mod constants;
+pub mod serde_def_types;
 pub mod types;

--- a/common/src/serde_def_types.rs
+++ b/common/src/serde_def_types.rs
@@ -1,0 +1,129 @@
+//! Types & trait implementations to enable deriving serde::{Serialize, Deserialize}
+//! on the foreign Arkworks, Alloy, and other types that we compose into complex structs.
+
+use alloy_primitives::{Address, FixedBytes, Uint};
+use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq2Config, FqConfig, FrConfig};
+use ark_ec::short_weierstrass::Affine;
+use ark_ff::{BigInt, Fp, Fp2ConfigWrapper, FpConfig, MontBackend, QuadExtField};
+use core::marker::PhantomData;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
+
+use crate::types::{G1Affine, G1BaseField, G2Affine, G2BaseField, ScalarField};
+
+macro_rules! impl_serde_as {
+    ($remote_type:ty, $def_type:ty, $($generics:tt)*) => {
+        impl<$($generics)*> SerializeAs<$remote_type> for $def_type {
+            fn serialize_as<S>(source: &$remote_type, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                <$def_type>::serialize(source, serializer)
+            }
+        }
+
+        impl<'de, $($generics)*> DeserializeAs<'de, $remote_type> for $def_type {
+            fn deserialize_as<D>(deserializer: D) -> Result<$remote_type, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <$def_type>::deserialize(deserializer)
+            }
+        }
+    };
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "BigInt")]
+pub(crate) struct BigIntDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u64; N]);
+
+impl_serde_as!(BigInt<N>, BigIntDef<N>, const N: usize);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Fp")]
+pub(crate) struct FpDef<P: FpConfig<N>, const N: usize>(
+    #[serde_as(as = "BigIntDef<N>")] pub BigInt<N>,
+    pub PhantomData<P>,
+);
+
+impl_serde_as!(Fp<P, N>, FpDef<P, N>, P: FpConfig<N>, const N: usize);
+
+pub(crate) type ScalarFieldDef = FpDef<MontBackend<FrConfig, 4>, 4>;
+pub(crate) type G1BaseFieldDef = FpDef<MontBackend<FqConfig, 4>, 4>;
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct SerdeScalarField(#[serde_as(as = "ScalarFieldDef")] pub ScalarField);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "QuadExtField<Fp2ConfigWrapper<Fq2Config>>")]
+pub(crate) struct G2BaseFieldDef {
+    #[serde_as(as = "G1BaseFieldDef")]
+    pub c0: G1BaseField,
+    #[serde_as(as = "G1BaseFieldDef")]
+    pub c1: G1BaseField,
+}
+
+impl_serde_as!(G2BaseField, G2BaseFieldDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Affine<G1Config>")]
+pub(crate) struct G1AffineDef {
+    #[serde_as(as = "G1BaseFieldDef")]
+    x: G1BaseField,
+    #[serde_as(as = "G1BaseFieldDef")]
+    y: G1BaseField,
+    infinity: bool,
+}
+
+impl_serde_as!(G1Affine, G1AffineDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Affine<G2Config>")]
+pub(crate) struct G2AffineDef {
+    #[serde_as(as = "G2BaseFieldDef")]
+    x: G2BaseField,
+    #[serde_as(as = "G2BaseFieldDef")]
+    y: G2BaseField,
+    infinity: bool,
+}
+
+impl_serde_as!(G2Affine, G2AffineDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "FixedBytes")]
+pub(crate) struct FixedBytesDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u8; N]);
+
+impl_serde_as!(FixedBytes<N>, FixedBytesDef<N>, const N: usize);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Address")]
+pub(crate) struct AddressDef(#[serde_as(as = "FixedBytesDef<20>")] FixedBytes<20>);
+
+impl_serde_as!(Address, AddressDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Uint")]
+pub(crate) struct UintDef<const BITS: usize, const LIMBS: usize> {
+    #[serde_as(as = "[_; LIMBS]")]
+    #[serde(getter = "Uint::as_limbs")]
+    limbs: [u64; LIMBS],
+}
+
+impl<const BITS: usize, const LIMBS: usize> From<UintDef<BITS, LIMBS>> for Uint<BITS, LIMBS> {
+    fn from(value: UintDef<BITS, LIMBS>) -> Self {
+        Uint::from_limbs(value.limbs)
+    }
+}
+
+impl_serde_as!(Uint<BITS, LIMBS>, UintDef<BITS, LIMBS>, const BITS: usize, const LIMBS: usize);
+
+pub(crate) type U256Def = UintDef<256, 4>;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,140 +1,23 @@
 //! Common types used throughout the verifier.
 
-use core::marker::PhantomData;
-
-use alloy_primitives::{Address, FixedBytes, Uint, U256};
-use ark_bn254::{
-    g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fq2Config, FqConfig, Fr, FrConfig,
-};
+use alloy_primitives::{Address, U256};
+use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fr};
 use ark_ec::short_weierstrass::Affine;
-use ark_ff::{BigInt, Fp, Fp256, Fp2ConfigWrapper, FpConfig, MontBackend, QuadExtField};
+use ark_ff::{Fp256, MontBackend};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DeserializeAs, SerializeAs};
+use serde_with::serde_as;
 
-use crate::constants::{NUM_SELECTORS, NUM_U64S_FELT, NUM_WIRE_TYPES, WALLET_SHARES_LEN};
+use crate::{
+    constants::{NUM_SELECTORS, NUM_U64S_FELT, NUM_WIRE_TYPES, WALLET_SHARES_LEN},
+    serde_def_types::*,
+};
 
-// TODO: Consider using associated types of the `CurveGroup` trait instead.
-// Docs imply that arithmetic should be more efficient: https://docs.rs/ark-ec/0.4.2/ark_ec/#elliptic-curve-groups
-// Since we don't use the Arkworks implementation of EC arithmetic, nor that of pairings, use whichever is more convenient for precompiles
 pub type ScalarField = Fr;
 pub type G1Affine = Affine<G1Config>;
 pub type G2Affine = Affine<G2Config>;
 pub type G1BaseField = Fq;
 pub type G2BaseField = Fq2;
 pub type MontFp256<P> = Fp256<MontBackend<P, NUM_U64S_FELT>>;
-
-macro_rules! impl_serde_as {
-    ($remote_type:ty, $def_type:ty, $($generics:tt)*) => {
-        impl<$($generics)*> SerializeAs<$remote_type> for $def_type {
-            fn serialize_as<S>(source: &$remote_type, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                <$def_type>::serialize(source, serializer)
-            }
-        }
-
-        impl<'de, $($generics)*> DeserializeAs<'de, $remote_type> for $def_type {
-            fn deserialize_as<D>(deserializer: D) -> Result<$remote_type, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                <$def_type>::deserialize(deserializer)
-            }
-        }
-    };
-}
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "BigInt")]
-struct BigIntDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u64; N]);
-
-impl_serde_as!(BigInt<N>, BigIntDef<N>, const N: usize);
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Fp")]
-struct FpDef<P: FpConfig<N>, const N: usize>(
-    #[serde_as(as = "BigIntDef<N>")] pub BigInt<N>,
-    pub PhantomData<P>,
-);
-
-impl_serde_as!(Fp<P, N>, FpDef<P, N>, P: FpConfig<N>, const N: usize);
-
-type ScalarFieldDef = FpDef<MontBackend<FrConfig, 4>, 4>;
-type G1BaseFieldDef = FpDef<MontBackend<FqConfig, 4>, 4>;
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "QuadExtField<Fp2ConfigWrapper<Fq2Config>>")]
-struct G2BaseFieldDef {
-    #[serde_as(as = "G1BaseFieldDef")]
-    pub c0: G1BaseField,
-    #[serde_as(as = "G1BaseFieldDef")]
-    pub c1: G1BaseField,
-}
-
-impl_serde_as!(G2BaseField, G2BaseFieldDef,);
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Affine<G1Config>")]
-struct G1AffineDef {
-    #[serde_as(as = "G1BaseFieldDef")]
-    x: G1BaseField,
-    #[serde_as(as = "G1BaseFieldDef")]
-    y: G1BaseField,
-    infinity: bool,
-}
-
-impl_serde_as!(G1Affine, G1AffineDef,);
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Affine<G2Config>")]
-struct G2AffineDef {
-    #[serde_as(as = "G2BaseFieldDef")]
-    x: G2BaseField,
-    #[serde_as(as = "G2BaseFieldDef")]
-    y: G2BaseField,
-    infinity: bool,
-}
-
-impl_serde_as!(G2Affine, G2AffineDef,);
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "FixedBytes")]
-struct FixedBytesDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u8; N]);
-
-impl_serde_as!(FixedBytes<N>, FixedBytesDef<N>, const N: usize);
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Address")]
-struct AddressDef(#[serde_as(as = "FixedBytesDef<20>")] FixedBytes<20>);
-
-impl_serde_as!(Address, AddressDef,);
-
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Uint")]
-struct UintDef<const BITS: usize, const LIMBS: usize> {
-    #[serde_as(as = "[_; LIMBS]")]
-    #[serde(getter = "Uint::as_limbs")]
-    limbs: [u64; LIMBS],
-}
-
-impl<const BITS: usize, const LIMBS: usize> From<UintDef<BITS, LIMBS>> for Uint<BITS, LIMBS> {
-    fn from(value: UintDef<BITS, LIMBS>) -> Self {
-        Uint::from_limbs(value.limbs)
-    }
-}
-
-impl_serde_as!(Uint<BITS, LIMBS>, UintDef<BITS, LIMBS>, const BITS: usize, const LIMBS: usize);
-
-type U256Def = UintDef<256, 4>;
 
 /// Preprocessed information derived from the circuit definition and universal SRS
 /// used by the verifier.

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,9 +1,15 @@
 //! Common types used throughout the verifier.
 
-use alloy_primitives::{Address, U256};
-use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fr};
+use core::marker::PhantomData;
+
+use alloy_primitives::{Address, FixedBytes, Uint, U256};
+use ark_bn254::{
+    g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fq2Config, FqConfig, Fr, FrConfig,
+};
 use ark_ec::short_weierstrass::Affine;
-use ark_ff::{Fp256, MontBackend};
+use ark_ff::{BigInt, Fp, Fp256, Fp2ConfigWrapper, FpConfig, MontBackend, QuadExtField};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
 
 use crate::constants::{NUM_SELECTORS, NUM_U64S_FELT, NUM_WIRE_TYPES, WALLET_SHARES_LEN};
 
@@ -17,72 +23,215 @@ pub type G1BaseField = Fq;
 pub type G2BaseField = Fq2;
 pub type MontFp256<P> = Fp256<MontBackend<P, NUM_U64S_FELT>>;
 
+macro_rules! impl_serde_as {
+    ($remote_type:ty, $def_type:ty, $($generics:tt)*) => {
+        impl<$($generics)*> SerializeAs<$remote_type> for $def_type {
+            fn serialize_as<S>(source: &$remote_type, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                <$def_type>::serialize(source, serializer)
+            }
+        }
+
+        impl<'de, $($generics)*> DeserializeAs<'de, $remote_type> for $def_type {
+            fn deserialize_as<D>(deserializer: D) -> Result<$remote_type, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <$def_type>::deserialize(deserializer)
+            }
+        }
+    };
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "BigInt")]
+struct BigIntDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u64; N]);
+
+impl_serde_as!(BigInt<N>, BigIntDef<N>, const N: usize);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Fp")]
+struct FpDef<P: FpConfig<N>, const N: usize>(
+    #[serde_as(as = "BigIntDef<N>")] pub BigInt<N>,
+    pub PhantomData<P>,
+);
+
+impl_serde_as!(Fp<P, N>, FpDef<P, N>, P: FpConfig<N>, const N: usize);
+
+type ScalarFieldDef = FpDef<MontBackend<FrConfig, 4>, 4>;
+type G1BaseFieldDef = FpDef<MontBackend<FqConfig, 4>, 4>;
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "QuadExtField<Fp2ConfigWrapper<Fq2Config>>")]
+struct G2BaseFieldDef {
+    #[serde_as(as = "G1BaseFieldDef")]
+    pub c0: G1BaseField,
+    #[serde_as(as = "G1BaseFieldDef")]
+    pub c1: G1BaseField,
+}
+
+impl_serde_as!(G2BaseField, G2BaseFieldDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Affine<G1Config>")]
+struct G1AffineDef {
+    #[serde_as(as = "G1BaseFieldDef")]
+    x: G1BaseField,
+    #[serde_as(as = "G1BaseFieldDef")]
+    y: G1BaseField,
+    infinity: bool,
+}
+
+impl_serde_as!(G1Affine, G1AffineDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Affine<G2Config>")]
+struct G2AffineDef {
+    #[serde_as(as = "G2BaseFieldDef")]
+    x: G2BaseField,
+    #[serde_as(as = "G2BaseFieldDef")]
+    y: G2BaseField,
+    infinity: bool,
+}
+
+impl_serde_as!(G2Affine, G2AffineDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "FixedBytes")]
+struct FixedBytesDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u8; N]);
+
+impl_serde_as!(FixedBytes<N>, FixedBytesDef<N>, const N: usize);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Address")]
+struct AddressDef(#[serde_as(as = "FixedBytesDef<20>")] FixedBytes<20>);
+
+impl_serde_as!(Address, AddressDef,);
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Uint")]
+struct UintDef<const BITS: usize, const LIMBS: usize> {
+    #[serde_as(as = "[_; LIMBS]")]
+    #[serde(getter = "Uint::as_limbs")]
+    limbs: [u64; LIMBS],
+}
+
+impl<const BITS: usize, const LIMBS: usize> From<UintDef<BITS, LIMBS>> for Uint<BITS, LIMBS> {
+    fn from(value: UintDef<BITS, LIMBS>) -> Self {
+        Uint::from_limbs(value.limbs)
+    }
+}
+
+impl_serde_as!(Uint<BITS, LIMBS>, UintDef<BITS, LIMBS>, const BITS: usize, const LIMBS: usize);
+
+type U256Def = UintDef<256, 4>;
+
 /// Preprocessed information derived from the circuit definition and universal SRS
 /// used by the verifier.
 // TODO: Give these variable human-readable names once end-to-end verifier is complete
-#[derive(Clone, Copy)]
+#[serde_as]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct VerificationKey {
     /// The number of gates in the circuit
     pub n: u64,
     /// The number of public inputs to the circuit
     pub l: u64,
     /// The constants used to generate the cosets of the evaluation domain
+    #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES]")]
     pub k: [ScalarField; NUM_WIRE_TYPES],
     /// The commitments to the selector polynomials
+    #[serde_as(as = "[G1AffineDef; NUM_SELECTORS]")]
     pub q_comms: [G1Affine; NUM_SELECTORS],
     /// The commitments to the permutation polynomials
+    #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
     pub sigma_comms: [G1Affine; NUM_WIRE_TYPES],
     /// The generator of the G1 group
+    #[serde_as(as = "G1AffineDef")]
     pub g: G1Affine,
     /// The generator of the G2 group
+    #[serde_as(as = "G2AffineDef")]
     pub h: G2Affine,
     /// The G2 commitment to the secret evaluation point
+    #[serde_as(as = "G2AffineDef")]
     pub x_h: G2Affine,
 }
 
 /// A Plonk proof, using the "fast prover" strategy described in the paper.
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct Proof {
     /// The commitments to the wire polynomials
+    #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
     pub wire_comms: [G1Affine; NUM_WIRE_TYPES],
     /// The commitment to the grand product polynomial encoding the permutation argument (i.e., copy constraints)
+    #[serde_as(as = "G1AffineDef")]
     pub z_comm: G1Affine,
     /// The commitments to the split quotient polynomials
+    #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
     pub quotient_comms: [G1Affine; NUM_WIRE_TYPES],
     /// The opening proof of evaluations at challenge point `zeta`
+    #[serde_as(as = "G1AffineDef")]
     pub w_zeta: G1Affine,
     /// The opening proof of evaluations at challenge point `zeta * omega`
+    #[serde_as(as = "G1AffineDef")]
     pub w_zeta_omega: G1Affine,
     /// The evaluations of the wire polynomials at the challenge point `zeta`
+    #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES]")]
     pub wire_evals: [ScalarField; NUM_WIRE_TYPES],
     /// The evaluations of the permutation polynomials at the challenge point `zeta`
+    #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES - 1]")]
     pub sigma_evals: [ScalarField; NUM_WIRE_TYPES - 1],
     /// The evaluation of the grand product polynomial at the challenge point `zeta * omega` (\bar{z})
+    #[serde_as(as = "ScalarFieldDef")]
     pub z_bar: ScalarField,
 }
 
 /// The public coin challenges used throughout the Plonk protocol, obtained via a Fiat-Shamir transformation.
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct Challenges {
     /// The first permutation challenge, used in round 2 of the prover algorithm
+    #[serde_as(as = "ScalarFieldDef")]
     pub beta: ScalarField,
     /// The second permutation challenge, used in round 2 of the prover algorithm
+    #[serde_as(as = "ScalarFieldDef")]
     pub gamma: ScalarField,
     /// The quotient challenge, used in round 3 of the prover algorithm
+    #[serde_as(as = "ScalarFieldDef")]
     pub alpha: ScalarField,
     /// The evaluation challenge, used in round 4 of the prover algorithm
+    #[serde_as(as = "ScalarFieldDef")]
     pub zeta: ScalarField,
     /// The opening challenge, used in round 5 of the prover algorithm
+    #[serde_as(as = "ScalarFieldDef")]
     pub v: ScalarField,
     /// The multipoint evaluation challenge, generated at the end of round 5 of the prover algorithm
+    #[serde_as(as = "ScalarFieldDef")]
     pub u: ScalarField,
 }
 
 /// Represents an external transfer of an ERC20 token
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct ExternalTransfer {
     /// The address of the account contract to deposit from or withdraw to
+    #[serde_as(as = "AddressDef")]
     pub account_addr: Address,
     /// The mint (contract address) of the token being transferred
+    #[serde_as(as = "AddressDef")]
     pub mint: Address,
     /// The amount of the token transferred
+    #[serde_as(as = "U256Def")]
     pub amount: U256,
     /// Whether or not the transfer is a withdrawal (otherwise a deposit)
     pub is_withdrawal: bool,
@@ -91,29 +240,43 @@ pub struct ExternalTransfer {
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.
 /// Since the secp256k1 base field order is larger than that of Bn254's scalar field,
 /// it takes 2 Bn254 scalar field elements to represent each coordinate.
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct PublicSigningKey {
+    #[serde_as(as = "[ScalarFieldDef; 2]")]
     pub x: [ScalarField; 2],
+    #[serde_as(as = "[ScalarFieldDef; 2]")]
     pub y: [ScalarField; 2],
 }
 
 /// Statement for `VALID_WALLET_CREATE` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct ValidWalletCreateStatement {
     /// The commitment to the private secret shares of the wallet
+    #[serde_as(as = "ScalarFieldDef")]
     pub private_shares_commitment: ScalarField,
     /// The blinded public secret shares of the wallet
+    #[serde_as(as = "[ScalarFieldDef; WALLET_SHARES_LEN]")]
     pub public_wallet_shares: [ScalarField; WALLET_SHARES_LEN],
 }
 
 /// Statement for `VALID_WALLET_UPDATE` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct ValidWalletUpdateStatement {
     /// The nullifier of the old wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
     pub old_shares_nullifier: ScalarField,
     /// A commitment to the new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
     pub new_private_shares_commitment: ScalarField,
     /// The blinded public secret shares of the new wallet
+    #[serde_as(as = "[ScalarFieldDef; WALLET_SHARES_LEN]")]
     pub new_public_shares: [ScalarField; WALLET_SHARES_LEN],
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to the old wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
     pub merkle_root: ScalarField,
     /// The external transfer associated with this update
     pub external_transfer: ExternalTransfer,
@@ -124,17 +287,23 @@ pub struct ValidWalletUpdateStatement {
 }
 
 /// Statement for the `VALID_REBLIND` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct ValidReblindStatement {
     /// The nullifier of the original wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
     pub original_shares_nullifier: ScalarField,
     /// A commitment to the private secret shares of the reblinded wallet
+    #[serde_as(as = "ScalarFieldDef")]
     pub reblinded_private_shares_commitment: ScalarField,
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to the original wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
     pub merkle_root: ScalarField,
 }
 
 /// Statememt for the `VALID_COMMITMENTS` circuit
+#[derive(Serialize, Deserialize)]
 pub struct ValidCommitmentsStatement {
     /// The index of the balance sent by the party if a successful match occurs
     pub balance_send_index: u64,
@@ -145,10 +314,14 @@ pub struct ValidCommitmentsStatement {
 }
 
 /// Statement for the `VALID_MATCH_SETTLE` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct ValidMatchSettleStatement {
     /// The modified blinded public secret shares of the first party
+    #[serde_as(as = "[ScalarFieldDef; WALLET_SHARES_LEN]")]
     pub party0_modified_shares: [ScalarField; WALLET_SHARES_LEN],
     /// The modified blinded public secret shares of the second party
+    #[serde_as(as = "[ScalarFieldDef; WALLET_SHARES_LEN]")]
     pub party1_modified_shares: [ScalarField; WALLET_SHARES_LEN],
     /// The index of the balance sent by the first party in the settlement
     pub party0_send_balance_index: u64,
@@ -165,8 +338,11 @@ pub struct ValidMatchSettleStatement {
 }
 
 /// Represents the outputs produced by one of the parties in a match
+#[serde_as]
+#[derive(Serialize, Deserialize)]
 pub struct MatchPayload {
     /// The public secret share of the party's wallet-level blinder
+    #[serde_as(as = "ScalarFieldDef")]
     pub wallet_blinder_share: ScalarField,
     /// The statement for the party's `VALID_COMMITMENTS` proof
     pub valid_commitments_statement: ValidCommitmentsStatement,

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -20,3 +20,4 @@ sha3 = { version = "^0.10", default-features = false }
 byteorder = "1.5"
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 test-helpers = { path = "../test-helpers" }
+postcard = { workspace = true }

--- a/contracts-core/src/lib.rs
+++ b/contracts-core/src/lib.rs
@@ -2,6 +2,6 @@
 
 extern crate alloc;
 
-pub mod serde;
+pub mod custom_serde;
 pub mod transcript;
 pub mod verifier;

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -10,7 +10,7 @@ use common::{
 };
 use core::{marker::PhantomData, result::Result};
 
-use crate::serde::{Serializable, TranscriptG1};
+use crate::custom_serde::{BytesSerializable, TranscriptG1};
 
 use self::errors::TranscriptError;
 
@@ -55,8 +55,8 @@ impl<H: TranscriptHasher> Transcript<H> {
     }
 
     /// Appends a serializable Arkworks type to the transcript
-    fn append_serializable<S: Serializable>(&mut self, message: &S) {
-        self.append_message(&message.serialize());
+    fn append_serializable<S: BytesSerializable>(&mut self, message: &S) {
+        self.append_message(&message.serialize_to_bytes());
     }
     /// Computes all the challenges used in the Plonk protocol,
     /// given a verification key, a proof, and a set of public inputs.
@@ -128,7 +128,7 @@ impl<H: TranscriptHasher> Transcript<H> {
 fn serialize_scalars_for_transcript(scalars: &[ScalarField]) -> Vec<u8> {
     scalars
         .iter()
-        .flat_map(|s| s.serialize().into_iter().rev())
+        .flat_map(|s| s.serialize_to_bytes().into_iter().rev())
         .collect()
 }
 

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -12,6 +12,7 @@ ark-bn254 = { workspace = true }
 common = { path = "../common" }
 contracts-core = { path = "../contracts-core" }
 ark-std = { version = "0.4.0", optional = true }
+postcard = { workspace = true }
 
 [features]
 darkpool = []

--- a/contracts-stylus/src/utils.rs
+++ b/contracts-stylus/src/utils.rs
@@ -2,7 +2,7 @@
 
 use common::types::{G1Affine, G2Affine, ScalarField};
 use contracts_core::{
-    serde::{Deserializable, Serializable},
+    custom_serde::{BytesDeserializable, BytesSerializable},
     verifier::{errors::VerifierError, G1ArithmeticBackend},
 };
 use stylus_sdk::{
@@ -24,8 +24,8 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
     /// Calls the `ecAdd` precompile with the given points, handling de/serialization
     fn ec_add(&mut self, a: G1Affine, b: G1Affine) -> Result<G1Affine, VerifierError> {
         // Serialize the points
-        let a_data = a.serialize();
-        let b_data = b.serialize();
+        let a_data = a.serialize_to_bytes();
+        let b_data = b.serialize_to_bytes();
 
         // Call the `ecAdd` precompile
         let res_xy_bytes = static_call(
@@ -36,14 +36,15 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Deserialize the affine coordinates returned from the precompile
-        G1Affine::deserialize(&res_xy_bytes).map_err(|_| VerifierError::ArithmeticBackend)
+        G1Affine::deserialize_from_bytes(&res_xy_bytes)
+            .map_err(|_| VerifierError::ArithmeticBackend)
     }
 
     /// Calls the `ecMul` precompile with the given scalar and point, handling de/serialization
     fn ec_scalar_mul(&mut self, a: ScalarField, b: G1Affine) -> Result<G1Affine, VerifierError> {
         // Serialize the point and scalar
-        let a_data = a.serialize();
-        let b_data = b.serialize();
+        let a_data = a.serialize_to_bytes();
+        let b_data = b.serialize_to_bytes();
 
         // Call the `ecMul` precompile
         let res_xy_bytes = static_call(
@@ -54,7 +55,8 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Deserialize the affine coordinates returned from the precompile
-        G1Affine::deserialize(&res_xy_bytes).map_err(|_| VerifierError::ArithmeticBackend)
+        G1Affine::deserialize_from_bytes(&res_xy_bytes)
+            .map_err(|_| VerifierError::ArithmeticBackend)
     }
 
     /// Calls the `ecPairing` precompile with the given points, handling de/serialization
@@ -66,10 +68,10 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         b_2: G2Affine,
     ) -> Result<bool, VerifierError> {
         // Serialize the points
-        let a_1_data = a_1.serialize();
-        let b_1_data = b_1.serialize();
-        let a_2_data = a_2.serialize();
-        let b_2_data = b_2.serialize();
+        let a_1_data = a_1.serialize_to_bytes();
+        let b_1_data = b_1.serialize_to_bytes();
+        let a_2_data = a_2.serialize_to_bytes();
+        let b_2_data = b_2.serialize_to_bytes();
 
         // Call the `ecPairing` precompile
         let res = static_call(

--- a/contracts-stylus/src/verifier.rs
+++ b/contracts-stylus/src/verifier.rs
@@ -7,7 +7,7 @@ use common::{
     types::{Proof, ScalarField, VerificationKey},
 };
 use contracts_core::transcript::TranscriptHasher;
-use contracts_core::{serde::Deserializable, verifier::Verifier};
+use contracts_core::verifier::Verifier;
 use stylus_sdk::crypto::keccak;
 use stylus_sdk::{abi::Bytes, prelude::*};
 
@@ -33,16 +33,16 @@ impl VerifierContract {
         proof: Bytes,
         public_inputs: Bytes,
     ) -> Result<bool, Vec<u8>> {
-        let vkey: VerificationKey = Deserializable::deserialize(vkey.as_slice()).unwrap();
+        let vkey: VerificationKey = postcard::from_bytes(vkey.as_slice()).unwrap();
 
         let backend = EvmPrecompileBackend { contract: self };
 
         let mut verifier = Verifier::<EvmPrecompileBackend<_>, StylusHasher>::new(vkey, backend);
 
-        let proof: Proof = Deserializable::deserialize(proof.as_slice()).unwrap();
+        let proof: Proof = postcard::from_bytes(proof.as_slice()).unwrap();
 
         let public_inputs: [ScalarField; NUM_PUBLIC_INPUTS] =
-            Deserializable::deserialize(public_inputs.as_slice()).unwrap();
+            postcard::from_bytes(public_inputs.as_slice()).unwrap();
 
         Ok(verifier.verify(&proof, &public_inputs, &None).unwrap())
     }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -15,3 +15,4 @@ ark-std = { workspace = true }
 rand = "0.8.5"
 clap = { version = "4.4.7", features = ["derive"] }
 json = "0.12"
+postcard = { workspace = true }


### PR DESCRIPTION
This PR leverages the [`serde`](https://github.com/serde-rs/serde) and [`postcard`](https://github.com/jamesmunns/postcard) crates to derive de/serialization for types that get passed around as calldata, to mitigate complexity around our own custom serde functionality.

As a result, there is some renaming of traits / modules to better highlight the differences between these two serialization regimes, in that we only implement custom serialization formats when they are imposed on us externally (precompiles & transcript), and otherwise derive them automatically.

All tests pass