### PR TITLE
contracts-stylus: structured statements & marking nullifiers in darkpool

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -229,10 +229,6 @@ pub struct MatchPayload {
     pub wallet_blinder_share: ScalarField,
     /// The statement for the party's `VALID_COMMITMENTS` proof
     pub valid_commitments_statement: ValidCommitmentsStatement,
-    /// The party's `VALID_COMMITMENTS` proof
-    pub valid_commitments_proof: Proof,
     /// The statement for the party's `VALID_REBLIND` proof
     pub valid_reblind_statement: ValidReblindStatement,
-    /// The party's `VALID_REBLIND` proof
-    pub valid_reblind_proof: Proof,
 }

--- a/contracts-stylus/src/constants.rs
+++ b/contracts-stylus/src/constants.rs
@@ -9,3 +9,14 @@ pub const EC_PAIRING_ADDRESS_LAST_BYTE: u8 = 8;
 /// The index of the last byte of the `ecPairing` precompile result,
 /// which is a boolean indicating whether the pairing check succeeded
 pub const PAIRING_CHECK_RESULT_LAST_BYTE_INDEX: usize = 31;
+
+/// The ID of the `VALID_WALLET_CREATE` circuit
+pub const VALID_WALLET_CREATE_CIRCUIT_ID: u8 = 0;
+/// The ID of the `VALID_WALLET_UPDATE` circuit
+pub const VALID_WALLET_UPDATE_CIRCUIT_ID: u8 = 1;
+/// The ID of the `VALID_COMMITMENTS` circuit
+pub const VALID_COMMITMENTS_CIRCUIT_ID: u8 = 2;
+/// The ID of the `VALID_REBLIND` circuit
+pub const VALID_REBLIND_CIRCUIT_ID: u8 = 3;
+/// The ID of the `VALID_MATCH_SETTLE` circuit
+pub const VALID_MATCH_SETTLE_CIRCUIT_ID: u8 = 4;

--- a/contracts-stylus/src/darkpool.rs
+++ b/contracts-stylus/src/darkpool.rs
@@ -2,14 +2,28 @@
 //! verifying the various proofs of the Renegade protocol, and handling deposits / withdrawals.
 
 use alloc::vec::Vec;
+use common::{
+    serde_def_types::SerdeScalarField,
+    types::{
+        MatchPayload, ScalarField, ValidMatchSettleStatement, ValidWalletCreateStatement,
+        ValidWalletUpdateStatement,
+    },
+};
 use stylus_sdk::{
     abi::Bytes,
-    alloy_primitives::{aliases::B256, Address, U8},
+    alloy_primitives::{aliases::B256, Address},
     prelude::*,
-    storage::{StorageAddress, StorageBool, StorageBytes, StorageMap, StorageU8},
+    storage::{StorageAddress, StorageBool, StorageBytes, StorageMap},
 };
 
-use crate::interfaces::IVerifier;
+use crate::{
+    constants::{
+        VALID_COMMITMENTS_CIRCUIT_ID, VALID_MATCH_SETTLE_CIRCUIT_ID, VALID_REBLIND_CIRCUIT_ID,
+        VALID_WALLET_CREATE_CIRCUIT_ID, VALID_WALLET_UPDATE_CIRCUIT_ID,
+    },
+    interfaces::IVerifier,
+    utils::serialize_statement_for_verification,
+};
 
 type SolScalar = B256;
 
@@ -18,17 +32,6 @@ type SolScalar = B256;
 pub struct DarkpoolContract {
     /// The address of the verifier contract
     verifier_address: StorageAddress,
-
-    /// The circuit ID of the `VALID_WALLET_CREATE` circuit
-    valid_wallet_create_circuit_id: StorageU8,
-    /// The circuit ID of the `VALID_WALLET_UPDATE` circuit
-    valid_wallet_update_circuit_id: StorageU8,
-    /// The circuit ID of the `VALID_COMMITMENTS` circuit
-    valid_commitments_circuit_id: StorageU8,
-    /// The circuit ID of the `VALID_REBLIND` circuit
-    valid_reblind_circuit_id: StorageU8,
-    /// The circuit ID of the `VALID_MATCH_SETTLE` circuit
-    valid_match_settle_circuit_id: StorageU8,
 
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
@@ -55,50 +58,29 @@ impl DarkpoolContract {
     // TODO: Remove `set_*_circuit_id` & `add_verification_key` methods in favor of a single
     // `set_circuit` method after implementing enum ABI
 
-    /// Stores the circuit ID for the `VALID_WALLET_CREATE` circuit
-    pub fn set_valid_wallet_create_circuit_id(&mut self, circuit_id: u8) -> Result<(), Vec<u8>> {
-        self.valid_wallet_create_circuit_id
-            .set(U8::from(circuit_id));
-        Ok(())
+    /// Sets the verification key for the `VALID_WALLET_CREATE` circuit
+    pub fn set_valid_wallet_create_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.set_vkey(VALID_WALLET_CREATE_CIRCUIT_ID, vkey)
     }
 
-    /// Stores the circuit ID for the `VALID_WALLET_UPDATE` circuit
-    pub fn set_valid_wallet_update_circuit_id(&mut self, circuit_id: u8) -> Result<(), Vec<u8>> {
-        self.valid_wallet_update_circuit_id
-            .set(U8::from(circuit_id));
-        Ok(())
+    /// Sets the verification key for the `VALID_WALLET_UPDATE` circuit
+    pub fn set_valid_wallet_update_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.set_vkey(VALID_WALLET_UPDATE_CIRCUIT_ID, vkey)
     }
 
-    /// Stores the circuit ID for the `VALID_COMMITMENTS` circuit
-    pub fn set_valid_commitments_circuit_id(&mut self, circuit_id: u8) -> Result<(), Vec<u8>> {
-        self.valid_commitments_circuit_id.set(U8::from(circuit_id));
-        Ok(())
+    /// Sets the verification key for the `VALID_COMMITMENTS` circuit
+    pub fn set_valid_commitments_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.set_vkey(VALID_COMMITMENTS_CIRCUIT_ID, vkey)
     }
 
-    /// Stores the circuit ID for the `VALID_REBLIND` circuit
-    pub fn set_valid_reblind_circuit_id(&mut self, circuit_id: u8) -> Result<(), Vec<u8>> {
-        self.valid_reblind_circuit_id.set(U8::from(circuit_id));
-        Ok(())
+    /// Sets the verification key for the `VALID_REBLIND` circuit
+    pub fn set_valid_reblind_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.set_vkey(VALID_REBLIND_CIRCUIT_ID, vkey)
     }
 
-    /// Stores the circuit ID for the `VALID_MATCH_SETTLE` circuit
-    pub fn set_valid_match_settle_circuit_id(&mut self, circuit_id: u8) -> Result<(), Vec<u8>> {
-        self.valid_match_settle_circuit_id.set(U8::from(circuit_id));
-        Ok(())
-    }
-
-    /// Stores the given verification key with the given circuit ID
-    pub fn add_verification_key(&mut self, circuit_id: u8, vkey: Bytes) -> Result<(), Vec<u8>> {
-        // TODO: Assert well-formedness of the verification key
-        assert!(
-            self.verification_keys.get(circuit_id).is_empty(),
-            "Verification key ID in use"
-        );
-
-        let mut slot = self.verification_keys.setter(circuit_id);
-        slot.set_bytes(vkey);
-
-        Ok(())
+    /// Sets the verification key for the `VALID_MATCH_SETTLE` circuit
+    pub fn set_valid_match_settle_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.set_vkey(VALID_MATCH_SETTLE_CIRCUIT_ID, vkey)
     }
 
     // -----------
@@ -120,11 +102,17 @@ impl DarkpoolContract {
         &mut self,
         _wallet_blinder_share: SolScalar,
         proof: Bytes,
-        public_inputs: Bytes,
+        valid_wallet_create_statement_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
-        let valid_wallet_create_circuit_id = self.valid_wallet_create_circuit_id.get().to();
+        let valid_wallet_create_statement: ValidWalletCreateStatement =
+            postcard::from_bytes(valid_wallet_create_statement_bytes.as_slice()).unwrap();
+
+        let public_inputs = serialize_statement_for_verification(&valid_wallet_create_statement)
+            .unwrap()
+            .into();
+
         assert!(
-            self.verify(valid_wallet_create_circuit_id, proof, public_inputs)?,
+            self.verify(VALID_WALLET_CREATE_CIRCUIT_ID, proof, public_inputs)?,
             "`VALID_WALLET_CREATE` proof invalid"
         );
 
@@ -140,22 +128,30 @@ impl DarkpoolContract {
         &mut self,
         _wallet_blinder_share: SolScalar,
         proof: Bytes,
-        public_inputs: Bytes,
+        valid_wallet_update_statement_bytes: Bytes,
         _public_inputs_signature: Bytes,
     ) -> Result<(), Vec<u8>> {
+        let valid_wallet_update_statement: ValidWalletUpdateStatement =
+            postcard::from_bytes(valid_wallet_update_statement_bytes.as_slice()).unwrap();
+
         // TODO: Assert that the Merkle root for which inclusion is proven in `VALID_WALLET_UPDATE`
         // is a valid historical root
 
         // TODO: Hash public inputs and verify signature (requires parsing pk_root from public inputs)
 
-        let valid_wallet_update_circuit_id = self.valid_wallet_update_circuit_id.get().to();
+        let public_inputs = serialize_statement_for_verification(&valid_wallet_update_statement)
+            .unwrap()
+            .into();
+
         assert!(
-            self.verify(valid_wallet_update_circuit_id, proof, public_inputs)?,
+            self.verify(VALID_WALLET_UPDATE_CIRCUIT_ID, proof, public_inputs)?,
             "`VALID_WALLET_UPDATE` proof invalid"
         );
 
         // TODO: Compute wallet commitment and insert to Merkle tree
-        // TODO: Mark old wallet nullifier as spent (requires parsing old wallet nullifier from public inputs)
+
+        self.mark_nullifier_spent(valid_wallet_update_statement.old_shares_nullifier)?;
+
         // TODO: Execute external transfers
         // TODO: Emit wallet updated event w/ wallet blinder share
 
@@ -165,66 +161,95 @@ impl DarkpoolContract {
     /// Settles a matched order between two parties,
     /// inserting the updated wallets into the commitment tree
     // TODO: Return new tree root
-    // TODO: Remove this lint allowance after implementing structured statements
     #[allow(clippy::too_many_arguments)]
     pub fn process_match_settle(
         &mut self,
-        _party_0_wallet_blinder_share: SolScalar,
+        party_0_match_payload: Bytes,
         party_0_valid_commitments_proof: Bytes,
-        party_0_valid_commitments_public_inputs: Bytes,
         party_0_valid_reblind_proof: Bytes,
-        party_0_valid_reblind_public_inputs: Bytes,
-        _party_1_wallet_blinder_share: SolScalar,
+        party_1_match_payload: Bytes,
         party_1_valid_commitments_proof: Bytes,
-        party_1_valid_commitments_public_inputs: Bytes,
         party_1_valid_reblind_proof: Bytes,
-        party_1_valid_reblind_public_inputs: Bytes,
         valid_match_settle_proof: Bytes,
-        valid_match_settle_public_inputs: Bytes,
+        valid_match_settle_statement: Bytes,
     ) -> Result<(), Vec<u8>> {
+        let party_0_match_payload: MatchPayload =
+            postcard::from_bytes(party_0_match_payload.as_slice()).unwrap();
+
+        let party_1_match_payload: MatchPayload =
+            postcard::from_bytes(party_1_match_payload.as_slice()).unwrap();
+
+        let valid_match_settle_statement: ValidMatchSettleStatement =
+            postcard::from_bytes(valid_match_settle_statement.as_slice()).unwrap();
+
         // TODO: Assert that the Merkle roots for which inclusion is proven in `VALID_REBLIND`
         // are valid historical roots
 
-        let valid_commitments_circuit_id = self.valid_commitments_circuit_id.get().to();
+        let party_0_valid_commitments_public_inputs = serialize_statement_for_verification(
+            &party_0_match_payload.valid_commitments_statement,
+        )
+        .unwrap()
+        .into();
+
         assert!(
             self.verify(
-                valid_commitments_circuit_id,
+                VALID_COMMITMENTS_CIRCUIT_ID,
                 party_0_valid_commitments_proof,
                 party_0_valid_commitments_public_inputs
             )?,
             "Party 0 `VALID_COMMITMENTS` proof invalid"
         );
+
+        let party_1_valid_commitments_public_inputs = serialize_statement_for_verification(
+            &party_1_match_payload.valid_commitments_statement,
+        )
+        .unwrap()
+        .into();
+
         assert!(
             self.verify(
-                valid_commitments_circuit_id,
+                VALID_COMMITMENTS_CIRCUIT_ID,
                 party_1_valid_commitments_proof,
                 party_1_valid_commitments_public_inputs
             )?,
             "Party 1 `VALID_COMMITMENTS` proof invalid"
         );
 
-        let valid_reblind_circuit_id = self.valid_reblind_circuit_id.get().to();
+        let party_0_valid_reblind_public_inputs =
+            serialize_statement_for_verification(&party_0_match_payload.valid_reblind_statement)
+                .unwrap()
+                .into();
+
         assert!(
             self.verify(
-                valid_reblind_circuit_id,
+                VALID_REBLIND_CIRCUIT_ID,
                 party_0_valid_reblind_proof,
                 party_0_valid_reblind_public_inputs
             )?,
             "Party 0 `VALID_REBLIND` proof invalid"
         );
+
+        let party_1_valid_reblind_public_inputs =
+            serialize_statement_for_verification(&party_1_match_payload.valid_reblind_statement)
+                .unwrap()
+                .into();
+
         assert!(
             self.verify(
-                valid_reblind_circuit_id,
+                VALID_REBLIND_CIRCUIT_ID,
                 party_1_valid_reblind_proof,
                 party_1_valid_reblind_public_inputs
             )?,
             "Party 1 `VALID_REBLIND` proof invalid"
         );
 
-        let valid_match_settle_circuit_id = self.valid_match_settle_circuit_id.get().to();
+        let valid_match_settle_public_inputs =
+            serialize_statement_for_verification(&valid_match_settle_statement)
+                .unwrap()
+                .into();
         assert!(
             self.verify(
-                valid_match_settle_circuit_id,
+                VALID_MATCH_SETTLE_CIRCUIT_ID,
                 valid_match_settle_proof,
                 valid_match_settle_public_inputs
             )?,
@@ -232,7 +257,18 @@ impl DarkpoolContract {
         );
 
         // TODO: Compute wallet commitments and insert to Merkle tree
-        // TODO: Mark old wallet nullifiers as spent (requires parsing old wallet nullifiers from public inputs)
+
+        self.mark_nullifier_spent(
+            party_0_match_payload
+                .valid_reblind_statement
+                .original_shares_nullifier,
+        )?;
+        self.mark_nullifier_spent(
+            party_1_match_payload
+                .valid_reblind_statement
+                .original_shares_nullifier,
+        )?;
+
         // TODO: Emit wallet updated events w/ wallet blinder shares
 
         Ok(())
@@ -241,14 +277,30 @@ impl DarkpoolContract {
 
 /// Internal helper methods
 impl DarkpoolContract {
+    /// Sets the verification key for the given circuit ID
+    pub fn set_vkey(&mut self, circuit_id: u8, vkey: Bytes) -> Result<(), Vec<u8>> {
+        // TODO: Assert well-formedness of the verification key
+
+        let mut slot = self.verification_keys.setter(circuit_id);
+        slot.set_bytes(vkey);
+
+        Ok(())
+    }
+
     /// Marks the given nullifier as spent
-    pub fn mark_nullifier_spent(&mut self, nullifier: SolScalar) -> Result<(), Vec<u8>> {
+    pub fn mark_nullifier_spent(&mut self, nullifier: ScalarField) -> Result<(), Vec<u8>> {
+        let nullifier_ser: SolScalar = SolScalar::from_slice(
+            postcard::to_allocvec(&SerdeScalarField(nullifier))
+                .unwrap()
+                .as_slice(),
+        );
+
         assert!(
-            !self.nullifier_set.get(nullifier),
+            !self.nullifier_set.get(nullifier_ser),
             "Nullifier already spent"
         );
 
-        self.nullifier_set.insert(nullifier, true);
+        self.nullifier_set.insert(nullifier_ser, true);
         Ok(())
     }
 

--- a/contracts-stylus/src/utils.rs
+++ b/contracts-stylus/src/utils.rs
@@ -1,8 +1,12 @@
 //! Common utilities used throughout the smart contracts, including testing contracts.
 
-use common::types::{G1Affine, G2Affine, ScalarField};
+use alloc::vec::Vec;
+use common::{
+    serde_def_types::SerdeScalarField,
+    types::{G1Affine, G2Affine, ScalarField},
+};
 use contracts_core::{
-    custom_serde::{BytesDeserializable, BytesSerializable},
+    custom_serde::{BytesDeserializable, BytesSerializable, ScalarSerializable},
     verifier::{errors::VerifierError, G1ArithmeticBackend},
 };
 use stylus_sdk::{
@@ -85,4 +89,16 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         // However, the precompile always returns a 32-byte output
         Ok(res[PAIRING_CHECK_RESULT_LAST_BYTE_INDEX] == 1)
     }
+}
+
+pub fn serialize_statement_for_verification<S: ScalarSerializable>(
+    statement: &S,
+) -> postcard::Result<Vec<u8>> {
+    postcard::to_allocvec(
+        &statement
+            .serialize_to_scalars()
+            .into_iter()
+            .map(SerdeScalarField)
+            .collect::<Vec<_>>(),
+    )
 }


### PR DESCRIPTION
This PR leverages the recent serialization work to have the Darkpool external methods deserialize calldata into structured statement types, and use these structs to:
1. serialize into scalars to be used as public inputs for verification, and
2. mark nullifiers as spent where appropriate

Tests for this functionality are deferred to the next PR, as it will take a decent chunk of work to generate dummy statement types & circuits for testing.

It's worth noting that there is some back-and-forth serialization, e.g. deserialize a nullifier as part of a statement, only to reserialize it to be written to storage, but this is not worth the complexity of mitigating