### PR TITLE
contracts-stylus: components, darkpool: add ownership checks

### DIFF
--- a/contracts-stylus/src/contracts/components/mod.rs
+++ b/contracts-stylus/src/contracts/components/mod.rs
@@ -1,0 +1,3 @@
+//! Composable contract "components" that other smart contracts can inherit for common functionality
+
+pub mod ownable;

--- a/contracts-stylus/src/contracts/components/ownable.rs
+++ b/contracts-stylus/src/contracts/components/ownable.rs
@@ -1,0 +1,43 @@
+//! Mirrors OpenZeppelin's `Ownable` contract for access controls:
+//! https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/access/Ownable.sol
+
+use alloc::vec::Vec;
+use stylus_sdk::{alloy_primitives::Address, msg, prelude::*, storage::StorageAddress};
+
+#[solidity_storage]
+pub struct Ownable {
+    owner: StorageAddress,
+}
+
+#[external]
+impl Ownable {
+    pub fn owner(&self) -> Result<Address, Vec<u8>> {
+        Ok(self.owner.get())
+    }
+
+    pub fn renounce_ownership(&mut self) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
+        self._transfer_ownership(Address::ZERO);
+        Ok(())
+    }
+
+    pub fn transfer_ownership(&mut self, new_owner: Address) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
+        assert_ne!(new_owner, Address::ZERO);
+        self._transfer_ownership(new_owner);
+        Ok(())
+    }
+}
+
+/// Internal methods
+impl Ownable {
+    pub fn _check_owner(&self) -> Result<(), Vec<u8>> {
+        assert_eq!(self.owner()?, msg::sender());
+        Ok(())
+    }
+
+    pub fn _transfer_ownership(&mut self, new_owner: Address) {
+        self.owner.set(new_owner);
+        // TODO: Emit ownership transfer event
+    }
+}

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -29,9 +29,14 @@ use crate::utils::{
     interfaces::IERC20,
 };
 
+use super::components::ownable::Ownable;
+
 #[solidity_storage]
 #[cfg_attr(feature = "darkpool", entrypoint)]
 pub struct DarkpoolContract {
+    #[borrow]
+    pub ownable: Ownable,
+
     /// The address of the verifier contract
     verifier_address: StorageAddress,
 
@@ -46,6 +51,7 @@ pub struct DarkpoolContract {
 }
 
 #[external]
+#[inherit(Ownable)]
 impl DarkpoolContract {
     // ----------
     // | CONFIG |
@@ -53,6 +59,7 @@ impl DarkpoolContract {
 
     /// Stores the given address for the verifier contract
     pub fn set_verifier_address(&mut self, address: Address) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.verifier_address.set(address);
         Ok(())
     }
@@ -62,30 +69,35 @@ impl DarkpoolContract {
 
     /// Sets the verification key for the `VALID_WALLET_CREATE` circuit
     pub fn set_valid_wallet_create_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.set_vkey(VALID_WALLET_CREATE_CIRCUIT_ID, vkey);
         Ok(())
     }
 
     /// Sets the verification key for the `VALID_WALLET_UPDATE` circuit
     pub fn set_valid_wallet_update_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.set_vkey(VALID_WALLET_UPDATE_CIRCUIT_ID, vkey);
         Ok(())
     }
 
     /// Sets the verification key for the `VALID_COMMITMENTS` circuit
     pub fn set_valid_commitments_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.set_vkey(VALID_COMMITMENTS_CIRCUIT_ID, vkey);
         Ok(())
     }
 
     /// Sets the verification key for the `VALID_REBLIND` circuit
     pub fn set_valid_reblind_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.set_vkey(VALID_REBLIND_CIRCUIT_ID, vkey);
         Ok(())
     }
 
     /// Sets the verification key for the `VALID_MATCH_SETTLE` circuit
     pub fn set_valid_match_settle_vkey(&mut self, vkey: Bytes) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.set_vkey(VALID_MATCH_SETTLE_CIRCUIT_ID, vkey);
         Ok(())
     }

--- a/contracts-stylus/src/contracts/mod.rs
+++ b/contracts-stylus/src/contracts/mod.rs
@@ -13,3 +13,5 @@ mod verifier;
     feature = "dummy-erc20"
 ))]
 mod test_contracts;
+
+mod components;

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,6 +5,8 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
+        function transferOwnership(address memory newOwner) external
+
         function setVerifierAddress(address memory _address) external
 
         function setValidWalletCreateVkey(bytes memory vkey) external

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -33,6 +33,7 @@ pub(crate) enum Tests {
     EcRecover,
     NullifierSet,
     Verifier,
+    Ownership,
     ExternalTransfer,
     UpdateWallet,
     ProcessMatchSettle,

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -5,11 +5,12 @@ use abis::{
 };
 use clap::Parser;
 use cli::{Cli, Tests};
-use constants::{DUMMY_ERC20_CONTRACT_KEY, VERIFIER_CONTRACT_KEY};
+use constants::{DARKPOOL_TEST_CONTRACT_KEY, DUMMY_ERC20_CONTRACT_KEY, VERIFIER_CONTRACT_KEY};
 use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_nullifier_set, test_process_match_settle, test_update_wallet, test_verifier,
+    test_nullifier_set, test_ownership, test_process_match_settle, test_update_wallet,
+    test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -63,6 +64,13 @@ async fn main() -> Result<()> {
                 parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?;
 
             test_verifier(contract, verifier_address).await?;
+        }
+        Tests::Ownership => {
+            let contract = DarkpoolTestContract::new(contract_address, client.clone());
+            let darkpool_test_contract_address =
+                parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?;
+
+            test_ownership(contract, darkpool_test_contract_address).await?;
         }
         Tests::ExternalTransfer => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());


### PR DESCRIPTION
This PR adds ownership checks to the relevant methods on the darkpool contract by mirroring the functionality of OpenZeppelin's [`Ownable`](https://docs.openzeppelin.com/contracts/5.x/api/access#Ownable) contract in Stylus.

Additionally, this PR adds tests asserting that each of the protected methods can only be called by the owner.