### PR TITLE
integration: set up `process_match_settle` test, check nullifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,11 +4199,13 @@ dependencies = [
  "ark-ec",
  "ark-std",
  "common",
+ "eyre",
  "jf-plonk",
  "jf-primitives",
  "jf-relation",
  "jf-utils",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,7 @@ dependencies = [
  "json",
  "postcard",
  "rand",
+ "serde",
  "test-helpers",
  "tokio",
 ]
@@ -4890,9 +4891,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
 rand = "0.8.5"
 num-bigint = { version = "0.4", default-features = false }
 eyre = "0.6.8"
+ethers = "2.0"
 
 [profile.release]
 codegen-units = 1        # prefer efficiency to compile time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_with = { version = "3.4", default-features = false, features = [
 postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
 rand = "0.8.5"
 num-bigint = { version = "0.4", default-features = false }
+eyre = "0.6.8"
 
 [profile.release]
 codegen-units = 1        # prefer efficiency to compile time

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -9,7 +9,7 @@ contracts-core = { path = "../contracts-core" }
 test-helpers = { path = "../test-helpers" }
 tokio = { version = "1.12.0", features = ["full"] }
 ethers = "2.0"
-eyre = "0.6.8"
+eyre = { workspace = true }
 ark-ff = { workspace = true }
 ark-std = { workspace = true }
 rand = { workspace = true }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -8,7 +8,7 @@ common = { path = "../common" }
 contracts-core = { path = "../contracts-core" }
 test-helpers = { path = "../test-helpers" }
 tokio = { version = "1.12.0", features = ["full"] }
-ethers = "2.0"
+ethers = { workspace = true }
 eyre = { workspace = true }
 ark-ff = { workspace = true }
 ark-std = { workspace = true }
@@ -16,3 +16,4 @@ rand = { workspace = true }
 clap = { version = "4.4.7", features = ["derive"] }
 json = "0.12"
 postcard = { workspace = true }
+serde = { workspace = true }

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -31,4 +31,5 @@ pub(crate) enum Tests {
     NullifierSet,
     Verifier,
     UpdateWallet,
+    ProcessMatchSettle,
 }

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use cli::{Cli, Tests};
 use constants::VERIFIER_CONTRACT_KEY;
 use eyre::Result;
-use tests::{test_nullifier_set, test_precompile_backend, test_verifier, test_update_wallet};
+use tests::{test_nullifier_set, test_precompile_backend, test_verifier, test_update_wallet, test_process_match_settle};
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
 mod abis;
@@ -50,6 +50,13 @@ async fn main() -> Result<()> {
                 parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
 
             test_update_wallet(contract, verifier_address).await?;
+        },
+        Tests::ProcessMatchSettle => {
+            let contract = DarkpoolTestContract::new(contract_address, client);
+            let verifier_address =
+                parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
+
+            test_process_match_settle(contract, verifier_address).await?;
         },
     }
 

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -4,14 +4,13 @@ use ark_ff::One;
 use ark_std::UniformRand;
 use common::{
     serde_def_types::SerdeScalarField,
-    types::{ScalarField, VerificationBundle},
+    types::{ScalarField, ValidWalletUpdateStatement, VerificationBundle},
 };
 use ethers::{abi::Address, providers::Middleware, types::Bytes};
 use eyre::Result;
 use rand::thread_rng;
 use test_helpers::{
-    convert_jf_proof_and_vkey, dummy_circuit_bundle, extract_statement, gen_jf_proof_and_vkey,
-    random_scalars, Circuit, Statement,
+    convert_jf_proof_and_vkey, dummy_circuit_bundle, gen_jf_proof_and_vkey, random_scalars, Circuit,
 };
 
 use crate::{
@@ -97,7 +96,7 @@ pub(crate) async fn test_update_wallet(
     // Generate test data
     let mut rng = thread_rng();
     let (valid_wallet_update_statement, vkey, proof) =
-        dummy_circuit_bundle(Circuit::ValidWalletUpdate, N, &mut rng)?;
+        dummy_circuit_bundle::<ValidWalletUpdateStatement>(N, &mut rng)?;
     let wallet_blinder_share = SerdeScalarField(ScalarField::rand(&mut rng));
 
     // Set up contract
@@ -121,8 +120,6 @@ pub(crate) async fn test_update_wallet(
         .await?;
 
     // Assert that correct nullifier is spent
-    let valid_wallet_update_statement =
-        extract_statement!(valid_wallet_update_statement, Statement::ValidWalletUpdate);
     let nullifier_bytes = serialize_to_calldata(&SerdeScalarField(
         valid_wallet_update_statement.old_shares_nullifier,
     ))?;

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -2,15 +2,19 @@
 
 use std::{fs::File, io::Read, str::FromStr, sync::Arc};
 
+use common::types::{Proof, VerificationKey};
 use ethers::{
     abi::Address,
     middleware::SignerMiddleware,
     providers::{Http, Middleware, Provider},
     signers::{LocalWallet, Signer},
+    types::Bytes,
 };
 use eyre::{eyre, Result};
+use test_helpers::{Circuit, Statement};
 
 use crate::{
+    abis::DarkpoolTestContract,
     cli::Tests,
     constants::{
         DARKPOOL_TEST_CONTRACT_KEY, DEPLOYMENTS_KEY, PRECOMPILE_TEST_CONTRACT_KEY,
@@ -66,4 +70,44 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: String) -
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
     })
+}
+
+pub(crate) fn serialize_circuit_bundle(
+    bundle: &(Statement, VerificationKey, Proof),
+) -> Result<(Bytes, Bytes, Bytes)> {
+    let (statement, vkey, proof) = bundle;
+    let statement_bytes: Bytes = postcard::to_allocvec(statement)?.into();
+    let vkey_bytes = postcard::to_allocvec(vkey)?.into();
+    let proof_bytes: Bytes = postcard::to_allocvec(proof)?.into();
+
+    Ok((statement_bytes, vkey_bytes, proof_bytes))
+}
+
+pub(crate) async fn setup_darkpool_test_contract(
+    contract: &DarkpoolTestContract<impl Middleware + 'static>,
+    verifier_address: Address,
+    vkeys: Vec<(Circuit, Bytes)>,
+) -> Result<()> {
+    // Set verifier address
+    contract
+        .set_verifier_address(verifier_address)
+        .send()
+        .await?
+        .await?;
+
+    // Set verification keys
+    for (circuit, vkey_bytes) in vkeys {
+        match circuit {
+            Circuit::ValidWalletCreate => contract.set_valid_wallet_create_vkey(vkey_bytes),
+            Circuit::ValidWalletUpdate => contract.set_valid_wallet_update_vkey(vkey_bytes),
+            Circuit::ValidCommitments => contract.set_valid_commitments_vkey(vkey_bytes),
+            Circuit::ValidReblind => contract.set_valid_reblind_vkey(vkey_bytes),
+            Circuit::ValidMatchSettle => contract.set_valid_match_settle_vkey(vkey_bytes),
+        }
+        .send()
+        .await?
+        .await?;
+    }
+
+    Ok(())
 }

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -9,6 +9,9 @@ rand = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-std = { workspace = true }
+alloy-primitives = { workspace = true }
+eyre = { workspace = true }
+serde = { workspace = true }
 jf-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", features = [
     "test-srs",
     "test_apis",
@@ -16,4 +19,3 @@ jf-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", features 
 jf-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
-alloy-primitives = { workspace = true }


### PR DESCRIPTION
This PR introduces additional helpers & scaffolding for the integration tests, and adds an integration test for the `process_match_settle` in which we assert that the correct nullifiers were marked as spent.