### PR TITLE
integration: add `Initializable` test

### DIFF
--- a/contracts-stylus/src/contracts/components/initializable.rs
+++ b/contracts-stylus/src/contracts/components/initializable.rs
@@ -13,11 +13,7 @@ pub struct Initializable {
     /// initialization steps to be added in future versions.
     ///
     /// This is particularly relevant for contracts that are upgradable.
-    #[cfg_attr(
-        not(any(feature = "darkpool", feature = "darkpool-test-contract")),
-        allow(dead_code)
-    )]
-    initialized: StorageU64,
+    pub initialized: StorageU64,
 }
 
 /// None of the `Initializable` methods are marked `external` because they are

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -2,7 +2,7 @@ use core::borrow::{Borrow, BorrowMut};
 
 use alloc::vec::Vec;
 use common::{serde_def_types::SerdeScalarField, types::ExternalTransfer};
-use stylus_sdk::{abi::Bytes, prelude::*};
+use stylus_sdk::{abi::Bytes, alloy_primitives::U64, prelude::*};
 
 use crate::contracts::{
     components::{initializable::Initializable, ownable::Ownable},
@@ -57,6 +57,13 @@ impl DarkpoolTestContract {
         let external_transfer: ExternalTransfer =
             postcard::from_bytes(transfer.as_slice()).unwrap();
         DarkpoolContract::execute_external_transfer(self, &external_transfer);
+        Ok(())
+    }
+
+    pub fn clear_initializable(&mut self) -> Result<(), Vec<u8>> {
+        BorrowMut::<Initializable>::borrow_mut(self)
+            .initialized
+            .set(U64::from_limbs([0]));
         Ok(())
     }
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -30,6 +30,8 @@ abigen!(
         function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)
 
         function executeExternalTransfer(bytes memory transfer) external
+
+        function clearInitializable() external
     ]"#
 );
 

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -34,7 +34,7 @@ pub(crate) enum Tests {
     NullifierSet,
     Merkle,
     Verifier,
-    Ownership,
+    Ownable,
     ExternalTransfer,
     NewWallet,
     UpdateWallet,

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -35,6 +35,7 @@ pub(crate) enum Tests {
     Merkle,
     Verifier,
     Ownable,
+    Initializable,
     ExternalTransfer,
     NewWallet,
     UpdateWallet,

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -13,8 +13,8 @@ use constants::{
 use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_merkle, test_nullifier_set, test_ownership, test_process_match_settle, test_update_wallet,
-    test_verifier, test_new_wallet,
+    test_merkle, test_new_wallet, test_nullifier_set, test_ownable, test_process_match_settle,
+    test_update_wallet, test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -74,12 +74,12 @@ async fn main() -> Result<()> {
 
             test_verifier(contract, verifier_address).await?;
         }
-        Tests::Ownership => {
+        Tests::Ownable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());
             let darkpool_test_contract_address =
                 parse_addr_from_deployments_file(&deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?;
 
-            test_ownership(contract, darkpool_test_contract_address).await?;
+            test_ownable(contract, darkpool_test_contract_address).await?;
         }
         Tests::ExternalTransfer => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -13,8 +13,8 @@ use constants::{
 use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_merkle, test_new_wallet, test_nullifier_set, test_ownable, test_process_match_settle,
-    test_update_wallet, test_verifier,
+    test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable,
+    test_process_match_settle, test_update_wallet, test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file, setup_client};
 
@@ -80,6 +80,11 @@ async fn main() -> Result<()> {
                 parse_addr_from_deployments_file(&deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?;
 
             test_ownable(contract, darkpool_test_contract_address).await?;
+        }
+        Tests::Initializable => {
+            let contract = DarkpoolTestContract::new(contract_address, client.clone());
+
+            test_initializable(contract).await?;
         }
         Tests::ExternalTransfer => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -311,6 +311,33 @@ pub(crate) async fn test_ownable(
     Ok(())
 }
 
+pub(crate) async fn test_initializable(
+    contract: DarkpoolTestContract<impl Middleware + 'static>,
+) -> Result<()> {
+    let dummy_verifier_address = Address::random();
+    let dummy_merkle_address = Address::random();
+
+    contract
+        .initialize(dummy_verifier_address, dummy_merkle_address)
+        .send()
+        .await?
+        .await?;
+
+    assert!(
+        contract
+            .initialize(dummy_verifier_address, dummy_merkle_address)
+            .send()
+            .await
+            .is_err(),
+        "Initialized contract twice"
+    );
+
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
+
+    Ok(())
+}
+
 pub(crate) async fn test_nullifier_set(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -449,6 +476,9 @@ pub(crate) async fn test_new_wallet(
 
     assert_eq!(ark_root, contract_root, "Merkle root incorrect");
 
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
+
     Ok(())
 }
 
@@ -525,6 +555,9 @@ pub(crate) async fn test_update_wallet(
             .0;
 
     assert_eq!(ark_root, contract_root, "Merkle root incorrect");
+
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
 
     Ok(())
 }
@@ -629,6 +662,9 @@ pub(crate) async fn test_process_match_settle(
             .0;
 
     assert_eq!(ark_root, contract_root, "Merkle root incorrect");
+
+    // Clear initializable state for future tests
+    contract.clear_initializable().send().await?.await?;
 
     Ok(())
 }

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -211,7 +211,7 @@ pub(crate) async fn test_verifier(
     Ok(())
 }
 
-pub(crate) async fn test_ownership(
+pub(crate) async fn test_ownable(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     darkpool_test_contract_address: Address,
 ) -> Result<()> {

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -92,7 +92,7 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
         Tests::Verifier => {
             parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?
         }
-        Tests::Ownership => {
+        Tests::Ownable => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
         Tests::ExternalTransfer => {

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -95,6 +95,9 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
         Tests::Ownable => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }
+        Tests::Initializable => {
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+        }
         Tests::ExternalTransfer => {
             parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
         }


### PR DESCRIPTION
This PR adds a test case ensuring that `initialize` can't be called on the darkpool twice, which passes.