### PR TITLE
contracts-core, contracts-stylus: verifier precompile w/ var-length public inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3770,8 +3771,13 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
+ "base64 0.21.4",
+ "chrono",
+ "hex",
  "serde",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ alloy-primitives = { version = "0.3.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_with = { version = "3.4", default-features = false, features = [
     "macros",
+    "alloc",
 ] }
 postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -22,8 +22,5 @@ pub const NUM_U64S_FELT: usize = 4;
 /// The number of bytes it takes to represent an unsigned 256-bit integer
 pub const NUM_BYTES_U256: usize = 32;
 
-/// The number of public inputs in the verifier testing circuit
-pub const NUM_PUBLIC_INPUTS: usize = 0;
-
 /// The number of secret-shared scalars it takes to represent a wallet
 pub const WALLET_SHARES_LEN: usize = 0;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,5 +1,6 @@
 //! Common types used throughout the verifier.
 
+use alloc::vec::Vec;
 use alloy_primitives::{Address, U256};
 use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fr};
 use ark_ec::short_weierstrass::Affine;
@@ -231,4 +232,14 @@ pub struct MatchPayload {
     pub valid_commitments_statement: ValidCommitmentsStatement,
     /// The statement for the party's `VALID_REBLIND` proof
     pub valid_reblind_statement: ValidReblindStatement,
+}
+
+/// A bundle of all of the inputs to the verifier
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct VerificationBundle {
+    pub vkey: VerificationKey,
+    pub proof: Proof,
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub public_inputs: Vec<ScalarField>,
 }

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -505,7 +505,7 @@ mod tests {
     use ark_ff::One;
     use common::types::{G1Affine, G2Affine, ScalarField};
     use jf_utils::multi_pairing;
-    use test_helpers::{convert_jf_proof_and_vkey, gen_jf_proof_and_vkey};
+    use test_helpers::{convert_jf_proof_and_vkey, gen_jf_proof_and_vkey, random_scalars};
 
     use crate::transcript::tests::TestHasher;
 
@@ -538,27 +538,30 @@ mod tests {
     }
 
     const N: usize = 8192;
+    const L: usize = 128;
 
     // Mirrors circuit definition in the Jellyfish benchmarks
     #[test]
     fn test_valid_proof_verification() {
-        let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(N).unwrap();
+        let public_inputs = random_scalars(L);
+        let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(N, &public_inputs).unwrap();
         let (proof, vkey) = convert_jf_proof_and_vkey(jf_proof, jf_vkey);
         let mut verifier =
             Verifier::<ArkG1ArithmeticBackend, TestHasher>::new(vkey, ArkG1ArithmeticBackend);
-        let result = verifier.verify(&proof, &[], &None).unwrap();
+        let result = verifier.verify(&proof, &public_inputs, &None).unwrap();
 
         assert!(result, "valid proof did not verify");
     }
 
     #[test]
     fn test_invalid_proof_verification() {
-        let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(N).unwrap();
+        let public_inputs = random_scalars(L);
+        let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(N, &public_inputs).unwrap();
         let (mut proof, vkey) = convert_jf_proof_and_vkey(jf_proof, jf_vkey);
         proof.z_bar += ScalarField::one();
         let mut verifier =
             Verifier::<ArkG1ArithmeticBackend, TestHasher>::new(vkey, ArkG1ArithmeticBackend);
-        let result = verifier.verify(&proof, &[], &None).unwrap();
+        let result = verifier.verify(&proof, &public_inputs, &None).unwrap();
 
         assert!(!result, "invalid proof verified");
     }

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -17,6 +17,7 @@ postcard = { workspace = true }
 [features]
 darkpool = []
 verifier = []
+verifier-test-contract = []
 darkpool-test-contract = []
 precompile-test-contract = ["dep:ark-std"]
 export-abi = ["stylus-sdk/export-abi"]

--- a/contracts-stylus/src/constants.rs
+++ b/contracts-stylus/src/constants.rs
@@ -11,12 +11,32 @@ pub const EC_PAIRING_ADDRESS_LAST_BYTE: u8 = 8;
 pub const PAIRING_CHECK_RESULT_LAST_BYTE_INDEX: usize = 31;
 
 /// The ID of the `VALID_WALLET_CREATE` circuit
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub const VALID_WALLET_CREATE_CIRCUIT_ID: u8 = 0;
 /// The ID of the `VALID_WALLET_UPDATE` circuit
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub const VALID_WALLET_UPDATE_CIRCUIT_ID: u8 = 1;
 /// The ID of the `VALID_COMMITMENTS` circuit
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub const VALID_COMMITMENTS_CIRCUIT_ID: u8 = 2;
 /// The ID of the `VALID_REBLIND` circuit
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub const VALID_REBLIND_CIRCUIT_ID: u8 = 3;
 /// The ID of the `VALID_MATCH_SETTLE` circuit
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub const VALID_MATCH_SETTLE_CIRCUIT_ID: u8 = 4;

--- a/contracts-stylus/src/interfaces.rs
+++ b/contracts-stylus/src/interfaces.rs
@@ -1,9 +1,0 @@
-//! Definitions of Solidity interfaces called by contracts in the Renegade protocol
-
-use stylus_sdk::stylus_proc::sol_interface;
-
-sol_interface! {
-    interface IVerifier {
-        function verify(bytes memory vkey, bytes memory proof, bytes memory public_inputs) external view returns (bool);
-    }
-}

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -2,7 +2,6 @@
 #![no_std]
 
 mod constants;
-mod interfaces;
 mod utils;
 
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
@@ -11,11 +10,12 @@ mod darkpool;
 #[cfg(feature = "verifier")]
 mod verifier;
 
-#[cfg(feature = "precompile-test-contract")]
-mod precompile_test_contract;
-
-#[cfg(feature = "darkpool-test-contract")]
-mod darkpool_test_contract;
+#[cfg(any(
+    feature = "precompile-test-contract",
+    feature = "verifier-test-contract",
+    feature = "darkpool-test-contract"
+))]
+mod test_contracts;
 
 extern crate alloc;
 

--- a/contracts-stylus/src/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/test_contracts/darkpool_test_contract.rs
@@ -1,12 +1,12 @@
 use alloc::vec::Vec;
+use common::serde_def_types::SerdeScalarField;
 use stylus_sdk::{
     abi::Bytes,
-    alloy_primitives::B256,
     call::{CallContext, StaticCallContext},
     prelude::*,
 };
 
-use crate::darkpool::DarkpoolContract;
+use crate::darkpool::{DarkpoolContract, SolScalar};
 
 // We implement the `CallContext` & `StaticCallContext` traits manually
 // for the `DarkpoolContract` because it is not the entrypoint when
@@ -31,8 +31,9 @@ struct DarkpoolTestContract {
 #[external]
 #[inherit(DarkpoolContract)]
 impl DarkpoolTestContract {
-    pub fn mark_nullifier_spent(&mut self, nullifier: B256) -> Result<(), Vec<u8>> {
-        self.darkpool.mark_nullifier_spent(nullifier)
+    pub fn mark_nullifier_spent(&mut self, nullifier: SolScalar) -> Result<(), Vec<u8>> {
+        let nullifier: SerdeScalarField = postcard::from_bytes(nullifier.as_slice()).unwrap();
+        self.darkpool.mark_nullifier_spent(nullifier.0)
     }
 
     pub fn verify(

--- a/contracts-stylus/src/test_contracts/mod.rs
+++ b/contracts-stylus/src/test_contracts/mod.rs
@@ -1,0 +1,10 @@
+//! Testing contracts which wrap various contract functionality for testing purposes.
+
+#[cfg(feature = "precompile-test-contract")]
+mod precompile_test_contract;
+
+#[cfg(feature = "verifier-test-contract")]
+mod verifier_test_contract;
+
+#[cfg(feature = "darkpool-test-contract")]
+mod darkpool_test_contract;

--- a/contracts-stylus/src/test_contracts/precompile_test_contract.rs
+++ b/contracts-stylus/src/test_contracts/precompile_test_contract.rs
@@ -18,7 +18,7 @@ struct PrecompileTestContract;
 #[external]
 impl PrecompileTestContract {
     pub fn test_ec_add(&mut self) -> Result<(), Vec<u8>> {
-        let mut backend = EvmPrecompileBackend { contract: self };
+        let mut backend = EvmPrecompileBackend;
 
         let mut rng = ark_std::test_rng();
         let a = G1Affine::rand(&mut rng);
@@ -30,7 +30,7 @@ impl PrecompileTestContract {
     }
 
     pub fn test_ec_mul(&mut self) -> Result<(), Vec<u8>> {
-        let mut backend = EvmPrecompileBackend { contract: self };
+        let mut backend = EvmPrecompileBackend;
 
         let mut rng = ark_std::test_rng();
         let a = ScalarField::rand(&mut rng);
@@ -44,7 +44,7 @@ impl PrecompileTestContract {
     }
 
     pub fn test_ec_pairing(&mut self) -> Result<(), Vec<u8>> {
-        let mut backend = EvmPrecompileBackend { contract: self };
+        let mut backend = EvmPrecompileBackend;
 
         let mut rng = ark_std::test_rng();
         let a_1 = G1Affine::rand(&mut rng);

--- a/contracts-stylus/src/test_contracts/verifier_test_contract.rs
+++ b/contracts-stylus/src/test_contracts/verifier_test_contract.rs
@@ -1,0 +1,21 @@
+//! Wrapper contract providing an ABI interface to the verifier "precompile" contract
+
+use alloc::vec::Vec;
+use stylus_sdk::{abi::Bytes, alloy_primitives::Address, call::static_call, prelude::*};
+
+#[solidity_storage]
+#[entrypoint]
+struct VerifierTestContract;
+
+#[external]
+impl VerifierTestContract {
+    fn verify(
+        &mut self,
+        verifier_address: Address,
+        verification_bundle_ser: Bytes,
+    ) -> Result<bool, Vec<u8>> {
+        let result = static_call(self, verifier_address, &verification_bundle_ser)?;
+
+        Ok(result[0] != 0)
+    }
+}

--- a/contracts-stylus/src/utils.rs
+++ b/contracts-stylus/src/utils.rs
@@ -9,22 +9,16 @@ use contracts_core::{
     custom_serde::{BytesDeserializable, BytesSerializable, ScalarSerializable},
     verifier::{errors::VerifierError, G1ArithmeticBackend},
 };
-use stylus_sdk::{
-    alloy_primitives::Address,
-    call::{static_call, Call},
-    storage::TopLevelStorage,
-};
+use stylus_sdk::{alloy_primitives::Address, call::RawCall};
 
 use crate::constants::{
     EC_ADD_ADDRESS_LAST_BYTE, EC_MUL_ADDRESS_LAST_BYTE, EC_PAIRING_ADDRESS_LAST_BYTE,
     PAIRING_CHECK_RESULT_LAST_BYTE_INDEX,
 };
 
-pub struct EvmPrecompileBackend<S> {
-    pub contract: S,
-}
+pub struct EvmPrecompileBackend;
 
-impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&'a mut S> {
+impl G1ArithmeticBackend for EvmPrecompileBackend {
     /// Calls the `ecAdd` precompile with the given points, handling de/serialization
     fn ec_add(&mut self, a: G1Affine, b: G1Affine) -> Result<G1Affine, VerifierError> {
         // Serialize the points
@@ -32,12 +26,12 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         let b_data = b.serialize_to_bytes();
 
         // Call the `ecAdd` precompile
-        let res_xy_bytes = static_call(
-            Call::new_in(self.contract),
-            Address::with_last_byte(EC_ADD_ADDRESS_LAST_BYTE),
-            &[a_data, b_data].concat(),
-        )
-        .map_err(|_| VerifierError::ArithmeticBackend)?;
+        let res_xy_bytes = RawCall::new_static()
+            .call(
+                Address::with_last_byte(EC_ADD_ADDRESS_LAST_BYTE),
+                &[a_data, b_data].concat(),
+            )
+            .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Deserialize the affine coordinates returned from the precompile
         G1Affine::deserialize_from_bytes(&res_xy_bytes)
@@ -51,12 +45,12 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         let b_data = b.serialize_to_bytes();
 
         // Call the `ecMul` precompile
-        let res_xy_bytes = static_call(
-            Call::new_in(self.contract),
-            Address::with_last_byte(EC_MUL_ADDRESS_LAST_BYTE),
-            &[b_data, a_data].concat(),
-        )
-        .map_err(|_| VerifierError::ArithmeticBackend)?;
+        let res_xy_bytes = RawCall::new_static()
+            .call(
+                Address::with_last_byte(EC_MUL_ADDRESS_LAST_BYTE),
+                &[b_data, a_data].concat(),
+            )
+            .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Deserialize the affine coordinates returned from the precompile
         G1Affine::deserialize_from_bytes(&res_xy_bytes)
@@ -78,19 +72,30 @@ impl<'a, S: TopLevelStorage + 'a> G1ArithmeticBackend for EvmPrecompileBackend<&
         let b_2_data = b_2.serialize_to_bytes();
 
         // Call the `ecPairing` precompile
-        let res = static_call(
-            Call::new_in(self.contract),
-            Address::with_last_byte(EC_PAIRING_ADDRESS_LAST_BYTE),
-            &[a_1_data, b_1_data, a_2_data, b_2_data].concat(),
-        )
-        .map_err(|_| VerifierError::ArithmeticBackend)?;
+        let res = RawCall::new_static()
+            // Only get the last byte of the 32-byte return data,
+            // containing the boolean result
+            .limit_return_data(
+                PAIRING_CHECK_RESULT_LAST_BYTE_INDEX, /* offset */
+                1,                                    /* size */
+            )
+            .call(
+                Address::with_last_byte(EC_PAIRING_ADDRESS_LAST_BYTE),
+                &[a_1_data, b_1_data, a_2_data, b_2_data].concat(),
+            )
+            .map_err(|_| VerifierError::ArithmeticBackend)?;
 
         // Return the result of the pairing check, which is either a 0 or 1.
-        // However, the precompile always returns a 32-byte output
-        Ok(res[PAIRING_CHECK_RESULT_LAST_BYTE_INDEX] == 1)
+        Ok(res[0] == 1)
     }
 }
 
+/// Serializes the given statement into scalars, and then into bytes,
+/// as expected by the verifier contract.
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub fn serialize_statement_for_verification<S: ScalarSerializable>(
     statement: &S,
 ) -> postcard::Result<Vec<u8>> {

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -14,9 +14,9 @@ abigen!(
 );
 
 abigen!(
-    VerifierContract,
+    VerifierTestContract,
     r#"[
-        function verify(bytes memory vkey, bytes memory proof, bytes memory public_inputs) external view returns (bool)
+        function verify(address memory verifier_address, bytes memory verification_bundle_ser) external view returns (bool)
     ]"#
 );
 

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -30,5 +30,4 @@ pub(crate) enum Tests {
     NullifierSet,
     Verifier,
     Precompile,
-    DarkpoolVerification,
 }

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -16,5 +16,14 @@ pub(crate) const PRECOMPILE_TEST_CONTRACT_KEY: &str = "precompile_test_contract"
 /// The verifier contract key in the `deployments.json` file
 pub(crate) const VERIFIER_CONTRACT_KEY: &str = "verifier_contract";
 
+/// The verifier contract key in the `deployments.json` file
+pub(crate) const VERIFIER_TEST_CONTRACT_KEY: &str = "verifier_test_contract";
+
 /// The darkpool test contract key in the `deployments.json` file
 pub(crate) const DARKPOOL_TEST_CONTRACT_KEY: &str = "darkpool_test_contract";
+
+/// The domain size to use when testing the verifier contract
+pub(crate) const N: usize = 8192;
+
+/// The number of public inputs to use when testing the verifier contract
+pub(crate) const L: usize = 128;

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,11 +1,12 @@
 //! Basic tests for Stylus programs. These assume that a devnet is already running locally.
 
-use abis::{DarkpoolTestContract, PrecompileTestContract, VerifierContract};
+use abis::{DarkpoolTestContract, PrecompileTestContract, VerifierTestContract};
 use clap::Parser;
 use cli::{Cli, Tests};
+use constants::VERIFIER_CONTRACT_KEY;
 use eyre::Result;
-use tests::{test_nullifier_set, test_precompile_backend, test_verifier, test_darkpool_verification};
-use utils::{get_test_contract_address, setup_client};
+use tests::{test_nullifier_set, test_precompile_backend, test_verifier};
+use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
 mod abis;
 mod cli;
@@ -31,15 +32,12 @@ async fn main() -> Result<()> {
 
             test_nullifier_set(contract).await?;
         }
-        Tests::DarkpoolVerification => {
-            let contract = DarkpoolTestContract::new(contract_address, client);
-
-            test_darkpool_verification(contract, deployments_file).await?;
-        }
         Tests::Verifier => {
-            let contract = VerifierContract::new(contract_address, client);
+            let contract = VerifierTestContract::new(contract_address, client);
+            let verifier_address =
+                parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
 
-            test_verifier(contract).await?;
+            test_verifier(contract, verifier_address).await?;
         }
         Tests::Precompile => {
             let contract = PrecompileTestContract::new(contract_address, client);

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -14,7 +14,7 @@ use crate::{
     cli::Tests,
     constants::{
         DARKPOOL_TEST_CONTRACT_KEY, DEPLOYMENTS_KEY, PRECOMPILE_TEST_CONTRACT_KEY,
-        VERIFIER_CONTRACT_KEY,
+        VERIFIER_TEST_CONTRACT_KEY,
     },
 };
 
@@ -56,11 +56,8 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: String) -
         Tests::NullifierSet => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
-        Tests::DarkpoolVerification => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
-        }
         Tests::Verifier => {
-            parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?
         }
         Tests::Precompile => {
             parse_addr_from_deployments_file(deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?


### PR DESCRIPTION
This PR changes the verifier contract to be a "minimal stylus entrypoint", in that it effectively acts as a precompile. The contract gets static-called directly without exposing an ABI-encoded interface. This brings the binary size down by avoiding ABI encoding/decoding code paths.

This became necessary when introducing variable-length inputs, as the code bloat from deserializing a vector of scalars just pushed the verifier contract over the limit.

As such, this PR also includes the changes necessary for variable-length public inputs, and the updates to the Darkpool contract to ingest these changes.

In order to test the verifier, I've introduced a test contract which exposes an interface, this makes it much more straightforward to interact with in testing code. All tests pass, save for the Darkpool verification test which has been removed in anticipation of tests with circuits that match the statements expected by the Darkpool.