### PR TITLE
contracts-stylus: merkle: add Merkle contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,6 +2289,7 @@ name = "integration"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "ark-crypto-primitives",
  "ark-ec",
  "ark-ff",
  "ark-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,17 +50,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
@@ -106,7 +95,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -120,21 +109,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
-]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -352,8 +326,8 @@ dependencies = [
 
 [[package]]
 name = "ark-mpc"
-version = "0.1.1"
-source = "git+https://github.com/renegade-fi/ark-mpc.git#6ef64d5d014af4d2f90909797e9508ed6796b683"
+version = "0.1.2"
+source = "git+https://github.com/renegade-fi/ark-mpc#4f4d2c122137d9788686c4ca4e54d2d8dabe9aa7"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -485,7 +459,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -571,7 +545,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -783,11 +756,8 @@ version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
 ]
 
 [[package]]
@@ -832,7 +802,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -918,7 +888,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "serde",
- "serde_with 3.4.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -949,10 +919,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#6a66bd62e50ae5b86f78dd6973eb02b5fb04daa8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/circuits-refactor#1ed1d034d82ae79777ff47232ad553284dda09f2"
 dependencies = [
  "ark-bn254",
- "ark-mpc",
 ]
 
 [[package]]
@@ -972,7 +941,7 @@ dependencies = [
  "rand",
  "renegade-crypto",
  "serde",
- "serde_with 3.4.0",
+ "serde_with",
  "test-helpers",
 ]
 
@@ -1126,7 +1095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1138,7 +1107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -1150,7 +1119,7 @@ checksum = "704722d1d929489c8528bb1882805700f1ba20f54325704973e786352320b1ed"
 dependencies = [
  "blake2",
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "serdect",
 ]
 
@@ -1187,7 +1156,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1211,7 +1180,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1222,7 +1191,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1248,7 +1217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1343,7 +1311,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1403,7 +1371,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1459,9 +1427,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -1608,7 +1576,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.38",
+ "syn 2.0.39",
  "toml",
  "walkdir",
 ]
@@ -1626,7 +1594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1652,7 +1620,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.38",
+ "syn 2.0.39",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1811,15 +1779,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
+checksum = "f69037fe1b785e84986b4f2cbcf647381876a00671d25ceef715d7812dd7e1dd"
 
 [[package]]
 name = "fixed-hash"
@@ -1946,7 +1914,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2011,15 +1979,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2053,7 +2019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2081,9 +2047,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.7",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2091,7 +2054,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash",
 ]
 
 [[package]]
@@ -2224,29 +2187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,7 +2254,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2408,41 +2347,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jf-plonk"
-version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7f8dbe5cb0c98fef71f17e17b828de28069975e7"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-mpc",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "async-trait",
- "derivative",
- "displaydoc",
- "downcast-rs",
- "dyn-clone",
- "espresso-systems-common",
- "futures",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "jf-primitives",
- "jf-relation",
- "jf-utils",
- "merlin",
- "num-bigint",
- "rand_chacha",
- "rayon",
- "serde",
- "sha3",
- "tagged-base64",
-]
-
-[[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7f8dbe5cb0c98fef71f17e17b828de28069975e7"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -2468,9 +2375,9 @@ dependencies = [
  "espresso-systems-common",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "jf-relation",
  "jf-utils",
  "merlin",
+ "mpc-relation",
  "num-bigint",
  "num-traits",
  "rand_chacha",
@@ -2484,35 +2391,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "jf-relation"
-version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7f8dbe5cb0c98fef71f17e17b828de28069975e7"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-381",
- "ark-bn254",
- "ark-bw6-761",
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "derivative",
- "displaydoc",
- "downcast-rs",
- "dyn-clone",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "jf-utils",
- "num-bigint",
- "rand_chacha",
- "rayon",
-]
-
-[[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7f8dbe5cb0c98fef71f17e17b828de28069975e7"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2638,9 +2519,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
@@ -2649,10 +2530,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.10"
+name = "libredox"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -2669,15 +2561,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "md-5"
@@ -2705,29 +2588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoize"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7500eb334b820fcb9d8bfb9061d75fe910ed6302f690b24f3abaa133a581479c"
-dependencies = [
- "lazy_static",
- "lru",
- "memoize-inner",
-]
-
-[[package]]
-name = "memoize-inner"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfde264c318ec8c2de5c39e0ba3910fac8d1065e3b947b183ebd884b799719b"
-dependencies = [
- "lazy_static",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,7 +2601,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
 ]
 
@@ -2772,33 +2632,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpc-stark"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84d6e9643f4e3917c59649b653969e5eee7bf372a80587bfdeead8eec90cb85"
+name = "mpc-plonk"
+version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-mpc",
+ "ark-poly",
  "ark-serialize",
+ "ark-std",
  "async-trait",
- "bytes",
- "crossbeam",
- "digest",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "dyn-clone",
+ "espresso-systems-common",
  "futures",
+ "hashbrown 0.13.2",
  "itertools 0.10.5",
- "kanal",
+ "jf-primitives",
+ "jf-utils",
+ "merlin",
+ "mpc-relation",
  "num-bigint",
- "quinn",
- "rand",
- "rcgen",
- "rustc-hash",
- "rustls 0.20.9",
+ "rand_chacha",
+ "rayon",
  "serde",
- "serde_json",
  "sha3",
- "tokio",
- "tracing",
- "zeroize",
+ "tagged-base64",
+]
+
+[[package]]
+name = "mpc-relation"
+version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+dependencies = [
+ "ark-bls12-377",
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-bw6-761",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "dyn-clone",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "jf-utils",
+ "num-bigint",
+ "rand_chacha",
+ "rayon",
 ]
 
 [[package]]
@@ -2868,7 +2756,7 @@ dependencies = [
  "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2973,7 +2861,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -2985,7 +2873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -3088,7 +2976,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3126,7 +3014,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3210,7 +3098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3368,7 +3256,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3378,14 +3266,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -3402,7 +3284,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3439,15 +3321,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -3457,12 +3330,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -3504,24 +3377,17 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#6a66bd62e50ae5b86f78dd6973eb02b5fb04daa8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/circuits-refactor#1ed1d034d82ae79777ff47232ad553284dda09f2"
 dependencies = [
- "ark-crypto-primitives",
  "ark-ec",
  "ark-ff",
- "ark-mpc",
  "bigdecimal",
  "constants",
  "itertools 0.10.5",
  "lazy_static",
- "memoize",
- "mpc-stark",
  "num-bigint",
- "rand",
- "rand_core 0.5.1",
  "serde",
  "serde_json",
- "starknet",
 ]
 
 [[package]]
@@ -3900,22 +3766,22 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3923,17 +3789,6 @@ name = "serde_json"
 version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_json_pythonic"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
 dependencies = [
  "itoa",
  "ryu",
@@ -3963,22 +3818,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
@@ -3988,20 +3827,8 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.38",
 ]
 
 [[package]]
@@ -4013,7 +3840,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4074,7 +3901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4190,187 +4017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcb61961b91757a9bc2d11549067445b2f921bd957f53710db35449767a1ba3"
-dependencies = [
- "starknet-accounts",
- "starknet-contract",
- "starknet-core 0.5.1",
- "starknet-crypto",
- "starknet-ff",
- "starknet-macros",
- "starknet-providers",
- "starknet-signers",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111ed887e4db14f0df1f909905e7737e4730770c8ed70997b58a71d5d940daac"
-dependencies = [
- "async-trait",
- "starknet-core 0.5.1",
- "starknet-providers",
- "starknet-signers",
- "thiserror",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d6f81a647694b2cb669ab60e77954b57bf5fbc757f5fcaf0a791c3bd341f04"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with 2.3.3",
- "starknet-accounts",
- "starknet-core 0.5.1",
- "starknet-providers",
- "thiserror",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f89c79b641618de8aa9668d74c6b6634659ceca311c6318a35c025f9d4d969"
-dependencies = [
- "base64 0.21.5",
- "flate2",
- "hex",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with 2.3.3",
- "sha3",
- "starknet-crypto",
- "starknet-ff",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1683ca7c63f0642310eddedb7d35056d8306084dff323d440711065c63ed87"
-dependencies = [
- "base64 0.21.5",
- "flate2",
- "hex",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with 2.3.3",
- "sha3",
- "starknet-crypto",
- "starknet-ff",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rfc6979",
- "sha2",
- "starknet-crypto-codegen",
- "starknet-curve",
- "starknet-ff",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto-codegen"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
-dependencies = [
- "starknet-curve",
- "starknet-ff",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
-dependencies = [
- "starknet-ff",
-]
-
-[[package]]
-name = "starknet-ff"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
-dependencies = [
- "ark-ff",
- "bigdecimal",
- "crypto-bigint",
- "getrandom",
- "hex",
- "num-bigint",
- "serde",
-]
-
-[[package]]
-name = "starknet-macros"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66fe05edab7ee6752a0aff3e14508001191083f3c6d0b6fa14f7008a96839b0"
-dependencies = [
- "starknet-core 0.7.2",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbfccb46a8969fb3ac803718d9d8270cff4eed5b7f6b9ba234875ad2cc997c5"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethereum-types",
- "flate2",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with 2.3.3",
- "starknet-core 0.5.1",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "starknet-signers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313524cc79344015ef2a8618947332ab17012b5c50600c7f84c60989bdec980"
-dependencies = [
- "async-trait",
- "auto_impl",
- "crypto-bigint",
- "eth-keystore",
- "rand",
- "starknet-core 0.5.1",
- "starknet-crypto",
- "thiserror",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,7 +4060,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4462,9 +4108,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "svm-rs"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cc95be7cc2c384a2f57cac56548d2178650905ebe5725bc8970ccc25529060"
+checksum = "20689c7d03b6461b502d0b95d6c24874c7d24dea2688af80486a130a06af3b07"
 dependencies = [
  "dirs",
  "fs2",
@@ -4493,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4510,7 +4156,7 @@ checksum = "e5f995d2140b0f751dbe94365be2591edbf3d1b75dcfaeac14183abbd2ff07bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4574,7 +4220,7 @@ checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -4603,10 +4249,10 @@ dependencies = [
  "common",
  "ethers",
  "eyre",
- "jf-plonk",
  "jf-primitives",
- "jf-relation",
  "jf-utils",
+ "mpc-plonk",
+ "mpc-relation",
  "rand",
  "renegade-crypto",
  "serde",
@@ -4629,7 +4275,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4712,7 +4358,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4825,7 +4471,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5055,7 +4701,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -5089,7 +4735,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5168,15 +4814,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -5365,22 +5002,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.24"
+version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092cd76b01a033a9965b9097da258689d9e17c69ded5dcf41bca001dd20ebc6d"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.24"
+version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13a20a7c6a90e2034bcc65495799da92efcec6a8dd4f3fcb6f7a48988637ead"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5400,7 +5037,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rand = "0.8.5"
 num-bigint = { version = "0.4", default-features = false }
 eyre = "0.6.8"
 ethers = "2.0"
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", default-features = false }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", branch = "joey/circuits-refactor", default-features = false }
 
 [profile.release]
 codegen-units = 1        # prefer efficiency to compile time

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -40,3 +40,9 @@ pub const NUM_BYTES_SIGNATURE: usize = 65;
 
 /// The number of secret-shared scalars it takes to represent a wallet
 pub const WALLET_SHARES_LEN: usize = 0;
+
+/// The height of the Merkle tree
+pub const MERKLE_HEIGHT: usize = 32;
+
+/// The height of the Merkle tree used in testing
+pub const TEST_MERKLE_HEIGHT: usize = 5;

--- a/contracts-core/src/crypto/merkle.rs
+++ b/contracts-core/src/crypto/merkle.rs
@@ -177,12 +177,11 @@ where
 #[cfg(test)]
 mod tests {
     use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
+    use common::constants::TEST_MERKLE_HEIGHT;
     use rand::thread_rng;
     use test_helpers::{merkle::MerkleConfig, misc::random_scalars};
 
     use super::SparseMerkleTree;
-
-    const TEST_MERKLE_HEIGHT: usize = 5;
 
     #[test]
     fn test_against_arkworks() {

--- a/contracts-core/src/crypto/mod.rs
+++ b/contracts-core/src/crypto/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod ecdsa;
 pub mod merkle;
+pub mod poseidon;

--- a/contracts-core/src/crypto/poseidon.rs
+++ b/contracts-core/src/crypto/poseidon.rs
@@ -1,0 +1,9 @@
+//! Helper functions for computing Poseidon2 hashes
+
+use common::types::ScalarField;
+use renegade_crypto::hash::Poseidon2Sponge;
+
+pub fn compute_poseidon_hash(inputs: &[ScalarField]) -> ScalarField {
+    let mut sponge = Poseidon2Sponge::new();
+    sponge.hash(inputs)
+}

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -16,6 +16,7 @@ alloy-sol-types = { workspace = true }
 
 [features]
 darkpool = []
+merkle = []
 verifier = []
 verifier-test-contract = []
 darkpool-test-contract = []

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -16,10 +16,11 @@ alloy-sol-types = { workspace = true }
 
 [features]
 darkpool = []
+darkpool-test-contract = []
 merkle = []
+merkle-test-contract = []
 verifier = []
 verifier-test-contract = []
-darkpool-test-contract = []
 precompile-test-contract = []
 dummy-erc20 = []
 export-abi = ["stylus-sdk/export-abi"]

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -1,0 +1,62 @@
+//! A Merkle tree smart contract, used to accumulate all of the wallet commitments
+//! in the dark pool.
+
+use alloc::vec::Vec;
+use common::serde_def_types::SerdeScalarField;
+use contracts_core::crypto::merkle::SparseMerkleTree;
+use stylus_sdk::{
+    abi::Bytes,
+    prelude::*,
+    storage::{StorageBool, StorageBytes, StorageMap},
+};
+
+use crate::utils::constants::MERKLE_HEIGHT;
+
+#[solidity_storage]
+#[entrypoint]
+pub struct MerkleContract {
+    /// The serialized merkle tree
+    pub merkle_tree: StorageBytes,
+    /// The current root of the Merkle tree, cached in storage for efficiency
+    pub current_root: StorageBytes,
+    /// The set of historic roots of the Merkle tree
+    pub root_history: StorageMap<Vec<u8>, StorageBool>,
+}
+
+#[external]
+impl MerkleContract {
+    /// Initialize this contract with a blank Merkle tree
+    // TODO: Make an `Initializable` component
+    pub fn init(&mut self) -> Result<(), Vec<u8>> {
+        let merkle_tree = SparseMerkleTree::<MERKLE_HEIGHT>::default();
+        let merkle_tree_bytes = postcard::to_allocvec(&merkle_tree).unwrap();
+        self.merkle_tree.set_bytes(merkle_tree_bytes);
+        Ok(())
+    }
+    /// Returns the current root of the merkle tree
+    // TODO: Cache this directly in contract storage?
+    pub fn root(&self) -> Result<Bytes, Vec<u8>> {
+        Ok(self.current_root.get_bytes().into())
+    }
+
+    /// Returns whether or not the given root is in the root history
+    pub fn root_in_history(&self, root: Bytes) -> Result<bool, Vec<u8>> {
+        Ok(self.root_history.get(root.0))
+    }
+
+    pub fn insert(&mut self, value: Bytes) -> Result<(), Vec<u8>> {
+        let mut merkle_tree: SparseMerkleTree<MERKLE_HEIGHT> =
+            postcard::from_bytes(&self.merkle_tree.get_bytes()).unwrap();
+        let value: SerdeScalarField = postcard::from_bytes(value.as_slice()).unwrap();
+
+        let _node_updates = merkle_tree.insert(value.0);
+        // TODO: Emit node update events
+
+        let root_bytes = postcard::to_allocvec(&SerdeScalarField(merkle_tree.root())).unwrap();
+        self.current_root.set_bytes(root_bytes);
+
+        let merkle_tree_bytes = postcard::to_allocvec(&merkle_tree).unwrap();
+        self.merkle_tree.set_bytes(merkle_tree_bytes);
+        Ok(())
+    }
+}

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -1,8 +1,10 @@
 //! A Merkle tree smart contract, used to accumulate all of the wallet commitments
 //! in the dark pool.
 
+use core::marker::PhantomData;
+
 use alloc::vec::Vec;
-use common::serde_def_types::SerdeScalarField;
+use common::{constants::MERKLE_HEIGHT, serde_def_types::SerdeScalarField};
 use contracts_core::crypto::merkle::SparseMerkleTree;
 use stylus_sdk::{
     abi::Bytes,
@@ -10,32 +12,38 @@ use stylus_sdk::{
     storage::{StorageBool, StorageBytes, StorageMap},
 };
 
-use crate::utils::constants::MERKLE_HEIGHT;
+pub trait MerkleParams {
+    const HEIGHT: usize;
+}
 
 // TODO: Make `Ownable` + `Initialiizable`
 
 #[solidity_storage]
-#[entrypoint]
-pub struct MerkleContract {
+pub struct MerkleContract<P: MerkleParams> {
     /// The serialized merkle tree
     pub merkle_tree: StorageBytes,
     /// The current root of the Merkle tree, cached in storage for efficiency
     pub current_root: StorageBytes,
     /// The set of historic roots of the Merkle tree
     pub root_history: StorageMap<Vec<u8>, StorageBool>,
+    /// Used to allow `MerkleParams` to be a generic type parameter
+    _phantom: PhantomData<P>,
 }
 
 #[external]
-impl MerkleContract {
+impl<P> MerkleContract<P>
+where
+    P: MerkleParams,
+    [(); P::HEIGHT - 1]:,
+{
     /// Initialize this contract with a blank Merkle tree
     pub fn init(&mut self) -> Result<(), Vec<u8>> {
-        let merkle_tree = SparseMerkleTree::<MERKLE_HEIGHT>::default();
+        let merkle_tree = SparseMerkleTree::<{ P::HEIGHT }>::default();
         let merkle_tree_bytes = postcard::to_allocvec(&merkle_tree).unwrap();
         self.merkle_tree.set_bytes(merkle_tree_bytes);
         Ok(())
     }
     /// Returns the current root of the merkle tree
-    // TODO: Cache this directly in contract storage?
     pub fn root(&self) -> Result<Bytes, Vec<u8>> {
         Ok(self.current_root.get_bytes().into())
     }
@@ -45,8 +53,9 @@ impl MerkleContract {
         Ok(self.root_history.get(root.0))
     }
 
+    /// Inserts a value into the Merkle tree at the next available index
     pub fn insert(&mut self, value: Bytes) -> Result<(), Vec<u8>> {
-        let mut merkle_tree: SparseMerkleTree<MERKLE_HEIGHT> =
+        let mut merkle_tree: SparseMerkleTree<{ P::HEIGHT }> =
             postcard::from_bytes(&self.merkle_tree.get_bytes()).unwrap();
         let value: SerdeScalarField = postcard::from_bytes(value.as_slice()).unwrap();
 
@@ -59,5 +68,37 @@ impl MerkleContract {
         let merkle_tree_bytes = postcard::to_allocvec(&merkle_tree).unwrap();
         self.merkle_tree.set_bytes(merkle_tree_bytes);
         Ok(())
+    }
+}
+
+struct ProdMerkleParams;
+impl MerkleParams for ProdMerkleParams {
+    const HEIGHT: usize = MERKLE_HEIGHT;
+}
+
+#[solidity_storage]
+#[cfg_attr(feature = "merkle", entrypoint)]
+struct ProdMerkleContract {
+    #[borrow]
+    merkle: MerkleContract<ProdMerkleParams>,
+}
+
+#[external]
+#[inherit(MerkleContract<ProdMerkleParams>)]
+impl ProdMerkleContract {
+    fn init(&mut self) -> Result<(), Vec<u8>> {
+        self.merkle.init()
+    }
+
+    fn root(&self) -> Result<Bytes, Vec<u8>> {
+        self.merkle.root()
+    }
+
+    fn root_in_history(&self, root: Bytes) -> Result<bool, Vec<u8>> {
+        self.merkle.root_in_history(root)
+    }
+
+    fn insert(&mut self, value: Bytes) -> Result<(), Vec<u8>> {
+        self.merkle.insert(value)
     }
 }

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -12,6 +12,8 @@ use stylus_sdk::{
 
 use crate::utils::constants::MERKLE_HEIGHT;
 
+// TODO: Make `Ownable` + `Initialiizable`
+
 #[solidity_storage]
 #[entrypoint]
 pub struct MerkleContract {
@@ -26,7 +28,6 @@ pub struct MerkleContract {
 #[external]
 impl MerkleContract {
     /// Initialize this contract with a blank Merkle tree
-    // TODO: Make an `Initializable` component
     pub fn init(&mut self) -> Result<(), Vec<u8>> {
         let merkle_tree = SparseMerkleTree::<MERKLE_HEIGHT>::default();
         let merkle_tree_bytes = postcard::to_allocvec(&merkle_tree).unwrap();

--- a/contracts-stylus/src/contracts/mod.rs
+++ b/contracts-stylus/src/contracts/mod.rs
@@ -3,6 +3,9 @@
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
 mod darkpool;
 
+#[cfg(feature = "merkle")]
+mod merkle;
+
 #[cfg(feature = "verifier")]
 mod verifier;
 

--- a/contracts-stylus/src/contracts/mod.rs
+++ b/contracts-stylus/src/contracts/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
 mod darkpool;
 
-#[cfg(feature = "merkle")]
+#[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
 mod merkle;
 
 #[cfg(feature = "verifier")]
@@ -12,6 +12,7 @@ mod verifier;
 #[cfg(any(
     feature = "precompile-test-contract",
     feature = "verifier-test-contract",
+    feature = "merkle-test-contract",
     feature = "darkpool-test-contract",
     feature = "dummy-erc20"
 ))]

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -1,0 +1,39 @@
+//! Testing contract for the Merkle tree which using the test height
+
+use alloc::vec::Vec;
+use common::constants::TEST_MERKLE_HEIGHT;
+use stylus_sdk::{abi::Bytes, prelude::*};
+
+use crate::contracts::merkle::{MerkleContract, MerkleParams};
+
+struct TestMerkleParams;
+impl MerkleParams for TestMerkleParams {
+    const HEIGHT: usize = TEST_MERKLE_HEIGHT;
+}
+
+#[solidity_storage]
+#[entrypoint]
+struct TestMerkleContract {
+    #[borrow]
+    merkle: MerkleContract<TestMerkleParams>,
+}
+
+#[external]
+#[inherit(MerkleContract<TestMerkleParams>)]
+impl TestMerkleContract {
+    fn init(&mut self) -> Result<(), Vec<u8>> {
+        self.merkle.init()
+    }
+
+    fn root(&self) -> Result<Bytes, Vec<u8>> {
+        self.merkle.root()
+    }
+
+    fn root_in_history(&self, root: Bytes) -> Result<bool, Vec<u8>> {
+        self.merkle.root_in_history(root)
+    }
+
+    fn insert(&mut self, value: Bytes) -> Result<(), Vec<u8>> {
+        self.merkle.insert(value)
+    }
+}

--- a/contracts-stylus/src/contracts/test_contracts/mod.rs
+++ b/contracts-stylus/src/contracts/test_contracts/mod.rs
@@ -6,6 +6,9 @@ mod precompile_test_contract;
 #[cfg(feature = "verifier-test-contract")]
 mod verifier_test_contract;
 
+#[cfg(feature = "merkle-test-contract")]
+mod merkle_test_contract;
+
 #[cfg(feature = "darkpool-test-contract")]
 mod darkpool_test_contract;
 

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 #![no_main]
 #![no_std]
 

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -43,3 +43,7 @@ pub const VALID_REBLIND_CIRCUIT_ID: u8 = 3;
     allow(dead_code)
 )]
 pub const VALID_MATCH_SETTLE_CIRCUIT_ID: u8 = 4;
+
+/// The height of the Merkle tree used in the dark pool
+#[cfg_attr(not(feature = "merkle"), allow(dead_code))]
+pub const MERKLE_HEIGHT: usize = 32;

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -43,7 +43,3 @@ pub const VALID_REBLIND_CIRCUIT_ID: u8 = 3;
     allow(dead_code)
 )]
 pub const VALID_MATCH_SETTLE_CIRCUIT_ID: u8 = 4;
-
-/// The height of the Merkle tree used in the dark pool
-#[cfg_attr(not(feature = "merkle"), allow(dead_code))]
-pub const MERKLE_HEIGHT: usize = 32;

--- a/contracts-stylus/src/utils/interfaces.rs
+++ b/contracts-stylus/src/utils/interfaces.rs
@@ -15,4 +15,11 @@ sol_interface! {
         function approve(address spender, uint256 value) external returns (bool);
         function transferFrom(address from, address to, uint256 value) external returns (bool);
     }
+
+    interface IMerkle {
+        function init() external;
+        function root() external view returns (bytes);
+        function rootInHistory(bytes root) external view returns (bool);
+        function insert(bytes value) external;
+    }
 }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -19,3 +19,4 @@ json = "0.12"
 postcard = { workspace = true }
 serde = { workspace = true }
 alloy-primitives = { workspace = true }
+ark-crypto-primitives = { workspace = true }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -29,6 +29,16 @@ abigen!(
 );
 
 abigen!(
+    MerkleContract,
+    r#"[
+        function init() external
+        function root() external view returns (bytes)
+        function rootInHistory(bytes root) external view returns (bool)
+        function insert(bytes value) external
+    ]"#
+);
+
+abigen!(
     VerifierTestContract,
     r#"[
         function verify(address memory verifier_address, bytes memory verification_bundle_ser) external view returns (bool)

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -32,6 +32,7 @@ pub(crate) enum Tests {
     EcPairing,
     EcRecover,
     NullifierSet,
+    Merkle,
     Verifier,
     Ownership,
     ExternalTransfer,

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -13,6 +13,9 @@ pub(crate) const DEPLOYMENTS_KEY: &str = "deployments";
 /// The precompile test contract key in the `deployments.json` file
 pub(crate) const PRECOMPILE_TEST_CONTRACT_KEY: &str = "precompile_test_contract";
 
+/// The Merkle contract key in the `deployments.json` file
+pub(crate) const MERKLE_TEST_CONTRACT_KEY: &str = "merkle_test_contract";
+
 /// The verifier contract key in the `deployments.json` file
 pub(crate) const VERIFIER_CONTRACT_KEY: &str = "verifier_contract";
 

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,7 +1,7 @@
 //! Basic tests for Stylus programs. These assume that a devnet is already running locally.
 
 use abis::{
-    DarkpoolTestContract, DummyErc20Contract, PrecompileTestContract, VerifierTestContract,
+    DarkpoolTestContract, DummyErc20Contract, PrecompileTestContract, VerifierTestContract, MerkleContract,
 };
 use clap::Parser;
 use cli::{Cli, Tests};
@@ -10,7 +10,7 @@ use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
     test_nullifier_set, test_ownership, test_process_match_settle, test_update_wallet,
-    test_verifier,
+    test_verifier, test_merkle,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -57,6 +57,11 @@ async fn main() -> Result<()> {
             let contract = DarkpoolTestContract::new(contract_address, client);
 
             test_nullifier_set(contract).await?;
+        }
+        Tests::Merkle => {
+            let contract = MerkleContract::new(contract_address, client);
+
+            test_merkle(contract).await?;
         }
         Tests::Verifier => {
             let contract = VerifierTestContract::new(contract_address, client);

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -24,8 +24,8 @@ use crate::{
     abis::{DarkpoolTestContract, DummyErc20Contract},
     cli::Tests,
     constants::{
-        DARKPOOL_TEST_CONTRACT_KEY, DEPLOYMENTS_KEY, N, PRECOMPILE_TEST_CONTRACT_KEY,
-        TRANSFER_AMOUNT, VERIFIER_TEST_CONTRACT_KEY,
+        DARKPOOL_TEST_CONTRACT_KEY, DEPLOYMENTS_KEY, MERKLE_TEST_CONTRACT_KEY, N,
+        PRECOMPILE_TEST_CONTRACT_KEY, TRANSFER_AMOUNT, VERIFIER_TEST_CONTRACT_KEY,
     },
 };
 
@@ -78,6 +78,9 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: String) -
         }
         Tests::NullifierSet => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+        }
+        Tests::Merkle => {
+            parse_addr_from_deployments_file(deployments_file, MERKLE_TEST_CONTRACT_KEY)?
         }
         Tests::Verifier => {
             parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -15,11 +15,11 @@ alloy-primitives = { workspace = true }
 eyre = { workspace = true }
 serde = { workspace = true }
 ethers = { workspace = true }
-jf-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", features = [
+mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", features = [
     "test-srs",
     "test_apis",
 ] }
-jf-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
+mpc-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
 renegade-crypto = { workspace = true }

--- a/test-helpers/src/proof_system.rs
+++ b/test-helpers/src/proof_system.rs
@@ -9,7 +9,7 @@ use common::{
     types::{G1Affine, G2Affine, Proof, ScalarField, VerificationKey},
 };
 use eyre::Result;
-use jf_plonk::{
+use mpc_plonk::{
     errors::PlonkError,
     proof_system::PlonkKzgSnark,
     proof_system::{
@@ -20,7 +20,7 @@ use jf_plonk::{
     transcript::SolidityTranscript,
 };
 use jf_primitives::pcs::prelude::{Commitment, UnivariateVerifierParam};
-use jf_relation::{Arithmetization, Circuit as JfCircuit, PlonkCircuit};
+use mpc_relation::{Arithmetization, Circuit as JfCircuit, PlonkCircuit};
 use rand::thread_rng;
 
 pub fn gen_circuit(n: usize, public_inputs: &[ScalarField]) -> Result<PlonkCircuit<ScalarField>> {


### PR DESCRIPTION
This PR creates a parameterizable Merkle contract, following the parameterization patterns used [here](https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/examples/erc20/src/erc20.rs) (namely, using a trait w/ associated consts + contract inheritance), and integrates it into the darkpool.

A new integration test has been added for the Merkle contract itself, which passes. Test coverage asserting correct Merkle behavior in the darkpool has not yet been added since the darkpool is once again beyond the binary size limit, which I'll handle in another PR.

Additionally, the Merkle contract should be `Ownable` and `Initializable`, I've left this for the next PR as well, for brevity.