### PR TITLE
contracts-stylus: darkpool: implement external transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
 name = "contracts-stylus"
 version = "0.1.0"
 dependencies = [
+ "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -2264,6 +2265,7 @@ dependencies = [
 name = "integration"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "ark-ec",
  "ark-ff",
  "ark-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ark-poly = "0.4.0"
 ark-std = "0.4.0"
 ark-serialize = "0.4.0"
 alloy-primitives = { version = "0.3.1", default-features = false }
+alloy-sol-types = { version = "0.3.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_with = { version = "3.4", default-features = false, features = [
     "macros",

--- a/common/src/custom_serde.rs
+++ b/common/src/custom_serde.rs
@@ -280,7 +280,15 @@ impl ScalarSerializable for ValidWalletUpdateStatement {
         ];
         scalars.extend(self.new_public_shares);
         scalars.push(self.merkle_root);
-        scalars.extend(self.external_transfer.serialize_to_scalars()?);
+
+        let external_transfer_scalars = self
+            .external_transfer
+            .as_ref()
+            .map_or(ExternalTransfer::default().serialize_to_scalars(), |e| {
+                e.serialize_to_scalars()
+            })?;
+        scalars.extend(external_transfer_scalars);
+
         scalars.extend(self.old_pk_root.serialize_to_scalars()?);
         scalars.extend(self.timestamp.serialize_to_scalars()?);
         Ok(scalars)

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -106,7 +106,7 @@ pub struct Challenges {
 
 /// Represents an external transfer of an ERC20 token
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct ExternalTransfer {
     /// The address of the account contract to deposit from or withdraw to
     #[serde_as(as = "AddressDef")]
@@ -163,7 +163,7 @@ pub struct ValidWalletUpdateStatement {
     #[serde_as(as = "ScalarFieldDef")]
     pub merkle_root: ScalarField,
     /// The external transfer associated with this update
-    pub external_transfer: ExternalTransfer,
+    pub external_transfer: Option<ExternalTransfer>,
     /// The public root key of the old wallet, rotated out after this update
     pub old_pk_root: PublicSigningKey,
     /// The timestamp this update was applied at

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -12,6 +12,7 @@ ark-bn254 = { workspace = true }
 common = { path = "../common" }
 contracts-core = { path = "../contracts-core" }
 postcard = { workspace = true }
+alloy-sol-types = { workspace = true }
 
 [features]
 darkpool = []
@@ -19,6 +20,7 @@ verifier = []
 verifier-test-contract = []
 darkpool-test-contract = []
 precompile-test-contract = []
+dummy-erc20 = []
 export-abi = ["stylus-sdk/export-abi"]
 
 [lib]

--- a/contracts-stylus/src/darkpool.rs
+++ b/contracts-stylus/src/darkpool.rs
@@ -158,7 +158,7 @@ impl DarkpoolContract {
         self.mark_nullifier_spent(valid_wallet_update_statement.old_shares_nullifier);
 
         if let Some(external_transfer) = valid_wallet_update_statement.external_transfer {
-            self.execute_external_transfer(external_transfer);
+            self.execute_external_transfer(&external_transfer);
         }
 
         // TODO: Emit wallet updated event w/ wallet blinder share
@@ -284,7 +284,7 @@ impl DarkpoolContract {
         result[0] != 0
     }
 
-    pub fn execute_external_transfer(&mut self, transfer: ExternalTransfer) {
+    pub fn execute_external_transfer(&mut self, transfer: &ExternalTransfer) {
         let erc20 = IERC20::new(transfer.mint);
         if transfer.is_withdrawal {
             erc20

--- a/contracts-stylus/src/interfaces.rs
+++ b/contracts-stylus/src/interfaces.rs
@@ -1,0 +1,18 @@
+//! Solidity ABI-compatible interface definitions used by the darkpool
+
+use stylus_sdk::stylus_proc::sol_interface;
+
+sol_interface! {
+    // Taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/token/ERC20/IERC20.sol
+    interface IERC20 {
+        event Transfer(address indexed from, address indexed to, uint256 value);
+        event Approval(address indexed owner, address indexed spender, uint256 value);
+
+        function totalSupply() external view returns (uint256);
+        function balanceOf(address account) external view returns (uint256);
+        function transfer(address to, uint256 value) external returns (bool);
+        function allowance(address owner, address spender) external view returns (uint256);
+        function approve(address spender, uint256 value) external returns (bool);
+        function transferFrom(address from, address to, uint256 value) external returns (bool);
+    }
+}

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 mod constants;
+mod interfaces;
 mod utils;
 
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -14,7 +14,8 @@ mod verifier;
 #[cfg(any(
     feature = "precompile-test-contract",
     feature = "verifier-test-contract",
-    feature = "darkpool-test-contract"
+    feature = "darkpool-test-contract",
+    feature = "dummy-erc20"
 ))]
 mod test_contracts;
 

--- a/contracts-stylus/src/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/test_contracts/dummy_erc20.rs
@@ -1,0 +1,174 @@
+//! A mock ERC20 token implementation used in integration testing.
+//!
+//! THIS IS NOT MEANT TO BE DEPLOYED AS A PRODUCTION CONTRACT.
+//!
+//! Adapted from https://github.com/OffchainLabs/stylus-sdk-rs/tree/stylus/examples/erc20
+
+use alloc::{string::String, vec::Vec};
+use core::marker::PhantomData;
+use stylus_sdk::{
+    alloy_primitives::{Address, U256},
+    alloy_sol_types::{sol, SolError},
+    evm, msg,
+    prelude::*,
+};
+
+pub trait Erc20Params {
+    const NAME: &'static str;
+    const SYMBOL: &'static str;
+    const DECIMALS: u8;
+}
+
+sol_storage! {
+    /// Erc20 implements all ERC-20 methods.
+    pub struct Erc20<T> {
+        /// Maps users to balances
+        mapping(address => uint256) balances;
+        /// The total supply of the token
+        uint256 total_supply;
+        /// Used to allow [`Erc20Params`]
+        PhantomData<T> phantom;
+    }
+}
+
+// Declare events and Solidity error types
+sol! {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    error InsufficientBalance(address from, uint256 have, uint256 want);
+}
+
+pub enum Erc20Error {
+    InsufficientBalance(InsufficientBalance),
+}
+
+// We will soon provide a #[derive(SolidityError)] to clean this up
+impl From<Erc20Error> for Vec<u8> {
+    fn from(err: Erc20Error) -> Vec<u8> {
+        match err {
+            Erc20Error::InsufficientBalance(e) => e.encode(),
+        }
+    }
+}
+
+// These methods aren't exposed to other contracts
+// Note: modifying storage will become much prettier soon
+impl<T: Erc20Params> Erc20<T> {
+    pub fn transfer_impl(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<(), Erc20Error> {
+        let mut sender_balance = self.balances.setter(from);
+        let old_sender_balance = sender_balance.get();
+        if old_sender_balance < value {
+            return Err(Erc20Error::InsufficientBalance(InsufficientBalance {
+                from,
+                have: old_sender_balance,
+                want: value,
+            }));
+        }
+        sender_balance.set(old_sender_balance - value);
+        let mut to_balance = self.balances.setter(to);
+        let new_to_balance = to_balance.get() + value;
+        to_balance.set(new_to_balance);
+        evm::log(Transfer { from, to, value });
+        Ok(())
+    }
+
+    pub fn mint(&mut self, address: Address, value: U256) {
+        let mut balance = self.balances.setter(address);
+        let new_balance = balance.get() + value;
+        balance.set(new_balance);
+        self.total_supply.set(self.total_supply.get() + value);
+        evm::log(Transfer {
+            from: Address::ZERO,
+            to: address,
+            value,
+        });
+    }
+
+    pub fn _burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
+        let mut balance = self.balances.setter(address);
+        let old_balance = balance.get();
+        if old_balance < value {
+            return Err(Erc20Error::InsufficientBalance(InsufficientBalance {
+                from: address,
+                have: old_balance,
+                want: value,
+            }));
+        }
+        balance.set(old_balance - value);
+        self.total_supply.set(self.total_supply.get() - value);
+        evm::log(Transfer {
+            from: address,
+            to: Address::ZERO,
+            value,
+        });
+        Ok(())
+    }
+}
+
+// These methods are external to other contracts
+// Note: modifying storage will become much prettier soon
+#[external]
+impl<T: Erc20Params> Erc20<T> {
+    pub fn name() -> Result<String, Erc20Error> {
+        Ok(T::NAME.into())
+    }
+
+    pub fn symbol() -> Result<String, Erc20Error> {
+        Ok(T::SYMBOL.into())
+    }
+
+    pub fn decimals() -> Result<u8, Erc20Error> {
+        Ok(T::DECIMALS)
+    }
+
+    pub fn balance_of(&self, address: Address) -> Result<U256, Erc20Error> {
+        Ok(self.balances.get(address))
+    }
+
+    pub fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Erc20Error> {
+        self.transfer_impl(msg::sender(), to, value)?;
+        Ok(true)
+    }
+
+    pub fn transfer_from(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<bool, Erc20Error> {
+        self.transfer_impl(from, to, value)?;
+        Ok(true)
+    }
+}
+
+struct DummyErc20Params;
+
+/// Immutable definitions
+impl Erc20Params for DummyErc20Params {
+    const NAME: &'static str = "Dummy ERC 20";
+    const SYMBOL: &'static str = "DUMMY";
+    const DECIMALS: u8 = 18;
+}
+
+// The contract
+sol_storage! {
+    #[entrypoint] // Makes DummyErc20 the entrypoint
+    struct DummyErc20 {
+        #[borrow] // Allows erc20 to access DummyErc20's storage and make calls
+        Erc20<DummyErc20Params> erc20;
+    }
+}
+
+#[external]
+#[inherit(Erc20<DummyErc20Params>)]
+impl DummyErc20 {
+    pub fn mint(&mut self, address: Address, amount: U256) -> Result<(), Vec<u8>> {
+        self.erc20.mint(address, amount);
+        Ok(())
+    }
+}

--- a/contracts-stylus/src/test_contracts/mod.rs
+++ b/contracts-stylus/src/test_contracts/mod.rs
@@ -8,3 +8,6 @@ mod verifier_test_contract;
 
 #[cfg(feature = "darkpool-test-contract")]
 mod darkpool_test_contract;
+
+#[cfg(feature = "dummy-erc20")]
+mod dummy_erc20;

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -18,3 +18,4 @@ clap = { version = "4.4.7", features = ["derive"] }
 json = "0.12"
 postcard = { workspace = true }
 serde = { workspace = true }
+alloy-primitives = { workspace = true }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -21,6 +21,8 @@ abigen!(
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
 
         function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)
+
+        function executeExternalTransfer(bytes memory transfer) external
     ]"#
 );
 
@@ -38,5 +40,13 @@ abigen!(
         function testEcMul(bytes memory a_bytes, bytes memory b_bytes) external view returns (bytes)
         function testEcPairing(bytes memory a_bytes, bytes memory b_bytes) external view returns (bool)
         function testEcRecover(bytes memory msg_hash, bytes memory signature) external view returns (bytes)
+    ]"#
+);
+
+abigen!(
+    DummyErc20Contract,
+    r#"[
+        function mint(address memory _address, uint256 memory value) external
+        function balanceOf(address memory _address) external view returns (uint256)
     ]"#
 );

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -33,6 +33,7 @@ pub(crate) enum Tests {
     EcRecover,
     NullifierSet,
     Verifier,
+    ExternalTransfer,
     UpdateWallet,
     ProcessMatchSettle,
 }

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -22,8 +22,14 @@ pub(crate) const VERIFIER_TEST_CONTRACT_KEY: &str = "verifier_test_contract";
 /// The darkpool test contract key in the `deployments.json` file
 pub(crate) const DARKPOOL_TEST_CONTRACT_KEY: &str = "darkpool_test_contract";
 
+/// The dummy erc20 contract key in the `deployments.json` file
+pub(crate) const DUMMY_ERC20_CONTRACT_KEY: &str = "dummy_erc20_contract";
+
 /// The domain size to use when testing the verifier contract
 pub(crate) const N: usize = 8192;
 
 /// The number of public inputs to use when testing the verifier contract
 pub(crate) const L: usize = 128;
+
+/// The amount of dummy ERC20 tokens to use when testing external transfers
+pub(crate) const TRANSFER_AMOUNT: u64 = 1000;

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,13 +1,15 @@
 //! Basic tests for Stylus programs. These assume that a devnet is already running locally.
 
-use abis::{DarkpoolTestContract, PrecompileTestContract, VerifierTestContract};
+use abis::{
+    DarkpoolTestContract, DummyErc20Contract, PrecompileTestContract, VerifierTestContract,
+};
 use clap::Parser;
 use cli::{Cli, Tests};
-use constants::VERIFIER_CONTRACT_KEY;
+use constants::{DUMMY_ERC20_CONTRACT_KEY, VERIFIER_CONTRACT_KEY};
 use eyre::Result;
 use tests::{
-    test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_nullifier_set,
-    test_process_match_settle, test_update_wallet, test_verifier,
+    test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
+    test_nullifier_set, test_process_match_settle, test_update_wallet, test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -61,6 +63,14 @@ async fn main() -> Result<()> {
                 parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
 
             test_verifier(contract, verifier_address).await?;
+        }
+        Tests::ExternalTransfer => {
+            let contract = DarkpoolTestContract::new(contract_address, client.clone());
+            let dummy_erc20_address =
+                parse_addr_from_deployments_file(deployments_file, DUMMY_ERC20_CONTRACT_KEY)?;
+            let dummy_erc20_contract = DummyErc20Contract::new(dummy_erc20_address, client);
+
+            test_external_transfer(contract, dummy_erc20_contract).await?;
         }
         Tests::UpdateWallet => {
             let contract = DarkpoolTestContract::new(contract_address, client);

--- a/test-helpers/src/renegade_circuits.rs
+++ b/test-helpers/src/renegade_circuits.rs
@@ -39,7 +39,7 @@ impl RenegadeStatement for ValidWalletUpdateStatement {
             new_private_shares_commitment: ScalarField::rand(rng),
             new_public_shares: dummy_wallet_shares(rng),
             merkle_root: ScalarField::rand(rng),
-            external_transfer: dummy_external_transfer(rng),
+            external_transfer: Some(dummy_external_transfer(rng)),
             old_pk_root: dummy_public_signing_key(rng),
             timestamp: rng.gen(),
         }


### PR DESCRIPTION
This PR implements external transfer functionality in the `update_wallet` method of the darkpool.

It also adds an integration test for the `execute_external_transfer` helper, which passes. This required defining a dummy ERC20 contract, which was adapted from https://github.com/OffchainLabs/stylus-sdk-rs/tree/stylus/examples/erc20, so review is not needed for it.