### PR TITLE
integration: initialize `update_wallet` test w/ nullifier check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,7 @@ dependencies = [
  "ark-std",
  "common",
  "jf-utils",
+ "rand",
  "sha3",
  "test-helpers",
 ]
@@ -4193,6 +4194,7 @@ dependencies = [
 name = "test-helpers"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "ark-bn254",
  "ark-ec",
  "ark-std",
@@ -4201,6 +4203,7 @@ dependencies = [
  "jf-primitives",
  "jf-relation",
  "jf-utils",
+ "rand",
 ]
 
 [[package]]

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -14,7 +14,7 @@ pub const HASH_OUTPUT_SIZE: usize = 32;
 
 /// The number of bytes to represent field elements of the base or scalar fields for the G1 curve group,
 /// as well as the base field which is extended for the G2 curve group
-pub const FELT_BYTES: usize = 32;
+pub const NUM_BYTES_FELT: usize = 32;
 
 /// The number of u64s it takes to represent a field element
 pub const NUM_U64S_FELT: usize = 4;
@@ -24,6 +24,9 @@ pub const NUM_BYTES_U64: usize = 8;
 
 /// The number of bytes it takes to represent an unsigned 256-bit integer
 pub const NUM_BYTES_U256: usize = 32;
+
+/// The number of bytes it takes to represent an Ethereum address
+pub const NUM_BYTES_ADDRESS: usize = 20;
 
 /// The number of secret-shared scalars it takes to represent a wallet
 pub const WALLET_SHARES_LEN: usize = 0;

--- a/common/src/custom_serde.rs
+++ b/common/src/custom_serde.rs
@@ -9,7 +9,7 @@ use ark_ff::{BigInt, BigInteger, MontConfig, PrimeField, Zero};
 use ark_serialize::Flags;
 
 use crate::{
-    constants::{FELT_BYTES, NUM_BYTES_U64, NUM_U64S_FELT},
+    constants::{NUM_BYTES_FELT, NUM_BYTES_U64, NUM_U64S_FELT},
     types::{
         ExternalTransfer, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256,
         PublicSigningKey, ScalarField, ValidCommitmentsStatement, ValidMatchSettleStatement,
@@ -81,7 +81,7 @@ impl<P: MontConfig<NUM_U64S_FELT>> BytesSerializable for MontFp256<P> {
 }
 
 impl<P: MontConfig<NUM_U64S_FELT>> BytesDeserializable for MontFp256<P> {
-    const SER_LEN: usize = FELT_BYTES;
+    const SER_LEN: usize = NUM_BYTES_FELT;
 
     fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, SerdeError> {
         // Field elements are serialized as big-endian, so we need to reverse here
@@ -111,7 +111,7 @@ impl BytesSerializable for G1Affine {
 }
 
 impl BytesDeserializable for G1Affine {
-    const SER_LEN: usize = FELT_BYTES * 2;
+    const SER_LEN: usize = NUM_BYTES_FELT * 2;
 
     /// Deserializes a G1 point from a byte array.
     ///
@@ -143,7 +143,7 @@ impl BytesSerializable for TranscriptG1 {
         };
 
         let mut x_bytes = x.into_bigint().to_bytes_le();
-        x_bytes[FELT_BYTES - 1] |= flags.u8_bitmask();
+        x_bytes[NUM_BYTES_FELT - 1] |= flags.u8_bitmask();
 
         x_bytes
     }
@@ -169,7 +169,7 @@ impl BytesSerializable for G2Affine {
 }
 
 impl BytesDeserializable for G2Affine {
-    const SER_LEN: usize = FELT_BYTES * 4;
+    const SER_LEN: usize = NUM_BYTES_FELT * 4;
 
     fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, SerdeError> {
         let mut cursor = 0;
@@ -359,7 +359,7 @@ fn deserialize_cursor<D: BytesDeserializable>(
     Ok(elem)
 }
 
-fn bigint_from_le_bytes(bytes: &[u8; FELT_BYTES]) -> Result<BigInt<NUM_U64S_FELT>, SerdeError> {
+fn bigint_from_le_bytes(bytes: &[u8; NUM_BYTES_FELT]) -> Result<BigInt<NUM_U64S_FELT>, SerdeError> {
     let mut u64s = [0u64; NUM_U64S_FELT];
     for i in 0..NUM_U64S_FELT {
         u64s[i] = u64::from_le_bytes(
@@ -374,7 +374,7 @@ fn bigint_from_le_bytes(bytes: &[u8; FELT_BYTES]) -> Result<BigInt<NUM_U64S_FELT
 #[cfg(test)]
 mod tests {
     use crate::{
-        constants::FELT_BYTES,
+        constants::NUM_BYTES_FELT,
         types::{G1Affine, G2Affine},
     };
     use ark_ec::AffineRepr;
@@ -400,10 +400,10 @@ mod tests {
         let a = G2Affine::generator();
         let res = a.serialize_to_bytes();
 
-        let x_c1 = BigUint::from_bytes_be(&res[..FELT_BYTES]);
-        let x_c0 = BigUint::from_bytes_be(&res[FELT_BYTES..FELT_BYTES * 2]);
-        let y_c1 = BigUint::from_bytes_be(&res[FELT_BYTES * 2..FELT_BYTES * 3]);
-        let y_c0 = BigUint::from_bytes_be(&res[FELT_BYTES * 3..]);
+        let x_c1 = BigUint::from_bytes_be(&res[..NUM_BYTES_FELT]);
+        let x_c0 = BigUint::from_bytes_be(&res[NUM_BYTES_FELT..NUM_BYTES_FELT * 2]);
+        let y_c1 = BigUint::from_bytes_be(&res[NUM_BYTES_FELT * 2..NUM_BYTES_FELT * 3]);
+        let y_c0 = BigUint::from_bytes_be(&res[NUM_BYTES_FELT * 3..]);
 
         // Expected values taken from: https://eips.ethereum.org/EIPS/eip-197#definition-of-the-groups
         assert_eq!(

--- a/common/src/custom_serde.rs
+++ b/common/src/custom_serde.rs
@@ -216,8 +216,12 @@ impl ScalarSerializable for u64 {
 
 impl ScalarSerializable for Address {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
-        let bytes = self.into_word().0;
-        // TODO: Assert address endianness is consistent with relayer-side implementation
+        // `into_word` left-pads the address w/ zeroes to 32 bytes.
+        // For now, we'll call this "big-endian" and reverse it so that the resulting
+        // little-endian `BigInt` fits in the scalar field.
+        // TODO: Ensure scalar representation is consistent with the relayer implementation
+        let mut bytes = self.into_word().0;
+        bytes.reverse();
         let bigint = bigint_from_le_bytes(&bytes)?;
         Ok(vec![
             ScalarField::from_bigint(bigint).ok_or(SerdeError::ScalarConversion)?

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -17,3 +17,4 @@ ark-std = { workspace = true }
 sha3 = { version = "^0.10", default-features = false }
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 test-helpers = { path = "../test-helpers" }
+rand = { workspace = true }

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -139,6 +139,7 @@ fn to_transcript_g1s(points: &[G1Affine]) -> Vec<TranscriptG1> {
 pub mod tests {
     use ark_std::UniformRand;
     use common::{constants::HASH_OUTPUT_SIZE, types::ScalarField};
+    use rand::thread_rng;
     use sha3::{Digest, Keccak256};
     use test_helpers::{dummy_proofs, dummy_vkeys, get_jf_challenges};
 
@@ -158,7 +159,7 @@ pub mod tests {
 
     #[test]
     fn test_transcript_equivalency() {
-        let mut rng = ark_std::test_rng();
+        let mut rng = thread_rng();
         let (vkey, jf_vkey) = dummy_vkeys(N as u64, L as u64);
         let (proof, jf_proof) = dummy_proofs();
         let public_inputs = [ScalarField::rand(&mut rng); L];

--- a/contracts-stylus/src/darkpool.rs
+++ b/contracts-stylus/src/darkpool.rs
@@ -171,7 +171,7 @@ impl DarkpoolContract {
         party_1_valid_commitments_proof: Bytes,
         party_1_valid_reblind_proof: Bytes,
         valid_match_settle_proof: Bytes,
-        valid_match_settle_statement: Bytes,
+        valid_match_settle_statement_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
         let party_0_match_payload: MatchPayload =
             postcard::from_bytes(party_0_match_payload.as_slice()).unwrap();
@@ -180,7 +180,7 @@ impl DarkpoolContract {
             postcard::from_bytes(party_1_match_payload.as_slice()).unwrap();
 
         let valid_match_settle_statement: ValidMatchSettleStatement =
-            postcard::from_bytes(valid_match_settle_statement.as_slice()).unwrap();
+            postcard::from_bytes(valid_match_settle_statement_bytes.as_slice()).unwrap();
 
         // TODO: Assert that the Merkle roots for which inclusion is proven in `VALID_REBLIND`
         // are valid historical roots

--- a/contracts-stylus/src/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/test_contracts/darkpool_test_contract.rs
@@ -6,7 +6,7 @@ use stylus_sdk::{
     prelude::*,
 };
 
-use crate::darkpool::{DarkpoolContract, SolScalar};
+use crate::darkpool::DarkpoolContract;
 
 // We implement the `CallContext` & `StaticCallContext` traits manually
 // for the `DarkpoolContract` because it is not the entrypoint when
@@ -31,9 +31,10 @@ struct DarkpoolTestContract {
 #[external]
 #[inherit(DarkpoolContract)]
 impl DarkpoolTestContract {
-    pub fn mark_nullifier_spent(&mut self, nullifier: SolScalar) -> Result<(), Vec<u8>> {
+    pub fn mark_nullifier_spent(&mut self, nullifier: Bytes) -> Result<(), Vec<u8>> {
         let nullifier: SerdeScalarField = postcard::from_bytes(nullifier.as_slice()).unwrap();
-        self.darkpool.mark_nullifier_spent(nullifier.0)
+        self.darkpool.mark_nullifier_spent(nullifier.0);
+        Ok(())
     }
 
     pub fn verify(
@@ -42,6 +43,6 @@ impl DarkpoolTestContract {
         proof: Bytes,
         public_inputs: Bytes,
     ) -> Result<bool, Vec<u8>> {
-        self.darkpool.verify(circuit_id, proof, public_inputs)
+        Ok(self.darkpool.verify(circuit_id, proof, public_inputs))
     }
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -13,11 +13,11 @@ abigen!(
         function setValidReblindVkey(bytes memory vkey) external
         function setValidMatchSettleVkey(bytes memory vkey) external
 
-        function isNullifierSpent(bytes32 memory nullifier) external view returns (bool)
-        function markNullifierSpent(bytes32 memory nullifier) external
+        function isNullifierSpent(bytes memory nullifier) external view returns (bool)
+        function markNullifierSpent(bytes memory nullifier) external
 
-        function newWallet(bytes32 memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes32 memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
+        function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
 
         function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,10 +5,21 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
+        function setVerifierAddress(address memory _address) external
+
+        function setValidWalletCreateVkey(bytes memory vkey) external
+        function setValidWalletUpdateVkey(bytes memory vkey) external
+        function setValidCommitmentsVkey(bytes memory vkey) external
+        function setValidReblindVkey(bytes memory vkey) external
+        function setValidMatchSettleVkey(bytes memory vkey) external
+
         function isNullifierSpent(bytes32 memory nullifier) external view returns (bool)
         function markNullifierSpent(bytes32 memory nullifier) external
-        function setVerifierAddress(address memory _address) external
-        function addVerificationKey(uint8 memory circuit_id, bytes memory vkey) external
+
+        function newWallet(bytes32 memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
+        function updateWallet(bytes32 memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
+
         function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)
     ]"#
 );

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -27,7 +27,8 @@ pub(crate) struct Cli {
 
 #[derive(ValueEnum, Clone, Copy)]
 pub(crate) enum Tests {
+    Precompile,
     NullifierSet,
     Verifier,
-    Precompile,
+    UpdateWallet,
 }

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use cli::{Cli, Tests};
 use constants::VERIFIER_CONTRACT_KEY;
 use eyre::Result;
-use tests::{test_nullifier_set, test_precompile_backend, test_verifier};
+use tests::{test_nullifier_set, test_precompile_backend, test_verifier, test_update_wallet};
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
 mod abis;
@@ -27,23 +27,30 @@ async fn main() -> Result<()> {
     let contract_address = get_test_contract_address(test, deployments_file.clone())?;
 
     match test {
+        Tests::Precompile => {
+            let contract = PrecompileTestContract::new(contract_address, client);
+
+            test_precompile_backend(contract).await?;
+        },
         Tests::NullifierSet => {
             let contract = DarkpoolTestContract::new(contract_address, client);
 
             test_nullifier_set(contract).await?;
-        }
+        },
         Tests::Verifier => {
             let contract = VerifierTestContract::new(contract_address, client);
             let verifier_address =
                 parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
 
             test_verifier(contract, verifier_address).await?;
-        }
-        Tests::Precompile => {
-            let contract = PrecompileTestContract::new(contract_address, client);
+        },
+        Tests::UpdateWallet => {
+            let contract = DarkpoolTestContract::new(contract_address, client);
+            let verifier_address =
+                parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
 
-            test_precompile_backend(contract).await?;
-        }
+            test_update_wallet(contract, verifier_address).await?;
+        },
     }
 
     Ok(())

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -53,14 +53,17 @@ pub(crate) fn parse_addr_from_deployments_file(
 
 pub(crate) fn get_test_contract_address(test: Tests, deployments_file: String) -> Result<Address> {
     Ok(match test {
+        Tests::Precompile => {
+            parse_addr_from_deployments_file(deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?
+        }
         Tests::NullifierSet => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
         Tests::Verifier => {
             parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?
         }
-        Tests::Precompile => {
-            parse_addr_from_deployments_file(deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?
+        Tests::UpdateWallet => {
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
     })
 }

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
+rand = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-std = { workspace = true }
@@ -15,3 +16,4 @@ jf-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", features 
 jf-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
+alloy-primitives = { workspace = true }


### PR DESCRIPTION
This PR introduces some scaffolding to test the various wallet interaction methods on the darkpool, and leverages this to make a barebones `update_wallet` test that for now, assures that the proof verifies and that the correct nullifier was spent.