### PR TITLE
contracts-stylus: darkpool, merkle: make darkpool `Initializable` & `delegatecall` Merkle contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.env
 /profiling_data
 /deployments.json
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,9 +919,10 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/circuits-refactor#1ed1d034d82ae79777ff47232ad553284dda09f2"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/circuits-refactor#dbdc3304ba7e6da2edac3317d937b94901df67c1"
 dependencies = [
  "ark-bn254",
+ "ark-ec",
 ]
 
 [[package]]
@@ -2116,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "f95b9abcae896730d42b78e09c155ed4ddf82c07b4de772c64aee5b2d8b7c150"
 dependencies = [
  "bytes",
  "fnv",
@@ -2350,7 +2351,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dd2da0bb6e68f1e42ad90960f4bb2eb3dacc9a43"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -2394,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dd2da0bb6e68f1e42ad90960f4bb2eb3dacc9a43"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2635,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dd2da0bb6e68f1e42ad90960f4bb2eb3dacc9a43"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2667,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dd2da0bb6e68f1e42ad90960f4bb2eb3dacc9a43"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3170,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bitflags 2.4.1",
  "lazy_static",
@@ -3180,7 +3181,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "unarray",
 ]
 
@@ -3378,7 +3379,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/circuits-refactor#1ed1d034d82ae79777ff47232ad553284dda09f2"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/circuits-refactor#dbdc3304ba7e6da2edac3317d937b94901df67c1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3599,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.5",
 ]
@@ -3934,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "snafu"
@@ -4334,9 +4335,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4353,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts-stylus/src/contracts/components/initializable.rs
+++ b/contracts-stylus/src/contracts/components/initializable.rs
@@ -13,11 +13,7 @@ pub struct Initializable {
     /// initialization steps to be added in future versions.
     ///
     /// This is particularly relevant for contracts that are upgradable.
-    #[cfg_attr(
-        not(any(feature = "darkpool", feature = "darkpool-test-contract")),
-        allow(dead_code)
-    )]
-    initialized: StorageU64,
+    pub initialized: StorageU64,
 }
 
 /// None of the `Initializable` methods are marked `external` because they are

--- a/contracts-stylus/src/contracts/components/initializable.rs
+++ b/contracts-stylus/src/contracts/components/initializable.rs
@@ -13,6 +13,10 @@ pub struct Initializable {
     /// initialization steps to be added in future versions.
     ///
     /// This is particularly relevant for contracts that are upgradable.
+    #[cfg_attr(
+        not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+        allow(dead_code)
+    )]
     initialized: StorageU64,
 }
 

--- a/contracts-stylus/src/contracts/components/initializable.rs
+++ b/contracts-stylus/src/contracts/components/initializable.rs
@@ -1,0 +1,36 @@
+//! Mirrors OpenZeppelin's `Initializable` contract for protected initialization:
+//! https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/proxy/utils/Initializable.sol
+//!
+//! But made significantly simpler because the functions defined here are not modifiers, as in Solidity.
+//! Down the road, this may be attempted with the use of procedural macros.
+
+use stylus_sdk::{alloy_primitives::U64, prelude::*, storage::StorageU64};
+
+#[solidity_storage]
+pub struct Initializable {
+    /// The version that this contract has been initialized to.
+    /// This used to prevent re-initialization, but allow for extra
+    /// initialization steps to be added in future versions.
+    ///
+    /// This is particularly relevant for contracts that are upgradable.
+    initialized: StorageU64,
+}
+
+/// None of the `Initializable` methods are marked `external` because they are
+/// meant to be called only by the contract that inherits from `Initializable`.
+#[external]
+impl Initializable {}
+
+impl Initializable {
+    /// Initializes this contract with the given version.
+    pub fn _initialize(&mut self, version: u64) {
+        let version = U64::from_limbs([version]);
+        assert!(self.initialized.get() < version);
+        self.initialized.set(version);
+    }
+
+    /// Gets the highest version that has been initialized.
+    pub fn _get_initialized_version(&self) -> u64 {
+        self.initialized.get().to()
+    }
+}

--- a/contracts-stylus/src/contracts/components/mod.rs
+++ b/contracts-stylus/src/contracts/components/mod.rs
@@ -1,3 +1,4 @@
 //! Composable contract "components" that other smart contracts can inherit for common functionality
 
+pub mod initializable;
 pub mod ownable;

--- a/contracts-stylus/src/contracts/components/ownable.rs
+++ b/contracts-stylus/src/contracts/components/ownable.rs
@@ -24,14 +24,14 @@ impl Ownable {
     }
 
     pub fn renounce_ownership(&mut self) -> Result<(), Vec<u8>> {
-        self._check_owner()?;
+        self._check_owner().unwrap();
         self._transfer_ownership(Address::ZERO);
         Ok(())
     }
 
     pub fn transfer_ownership(&mut self, new_owner: Address) -> Result<(), Vec<u8>> {
         if self.owner_initialized.get() {
-            self._check_owner()?;
+            self._check_owner().unwrap();
         } else {
             self.owner_initialized.set(true);
         }
@@ -46,7 +46,7 @@ impl Ownable {
 /// Internal methods
 impl Ownable {
     pub fn _check_owner(&self) -> Result<(), Vec<u8>> {
-        assert_eq!(self.owner()?, msg::sender());
+        assert_eq!(self.owner.get(), msg::sender());
         Ok(())
     }
 

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -87,6 +87,8 @@ impl DarkpoolContract {
         // Mark the darkpool as initialized
         this.initializable._initialize(1);
 
+        // TODO: Emit intialization event
+
         Ok(())
     }
 

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -110,7 +110,7 @@ struct ProdMerkleContract {
 #[inherit(MerkleContract<ProdMerkleParams>, Ownable)]
 impl ProdMerkleContract {
     fn init(&mut self) -> Result<(), Vec<u8>> {
-        self.ownable._check_owner()?;
+        self.ownable._check_owner().unwrap();
         self.merkle.init()
     }
 
@@ -123,7 +123,7 @@ impl ProdMerkleContract {
     }
 
     fn insert_shares_commitment(&mut self, shares: Bytes) -> Result<(), Vec<u8>> {
-        self.ownable._check_owner()?;
+        self.ownable._check_owner().unwrap();
         self.merkle.insert_shares_commitment(shares)
     }
 }

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -12,11 +12,11 @@ use stylus_sdk::{
     storage::{StorageBool, StorageBytes, StorageMap},
 };
 
+use super::components::ownable::Ownable;
+
 pub trait MerkleParams {
     const HEIGHT: usize;
 }
-
-// TODO: Make `Ownable` + `Initialiizable`
 
 #[solidity_storage]
 pub struct MerkleContract<P: MerkleParams> {
@@ -102,12 +102,15 @@ impl MerkleParams for ProdMerkleParams {
 struct ProdMerkleContract {
     #[borrow]
     merkle: MerkleContract<ProdMerkleParams>,
+    #[borrow]
+    ownable: Ownable,
 }
 
 #[external]
-#[inherit(MerkleContract<ProdMerkleParams>)]
+#[inherit(MerkleContract<ProdMerkleParams>, Ownable)]
 impl ProdMerkleContract {
     fn init(&mut self) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.merkle.init()
     }
 
@@ -120,6 +123,7 @@ impl ProdMerkleContract {
     }
 
     fn insert_shares_commitment(&mut self, shares: Bytes) -> Result<(), Vec<u8>> {
+        self.ownable._check_owner()?;
         self.merkle.insert_shares_commitment(shares)
     }
 }

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -2,7 +2,7 @@ use core::borrow::{Borrow, BorrowMut};
 
 use alloc::vec::Vec;
 use common::{serde_def_types::SerdeScalarField, types::ExternalTransfer};
-use stylus_sdk::{abi::Bytes, prelude::*};
+use stylus_sdk::{abi::Bytes, alloy_primitives::U64, prelude::*};
 
 use crate::contracts::{
     components::{initializable::Initializable, ownable::Ownable},
@@ -57,6 +57,13 @@ impl DarkpoolTestContract {
         let external_transfer: ExternalTransfer =
             postcard::from_bytes(transfer.as_slice()).unwrap();
         DarkpoolContract::execute_external_transfer(self, &external_transfer);
+        Ok(())
+    }
+
+    pub fn clear_initializable(&mut self) -> Result<(), Vec<u8>> {
+        BorrowMut::<Initializable>::borrow_mut(self)
+            .initialized
+            .set(U64::from_limbs([0]));
         Ok(())
     }
 }

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -2,34 +2,12 @@ use core::borrow::{Borrow, BorrowMut};
 
 use alloc::vec::Vec;
 use common::{serde_def_types::SerdeScalarField, types::ExternalTransfer};
-use stylus_sdk::{
-    abi::Bytes,
-    alloy_primitives::U256,
-    call::{CallContext, MutatingCallContext, NonPayableCallContext, StaticCallContext},
-    prelude::*,
+use stylus_sdk::{abi::Bytes, prelude::*};
+
+use crate::contracts::{
+    components::{initializable::Initializable, ownable::Ownable},
+    darkpool::DarkpoolContract,
 };
-
-use crate::contracts::{components::ownable::Ownable, darkpool::DarkpoolContract};
-
-// We implement the `*Context`traits manually for the
-// `DarkpoolContract` because it is not the entrypoint when
-// building the `DarkpoolTestContract`, and as such doesn't have these
-// traits implemented for it by the `#[entrypoint]` macro.`
-impl CallContext for &mut DarkpoolContract {
-    fn gas(&self) -> u64 {
-        u64::MAX
-    }
-}
-
-impl StaticCallContext for &mut DarkpoolContract {}
-
-unsafe impl MutatingCallContext for &mut DarkpoolContract {
-    fn value(&self) -> U256 {
-        U256::ZERO
-    }
-}
-
-impl NonPayableCallContext for &mut DarkpoolContract {}
 
 #[solidity_storage]
 #[entrypoint]
@@ -38,8 +16,9 @@ struct DarkpoolTestContract {
     darkpool: DarkpoolContract,
 }
 
-// We manually implement `Borrow<Ownable>` & `BorrowMut<Ownable>` because
+// We manually implement `Borrow<_>` & `BorrowMut<_>` because
 // Stylus can't yet automatically infer multi-level inheritance.
+
 impl BorrowMut<Ownable> for DarkpoolTestContract {
     fn borrow_mut(&mut self) -> &mut Ownable {
         &mut self.darkpool.ownable
@@ -52,13 +31,25 @@ impl Borrow<Ownable> for DarkpoolTestContract {
     }
 }
 
+impl BorrowMut<Initializable> for DarkpoolTestContract {
+    fn borrow_mut(&mut self) -> &mut Initializable {
+        &mut self.darkpool.initializable
+    }
+}
+
+impl Borrow<Initializable> for DarkpoolTestContract {
+    fn borrow(&self) -> &Initializable {
+        &self.darkpool.initializable
+    }
+}
+
 // Expose the internal helper methods of the Darkpool contract as external for testing purposes
 #[external]
-#[inherit(DarkpoolContract, Ownable)]
+#[inherit(DarkpoolContract, Ownable, Initializable)]
 impl DarkpoolTestContract {
     pub fn mark_nullifier_spent(&mut self, nullifier: Bytes) -> Result<(), Vec<u8>> {
         let nullifier: SerdeScalarField = postcard::from_bytes(nullifier.as_slice()).unwrap();
-        self.darkpool.mark_nullifier_spent(nullifier.0);
+        DarkpoolContract::mark_nullifier_spent(self, nullifier.0);
         Ok(())
     }
 
@@ -68,13 +59,18 @@ impl DarkpoolTestContract {
         proof: Bytes,
         public_inputs: Bytes,
     ) -> Result<bool, Vec<u8>> {
-        Ok(self.darkpool.verify(circuit_id, proof, public_inputs))
+        Ok(DarkpoolContract::verify(
+            self,
+            circuit_id,
+            proof,
+            public_inputs,
+        ))
     }
 
     pub fn execute_external_transfer(&mut self, transfer: Bytes) -> Result<(), Vec<u8>> {
         let external_transfer: ExternalTransfer =
             postcard::from_bytes(transfer.as_slice()).unwrap();
-        self.darkpool.execute_external_transfer(&external_transfer);
+        DarkpoolContract::execute_external_transfer(self, &external_transfer);
         Ok(())
     }
 }

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -43,7 +43,7 @@ impl Borrow<Initializable> for DarkpoolTestContract {
     }
 }
 
-// Expose the internal helper methods of the Darkpool contract as external for testing purposes
+// Expose internal helper methods of the Darkpool contract used in testing
 #[external]
 #[inherit(DarkpoolContract, Ownable, Initializable)]
 impl DarkpoolTestContract {
@@ -51,20 +51,6 @@ impl DarkpoolTestContract {
         let nullifier: SerdeScalarField = postcard::from_bytes(nullifier.as_slice()).unwrap();
         DarkpoolContract::mark_nullifier_spent(self, nullifier.0);
         Ok(())
-    }
-
-    pub fn verify(
-        &mut self,
-        circuit_id: u8,
-        proof: Bytes,
-        public_inputs: Bytes,
-    ) -> Result<bool, Vec<u8>> {
-        Ok(DarkpoolContract::verify(
-            self,
-            circuit_id,
-            proof,
-            public_inputs,
-        ))
     }
 
     pub fn execute_external_transfer(&mut self, transfer: Bytes) -> Result<(), Vec<u8>> {

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -4,10 +4,7 @@ use alloc::vec::Vec;
 use common::constants::TEST_MERKLE_HEIGHT;
 use stylus_sdk::{abi::Bytes, prelude::*};
 
-use crate::contracts::{
-    components::ownable::Ownable,
-    merkle::{MerkleContract, MerkleParams},
-};
+use crate::contracts::merkle::{MerkleContract, MerkleParams};
 
 struct TestMerkleParams;
 impl MerkleParams for TestMerkleParams {
@@ -19,12 +16,10 @@ impl MerkleParams for TestMerkleParams {
 struct TestMerkleContract {
     #[borrow]
     merkle: MerkleContract<TestMerkleParams>,
-    #[borrow]
-    ownable: Ownable,
 }
 
 #[external]
-#[inherit(MerkleContract<TestMerkleParams>, Ownable)]
+#[inherit(MerkleContract<TestMerkleParams>)]
 impl TestMerkleContract {
     fn init(&mut self) -> Result<(), Vec<u8>> {
         self.merkle.init()

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -4,7 +4,10 @@ use alloc::vec::Vec;
 use common::constants::TEST_MERKLE_HEIGHT;
 use stylus_sdk::{abi::Bytes, prelude::*};
 
-use crate::contracts::merkle::{MerkleContract, MerkleParams};
+use crate::contracts::{
+    components::ownable::Ownable,
+    merkle::{MerkleContract, MerkleParams},
+};
 
 struct TestMerkleParams;
 impl MerkleParams for TestMerkleParams {
@@ -16,10 +19,12 @@ impl MerkleParams for TestMerkleParams {
 struct TestMerkleContract {
     #[borrow]
     merkle: MerkleContract<TestMerkleParams>,
+    #[borrow]
+    ownable: Ownable,
 }
 
 #[external]
-#[inherit(MerkleContract<TestMerkleParams>)]
+#[inherit(MerkleContract<TestMerkleParams>, Ownable)]
 impl TestMerkleContract {
     fn init(&mut self) -> Result<(), Vec<u8>> {
         self.merkle.init()

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -13,6 +13,9 @@ pub const EC_RECOVER_ADDRESS_LAST_BYTE: u8 = 1;
 /// which is a boolean indicating whether the pairing check succeeded
 pub const PAIRING_CHECK_RESULT_LAST_BYTE_INDEX: usize = 31;
 
+/// The byte length of the input to the `ecRecover` precompile
+pub const EC_RECOVER_INPUT_LEN: usize = 128;
+
 /// The ID of the `VALID_WALLET_CREATE` circuit
 #[cfg_attr(
     not(any(feature = "darkpool", feature = "darkpool-test-contract")),

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -37,5 +37,5 @@ pub fn delegate_call_helper<C: SolCall>(
 ) -> C::Return {
     let calldata = C::new(args).encode();
     let res = unsafe { delegate_call(storage, address, &calldata).unwrap() };
-    C::decode_returns(&res, true /* valudate */).unwrap()
+    C::decode_returns(&res, true /* validate */).unwrap()
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -1,7 +1,9 @@
 //! Miscellaneous helper functions for the contracts.
 
 use alloc::vec::Vec;
+use alloy_sol_types::{SolCall, SolType};
 use common::{custom_serde::ScalarSerializable, serde_def_types::SerdeScalarField};
+use stylus_sdk::{alloy_primitives::Address, call::delegate_call, storage::TopLevelStorage};
 
 /// Serializes the given statement into scalars, and then into bytes,
 /// as expected by the verifier contract.
@@ -20,4 +22,20 @@ pub fn serialize_statement_for_verification<S: ScalarSerializable>(
             .map(SerdeScalarField)
             .collect::<Vec<_>>(),
     )
+}
+
+/// Performs a `delegatecall` to the given address, calling the function
+/// defined as a `SolCall` with the given arguments.
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
+pub fn delegate_call_helper<C: SolCall>(
+    storage: &mut impl TopLevelStorage,
+    address: Address,
+    args: <C::Arguments<'_> as SolType>::RustType,
+) -> C::Return {
+    let calldata = C::new(args).encode();
+    let res = unsafe { delegate_call(storage, address, &calldata).unwrap() };
+    C::decode_returns(&res, true /* valudate */).unwrap()
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -15,7 +15,7 @@ pub fn serialize_statement_for_verification<S: ScalarSerializable>(
     postcard::to_allocvec(
         &statement
             .serialize_to_scalars()
-            .map_err(|_| postcard::Error::SerdeSerCustom)?
+            .unwrap()
             .into_iter()
             .map(SerdeScalarField)
             .collect::<Vec<_>>(),

--- a/contracts-stylus/src/utils/interfaces.rs
+++ b/contracts-stylus/src/utils/interfaces.rs
@@ -22,4 +22,10 @@ sol_interface! {
         function rootInHistory(bytes root) external view returns (bool);
         function insertSharesCommitment(bytes shares) external;
     }
+
+    interface IOwnable {
+        function owner() public view virtual returns (address);
+        function renounceOwnership() public virtual;
+        function transferOwnership(address new_owner) public virtual;
+    }
 }

--- a/contracts-stylus/src/utils/interfaces.rs
+++ b/contracts-stylus/src/utils/interfaces.rs
@@ -1,5 +1,6 @@
 //! Solidity ABI-compatible interface definitions used by the darkpool
 
+use alloy_sol_types::sol;
 use stylus_sdk::stylus_proc::sol_interface;
 
 sol_interface! {
@@ -22,10 +23,12 @@ sol_interface! {
         function rootInHistory(bytes root) external view returns (bool);
         function insertSharesCommitment(bytes shares) external;
     }
+}
 
-    interface IOwnable {
-        function owner() public view virtual returns (address);
-        function renounceOwnership() public virtual;
-        function transferOwnership(address new_owner) public virtual;
-    }
+sol! {
+    // Merkle functions
+    function init() external;
+    function root() external view returns (bytes);
+    function rootInHistory(bytes root) external view returns (bool);
+    function insertSharesCommitment(bytes shares) external;
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,12 +5,12 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
-        function transferOwnership(address memory newOwner) external
+        function initialize(address memory verifier_address, address memory merkle_address) external
+
+        function transferOwnership(address memory new_owner) external
 
         function setVerifierAddress(address memory _address) external
         function setMerkleAddress(address memory _address) external
-
-        function initMerkle() external
 
         function setValidWalletCreateVkey(bytes memory vkey) external
         function setValidWalletUpdateVkey(bytes memory vkey) external

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -30,6 +30,8 @@ abigen!(
         function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)
 
         function executeExternalTransfer(bytes memory transfer) external
+
+        function clearInitializable() external
     ]"#
 );
 

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -34,7 +34,7 @@ pub(crate) enum Tests {
     NullifierSet,
     Merkle,
     Verifier,
-    Ownership,
+    Ownable,
     ExternalTransfer,
     NewWallet,
     UpdateWallet,

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -35,6 +35,7 @@ pub(crate) enum Tests {
     Merkle,
     Verifier,
     Ownable,
+    Initializable,
     ExternalTransfer,
     NewWallet,
     UpdateWallet,

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -13,8 +13,8 @@ use constants::{
 use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_merkle, test_nullifier_set, test_ownership, test_process_match_settle, test_update_wallet,
-    test_verifier, test_new_wallet,
+    test_merkle, test_new_wallet, test_nullifier_set, test_ownable, test_process_match_settle,
+    test_update_wallet, test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -74,12 +74,12 @@ async fn main() -> Result<()> {
 
             test_verifier(contract, verifier_address).await?;
         }
-        Tests::Ownership => {
+        Tests::Ownable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());
             let darkpool_test_contract_address =
                 parse_addr_from_deployments_file(&deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?;
 
-            test_ownership(contract, darkpool_test_contract_address).await?;
+            test_ownable(contract, darkpool_test_contract_address).await?;
         }
         Tests::ExternalTransfer => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -13,8 +13,8 @@ use constants::{
 use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_merkle, test_new_wallet, test_nullifier_set, test_ownable, test_process_match_settle,
-    test_update_wallet, test_verifier,
+    test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable,
+    test_process_match_settle, test_update_wallet, test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -80,6 +80,11 @@ async fn main() -> Result<()> {
                 parse_addr_from_deployments_file(&deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?;
 
             test_ownable(contract, darkpool_test_contract_address).await?;
+        }
+        Tests::Initializable => {
+            let contract = DarkpoolTestContract::new(contract_address, client.clone());
+
+            test_initializable(contract).await?;
         }
         Tests::ExternalTransfer => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -311,6 +311,33 @@ pub(crate) async fn test_ownable(
     Ok(())
 }
 
+pub(crate) async fn test_initializable(
+    contract: DarkpoolTestContract<impl Middleware + 'static>,
+) -> Result<()> {
+    let dummy_verifier_address = Address::random();
+    let dummy_merkle_address = Address::random();
+
+    contract
+        .initialize(dummy_verifier_address, dummy_merkle_address)
+        .send()
+        .await?
+        .await?;
+
+    assert!(
+        contract
+            .initialize(dummy_verifier_address, dummy_merkle_address)
+            .send()
+            .await
+            .is_err(),
+        "Initialized contract twice"
+    );
+
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
+
+    Ok(())
+}
+
 pub(crate) async fn test_nullifier_set(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -449,6 +476,9 @@ pub(crate) async fn test_new_wallet(
 
     assert_eq!(ark_root, contract_root, "Merkle root incorrect");
 
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
+
     Ok(())
 }
 
@@ -525,6 +555,9 @@ pub(crate) async fn test_update_wallet(
             .0;
 
     assert_eq!(ark_root, contract_root, "Merkle root incorrect");
+
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
 
     Ok(())
 }
@@ -629,6 +662,9 @@ pub(crate) async fn test_process_match_settle(
             .0;
 
     assert_eq!(ark_root, contract_root, "Merkle root incorrect");
+
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
 
     Ok(())
 }

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -254,6 +254,15 @@ pub(crate) async fn test_ownership(
     )
     .await?;
 
+    // Assert that `setMerkleAddress` only succeeds for the owner
+    assert_only_owner::<_, Address>(
+        &contract,
+        &contract_with_dummy_signer,
+        "setMerkleAddress",
+        dummy_verifier_address,
+    )
+    .await?;
+
     // Assert that `setValidWalletCreateVkey` only succeeds for the owner
     assert_only_owner::<_, Bytes>(
         &contract,

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -211,7 +211,7 @@ pub(crate) async fn test_verifier(
     Ok(())
 }
 
-pub(crate) async fn test_ownership(
+pub(crate) async fn test_ownable(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     darkpool_test_contract_address: Address,
 ) -> Result<()> {

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -120,26 +120,8 @@ pub(crate) async fn setup_darkpool_test_contract(
     verifier_address: Address,
     vkeys: Vec<(Circuit, Bytes)>,
 ) -> Result<()> {
-    // Set the owner to the default sender
     contract
-        .transfer_ownership(contract.client().default_sender().unwrap())
-        .send()
-        .await?
-        .await?;
-
-    // Set Merkle address
-    contract
-        .set_merkle_address(merkle_address)
-        .send()
-        .await?
-        .await?;
-
-    // Initialize Merkle tree
-    contract.init_merkle().send().await?.await?;
-
-    // Set verifier address
-    contract
-        .set_verifier_address(verifier_address)
+        .initialize(verifier_address, merkle_address)
         .send()
         .await?
         .await?;

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -92,7 +92,7 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
         Tests::Verifier => {
             parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?
         }
-        Tests::Ownership => {
+        Tests::Ownable => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
         Tests::ExternalTransfer => {

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -95,6 +95,9 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
         Tests::Ownable => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
+        Tests::Initializable => {
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+        }
         Tests::ExternalTransfer => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }

--- a/test-helpers/src/proof_system.rs
+++ b/test-helpers/src/proof_system.rs
@@ -20,7 +20,7 @@ use mpc_plonk::{
     transcript::SolidityTranscript,
 };
 use jf_primitives::pcs::prelude::{Commitment, UnivariateVerifierParam};
-use mpc_relation::{Arithmetization, Circuit as JfCircuit, PlonkCircuit};
+use mpc_relation::{Arithmetization, Circuit as JfCircuit, PlonkCircuit, ConstraintSystem};
 use rand::thread_rng;
 
 pub fn gen_circuit(n: usize, public_inputs: &[ScalarField]) -> Result<PlonkCircuit<ScalarField>> {


### PR DESCRIPTION
This PR ended up being more of a mixed bag than I'd like, it led to many detours...

Primarly, however, this extends appropriate access controls to the Merkle contract, making it owned by the darkpool.

Technically, we could just `delegatecall` to the Merkle contract and not worry about access controls on the deployed contract itself, but this is a bad idea in the case that we ever point the darkpool to a Merkle implementation that can `selfdestruct`. This is the basis of the pattern that upgradeable contracts (like, in our case, the darkpool) should never `delegatecall` ([reference](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#potentially-unsafe-operations)) - and I err on the side of following best practices, even if we believe we can avoid the situations they protect against.

This does mean that we will also have the Merkle contract sit behind an upgradeable proxy.

This PR also makes some small changes across the codebase to reduce binary size, as we are once again beyond the limit. The biggest lift here was defining the `process_party` helper for the `process_match_settle` method on the darkpool, but other changes include using statically-sized arrays in various serialization code, and avoiding error type conversions when we're going to unwrap anyway.

Finally, we make the `DarkpoolContract` methods generic over a type `S: TopLevelStorage + BorrowMut<Self>`, making it possible for the `DarkpoolContract` to make multiple calls to other contracts in one external method when it is a parent contract (as is the case when the `DarkpoolTestContract` inherits from it). Much of the diff in this PR is largely cosmetic, stemming from this change.

Tests for the new access controls are not yet written in order to not overload this review.

---

## EDIT

After discussion, we decided to `delegatecall` the Merkle contract after all, as this simplifies the smart contract topology significantly, and it is simple to avoid calling `selfdestruct` in any implementations of the Merkle contract (a doc comment has been left for this).

As a result, the only change in terms of access controls in this PR is to make the darkpool `Initializable`, we don't need to worry about `Ownable` for the Merkle contract.

Also, I am somewhat confused as to how the current implementation doesn't lead to storage collisions, but it doesn't seem to. I would think that the Merkle contract's fields would overwrite those in the Darkpool, since [Stylus lays out storage variables in the same way as the EVM](https://docs.arbitrum.io/stylus/reference/rust-sdk-guide#sol_storage:~:text=The%20types%20in%20%23%5Bsolidity_storage%5D%20are%20laid%20out%20in%20the%20EVM%20state%20trie%20exactly%20as%20they%20are%20in%20Solidity.), but ad hoc tests seem to show that everything continues working as expected. I'll save this as a potential problem to fully suss out later.