### PR TITLE
contracts-stylus: darkpool: verify ECDSA sig on VALID WALLET UPDATE statement

### DIFF
--- a/contracts-stylus/src/utils.rs
+++ b/contracts-stylus/src/utils.rs
@@ -2,18 +2,25 @@
 
 use alloc::vec::Vec;
 use common::{
-    backends::{EcRecoverBackend, EcdsaError, G1ArithmeticBackend, G1ArithmeticError},
+    backends::{EcRecoverBackend, EcdsaError, G1ArithmeticBackend, G1ArithmeticError, HashBackend},
     constants::{HASH_OUTPUT_SIZE, NUM_BYTES_ADDRESS, NUM_BYTES_SIGNATURE, NUM_BYTES_U256},
     custom_serde::{BytesDeserializable, BytesSerializable, ScalarSerializable},
     serde_def_types::SerdeScalarField,
     types::{G1Affine, G2Affine, ScalarField},
 };
-use stylus_sdk::{alloy_primitives::Address, call::RawCall};
+use stylus_sdk::{alloy_primitives::Address, call::RawCall, crypto::keccak};
 
 use crate::constants::{
     EC_ADD_ADDRESS_LAST_BYTE, EC_MUL_ADDRESS_LAST_BYTE, EC_PAIRING_ADDRESS_LAST_BYTE,
     EC_RECOVER_ADDRESS_LAST_BYTE, PAIRING_CHECK_RESULT_LAST_BYTE_INDEX,
 };
+
+pub struct StylusHasher;
+impl HashBackend for StylusHasher {
+    fn hash(input: &[u8]) -> [u8; HASH_OUTPUT_SIZE] {
+        keccak(input).into()
+    }
+}
 
 pub struct PrecompileG1ArithmeticBackend;
 

--- a/contracts-stylus/src/verifier.rs
+++ b/contracts-stylus/src/verifier.rs
@@ -1,18 +1,11 @@
 //! The verifier smart contract, responsible for verifying Plonk proofs.
 
 use alloc::{vec, vec::Vec};
-use common::{backends::HashBackend, constants::HASH_OUTPUT_SIZE, types::VerificationBundle};
+use common::types::VerificationBundle;
 use contracts_core::verifier::Verifier;
-use stylus_sdk::{crypto::keccak, prelude::*, ArbResult};
+use stylus_sdk::{prelude::*, ArbResult};
 
-use crate::utils::PrecompileG1ArithmeticBackend;
-
-pub struct StylusHasher;
-impl HashBackend for StylusHasher {
-    fn hash(input: &[u8]) -> [u8; HASH_OUTPUT_SIZE] {
-        keccak(input).into()
-    }
-}
+use crate::utils::{PrecompileG1ArithmeticBackend, StylusHasher};
 
 /// Verify the given proof, using the given verification bundle
 #[entrypoint]

--- a/test-helpers/src/renegade_circuits.rs
+++ b/test-helpers/src/renegade_circuits.rs
@@ -124,16 +124,24 @@ fn dummy_public_signing_key(rng: &mut impl Rng) -> PublicSigningKey {
     }
 }
 
-pub fn dummy_circuit_bundle<S: RenegadeStatement>(
+pub fn circuit_bundle_from_statement<S: RenegadeStatement>(
+    statement: &S,
     num_public_inputs: usize,
-    rng: &mut impl Rng,
-) -> Result<(S, VerificationKey, Proof)> {
-    let statement = S::dummy(rng);
+) -> Result<(VerificationKey, Proof)> {
     let public_inputs = statement
         .serialize_to_scalars()
         .map_err(|_| eyre!("failed to serialize statement to scalars"))?;
     let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(num_public_inputs, &public_inputs)?;
     let (proof, vkey) = convert_jf_proof_and_vkey(jf_proof, jf_vkey);
 
+    Ok((vkey, proof))
+}
+
+pub fn dummy_circuit_bundle<S: RenegadeStatement>(
+    num_public_inputs: usize,
+    rng: &mut impl Rng,
+) -> Result<(S, VerificationKey, Proof)> {
+    let statement = S::dummy(rng);
+    let (vkey, proof) = circuit_bundle_from_statement(&statement, num_public_inputs)?;
     Ok((statement, vkey, proof))
 }


### PR DESCRIPTION
This PR uses the `ecdsa_verify` method in `update_wallet` on the darkpool to verify ECDSA signatures of the `VALID WALLET UPDATE` statement using the `ecRecover` precompile. The `update_wallet` test has been updated to properly sign the statement, and passes.