### PR TITLE
contracts-stylus: merkle, darkpool: Merkle contract computes commitment to wallet shares

### DIFF
--- a/contracts-core/src/crypto/ecdsa.rs
+++ b/contracts-core/src/crypto/ecdsa.rs
@@ -44,8 +44,14 @@ pub fn pubkey_to_address<H: HashBackend>(pubkey: &PublicSigningKey) -> [u8; NUM_
         .unwrap()
 }
 
+/// Returns the lower 128 bits of a scalar as a big-endian byte array
 fn scalar_lower_128_bytes_be(scalar: &ScalarField) -> Vec<u8> {
     let bigint = scalar.into_bigint();
+    // The `BigInt` type stores the scalar as an array of 4 u64 limbs in "little-endian" order,
+    // i.e. the least significant limb is stored first.
+    // This means the lower 128 bits of the scalar are stored in the first 2 limbs,
+    // so we access these directly and convert them to big-endian byte arrays.
+    // Note we have to reverse the order of the first and second limbs for big-endian representation.
     let mut lower_128_bytes_be = bigint.0[1].to_be_bytes().to_vec();
     lower_128_bytes_be.extend(bigint.0[0].to_be_bytes().to_vec());
     lower_128_bytes_be

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -33,7 +33,7 @@ impl TestMerkleContract {
         self.merkle.root_in_history(root)
     }
 
-    fn insert(&mut self, value: Bytes) -> Result<(), Vec<u8>> {
-        self.merkle.insert(value)
+    fn insert_shares_commitment(&mut self, shares: Bytes) -> Result<(), Vec<u8>> {
+        self.merkle.insert_shares_commitment(shares)
     }
 }

--- a/contracts-stylus/src/utils/interfaces.rs
+++ b/contracts-stylus/src/utils/interfaces.rs
@@ -20,6 +20,6 @@ sol_interface! {
         function init() external;
         function root() external view returns (bytes);
         function rootInHistory(bytes root) external view returns (bool);
-        function insert(bytes value) external;
+        function insertSharesCommitment(bytes shares) external;
     }
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -34,7 +34,7 @@ abigen!(
         function init() external
         function root() external view returns (bytes)
         function rootInHistory(bytes root) external view returns (bool)
-        function insert(bytes value) external
+        function insertSharesCommitment(bytes shares) external
     ]"#
 );
 


### PR DESCRIPTION
This PR changes the Merkle contract interface to be more application-specific, in that it accepts a set of wallet shares, and computes their commitment on its own before inserting them into the Merkle tree. This is the only way we use the Merkle tree, and also mitigates binary size bloat in the darkpool contract by removing an invocation of the Poseidon hash function there.

The existing Merkle contract test has been updated to reflect this change, but tests asserting that the Merkle root updates as expected in the invocation of the darkpool method are left for the next PR.