### PR TITLE
contracts-stylus: emit events

### DIFF
--- a/common/src/serde_def_types.rs
+++ b/common/src/serde_def_types.rs
@@ -54,7 +54,7 @@ pub type ScalarFieldDef = FpDef<MontBackend<FrConfig, 4>, 4>;
 pub(crate) type G1BaseFieldDef = FpDef<MontBackend<FqConfig, 4>, 4>;
 
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct SerdeScalarField(#[serde_as(as = "ScalarFieldDef")] pub ScalarField);
 
 #[serde_as]

--- a/contracts-stylus/src/contracts/components/initializable.rs
+++ b/contracts-stylus/src/contracts/components/initializable.rs
@@ -4,7 +4,9 @@
 //! But made significantly simpler because the functions defined here are not modifiers, as in Solidity.
 //! Down the road, this may be attempted with the use of procedural macros.
 
-use stylus_sdk::{alloy_primitives::U64, prelude::*, storage::StorageU64};
+use stylus_sdk::{alloy_primitives::U64, prelude::*, storage::StorageU64, evm};
+
+use crate::utils::solidity::Initialized;
 
 #[solidity_storage]
 pub struct Initializable {
@@ -24,9 +26,10 @@ impl Initializable {}
 impl Initializable {
     /// Initializes this contract with the given version.
     pub fn _initialize(&mut self, version: u64) {
-        let version = U64::from_limbs([version]);
-        assert!(self.initialized.get() < version);
-        self.initialized.set(version);
+        let version_uint64 = U64::from_limbs([version]);
+        assert!(self.initialized.get() < version_uint64);
+        self.initialized.set(version_uint64);
+        evm::log(Initialized { version })
     }
 
     /// Gets the highest version that has been initialized.

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -29,7 +29,7 @@ use crate::utils::{
         VALID_WALLET_CREATE_CIRCUIT_ID, VALID_WALLET_UPDATE_CIRCUIT_ID,
     },
     helpers::{delegate_call_helper, serialize_statement_for_verification},
-    interfaces::{initCall, insertSharesCommitmentCall, rootCall, rootInHistoryCall, IERC20},
+    solidity::{initCall, insertSharesCommitmentCall, rootCall, rootInHistoryCall, IERC20},
 };
 
 use super::components::{initializable::Initializable, ownable::Ownable};

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -30,12 +30,9 @@ use crate::utils::{
         VALID_COMMITMENTS_CIRCUIT_ID, VALID_MATCH_SETTLE_CIRCUIT_ID, VALID_REBLIND_CIRCUIT_ID,
         VALID_WALLET_CREATE_CIRCUIT_ID, VALID_WALLET_UPDATE_CIRCUIT_ID,
     },
-    helpers::{
-        delegate_call_helper, keccak_hash_scalar, serialize_statement_for_verification,
-        serialize_wallet_shares,
-    },
+    helpers::{delegate_call_helper, keccak_hash_scalar, serialize_statement_for_verification},
     solidity::{
-        initCall, insertSharesCommitmentCall, rootCall, rootInHistoryCall, Deposit, MatchSettled,
+        initCall, insertSharesCommitmentCall, rootCall, rootInHistoryCall, Deposit,
         MerkleAddressSet, VerificationKeySet, VerifierAddressSet, WalletCreated, WalletUpdated,
         Withdrawal, IERC20,
     },
@@ -235,11 +232,8 @@ impl DarkpoolContract {
         );
 
         let wallet_blinder_share_hash = keccak(wallet_blinder_share);
-        let public_wallet_shares =
-            serialize_wallet_shares(&valid_wallet_create_statement.public_wallet_shares);
         evm::log(WalletCreated {
             wallet_blinder_share: wallet_blinder_share_hash.into(),
-            public_wallet_shares,
         });
 
         Ok(())
@@ -295,11 +289,8 @@ impl DarkpoolContract {
         }
 
         let wallet_blinder_share_hash = keccak(wallet_blinder_share);
-        let public_wallet_shares =
-            serialize_wallet_shares(&valid_wallet_update_statement.new_public_shares);
         evm::log(WalletUpdated {
             wallet_blinder_share: wallet_blinder_share_hash.into(),
-            public_wallet_shares,
         });
 
         Ok(())
@@ -357,16 +348,12 @@ impl DarkpoolContract {
             keccak_hash_scalar(party_0_match_payload.wallet_blinder_share);
         let party_1_wallet_blinder_share_hash =
             keccak_hash_scalar(party_1_match_payload.wallet_blinder_share);
-        let party_0_public_wallet_shares =
-            serialize_wallet_shares(&valid_match_settle_statement.party0_modified_shares);
-        let party_1_public_wallet_shares =
-            serialize_wallet_shares(&valid_match_settle_statement.party1_modified_shares);
 
-        evm::log(MatchSettled {
-            party_0_wallet_blinder_share: party_0_wallet_blinder_share_hash.into(),
-            party_1_wallet_blinder_share: party_1_wallet_blinder_share_hash.into(),
-            party_0_public_wallet_shares,
-            party_1_public_wallet_shares,
+        evm::log(WalletUpdated {
+            wallet_blinder_share: party_0_wallet_blinder_share_hash.into(),
+        });
+        evm::log(WalletUpdated {
+            wallet_blinder_share: party_1_wallet_blinder_share_hash.into(),
         });
 
         Ok(())

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -3,8 +3,7 @@
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use common::{
-    constants::WALLET_SHARES_LEN, custom_serde::ScalarSerializable,
-    serde_def_types::SerdeScalarField, types::ScalarField,
+    custom_serde::ScalarSerializable, serde_def_types::SerdeScalarField, types::ScalarField,
 };
 use stylus_sdk::{
     alloy_primitives::{Address, B256},
@@ -51,15 +50,4 @@ pub fn delegate_call_helper<C: SolCall>(
 /// Computes the Keccak-256 hash of the given scalar when serialized to bytes
 pub fn keccak_hash_scalar(scalar: ScalarField) -> B256 {
     keccak(postcard::to_allocvec(&SerdeScalarField(scalar)).unwrap())
-}
-
-pub fn serialize_wallet_shares(scalars: &[ScalarField; WALLET_SHARES_LEN]) -> Vec<u8> {
-    let serde_wallet_shares: [SerdeScalarField; WALLET_SHARES_LEN] = scalars
-        .iter()
-        .map(|s| SerdeScalarField(*s))
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap();
-
-    postcard::to_allocvec(&serde_wallet_shares).unwrap()
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -3,7 +3,8 @@
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use common::{
-    custom_serde::ScalarSerializable, serde_def_types::SerdeScalarField, types::ScalarField,
+    constants::WALLET_SHARES_LEN, custom_serde::ScalarSerializable,
+    serde_def_types::SerdeScalarField, types::ScalarField,
 };
 use stylus_sdk::{
     alloy_primitives::{Address, B256},
@@ -50,4 +51,15 @@ pub fn delegate_call_helper<C: SolCall>(
 /// Computes the Keccak-256 hash of the given scalar when serialized to bytes
 pub fn keccak_hash_scalar(scalar: ScalarField) -> B256 {
     keccak(postcard::to_allocvec(&SerdeScalarField(scalar)).unwrap())
+}
+
+pub fn serialize_wallet_shares(scalars: &[ScalarField; WALLET_SHARES_LEN]) -> Vec<u8> {
+    let serde_wallet_shares: [SerdeScalarField; WALLET_SHARES_LEN] = scalars
+        .iter()
+        .map(|s| SerdeScalarField(*s))
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+
+    postcard::to_allocvec(&serde_wallet_shares).unwrap()
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -2,8 +2,15 @@
 
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
-use common::{custom_serde::ScalarSerializable, serde_def_types::SerdeScalarField};
-use stylus_sdk::{alloy_primitives::Address, call::delegate_call, storage::TopLevelStorage};
+use common::{
+    custom_serde::ScalarSerializable, serde_def_types::SerdeScalarField, types::ScalarField,
+};
+use stylus_sdk::{
+    alloy_primitives::{Address, B256},
+    call::delegate_call,
+    crypto::keccak,
+    storage::TopLevelStorage,
+};
 
 /// Serializes the given statement into scalars, and then into bytes,
 /// as expected by the verifier contract.
@@ -38,4 +45,9 @@ pub fn delegate_call_helper<C: SolCall>(
     let calldata = C::new(args).encode();
     let res = unsafe { delegate_call(storage, address, &calldata).unwrap() };
     C::decode_returns(&res, true /* validate */).unwrap()
+}
+
+/// Computes the Keccak-256 hash of the given scalar when serialized to bytes
+pub fn keccak_hash_scalar(scalar: ScalarField) -> B256 {
+    keccak(postcard::to_allocvec(&SerdeScalarField(scalar)).unwrap())
 }

--- a/contracts-stylus/src/utils/mod.rs
+++ b/contracts-stylus/src/utils/mod.rs
@@ -4,4 +4,4 @@
 pub mod backends;
 pub mod constants;
 pub mod helpers;
-pub mod interfaces;
+pub mod solidity;

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -1,4 +1,4 @@
-//! Solidity ABI-compatible interface definitions used by the darkpool
+//! Various Solidity definitions, including ABI-compatible interfaces, events, functions, etc.
 
 use alloy_sol_types::sol;
 use stylus_sdk::stylus_proc::sol_interface;

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -60,9 +60,8 @@ sol! {
     event VerifierAddressSet(address indexed previous_verifier_address, address indexed new_verifier_address);
     event MerkleAddressSet(address indexed previous_merkle_address, address indexed new_merkle_address);
     event VerificationKeySet(uint8 indexed circuit_id, bytes verification_key);
-    event WalletCreated(bytes indexed wallet_blinder_share, bytes public_wallet_shares);
-    event WalletUpdated(bytes indexed wallet_blinder_share, bytes public_wallet_shares);
-    event MatchSettled(bytes indexed party_0_wallet_blinder_share, bytes indexed party_1_wallet_blinder_share, bytes party_0_public_wallet_shares, bytes party_1_public_wallet_shares);
+    event WalletCreated(bytes indexed wallet_blinder_share);
+    event WalletUpdated(bytes indexed wallet_blinder_share);
     event Deposit(address indexed sender, address indexed mint, uint256 amount);
     event Withdrawal(address indexed recipient, address indexed mint, uint256 amount);
 }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -55,4 +55,14 @@ sol! {
     event RootChanged(bytes indexed prev_root, bytes indexed new_root);
     event ValueInserted(uint128 indexed index, bytes indexed value);
     event InternalNodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value);
+
+    // Darkpool events
+    event VerifierAddressSet(address indexed previous_verifier_address, address indexed new_verifier_address);
+    event MerkleAddressSet(address indexed previous_merkle_address, address indexed new_merkle_address);
+    event VerificationKeySet(uint8 indexed circuit_id, bytes verification_key);
+    event WalletCreated(bytes indexed wallet_blinder_share, bytes public_wallet_shares);
+    event WalletUpdated(bytes indexed wallet_blinder_share, bytes public_wallet_shares);
+    event MatchSettled(bytes indexed party_0_wallet_blinder_share, bytes indexed party_1_wallet_blinder_share, bytes party_0_public_wallet_shares, bytes party_1_public_wallet_shares);
+    event Deposit(address indexed sender, address indexed mint, uint256 amount);
+    event Withdrawal(address indexed recipient, address indexed mint, uint256 amount);
 }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -44,6 +44,13 @@ sol! {
     // Indexed `bytes` event parameters are encoded as their Keccak-256 hash
     // https://docs.soliditylang.org/en/latest/abi-spec.html#encoding-of-indexed-event-parameters
 
+    // Ownable events
+    event InvalidOwner(address owner);
+    event OwnershipTransferred(address indexed previous_owner, address indexed new_owner);
+
+    // Initializable events
+    event Initialized(uint64 version);
+
     // Merkle events
     event RootChanged(bytes indexed prev_root, bytes indexed new_root);
     event ValueInserted(uint128 indexed index, bytes indexed value);

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -26,9 +26,26 @@ sol_interface! {
 }
 
 sol! {
+
+    // -------------
+    // | FUNCTIONS |
+    // -------------
+
     // Merkle functions
     function init() external;
     function root() external view returns (bytes);
     function rootInHistory(bytes root) external view returns (bool);
     function insertSharesCommitment(bytes shares) external;
+
+    // ----------
+    // | EVENTS |
+    // ----------
+
+    // Indexed `bytes` event parameters are encoded as their Keccak-256 hash
+    // https://docs.soliditylang.org/en/latest/abi-spec.html#encoding-of-indexed-event-parameters
+
+    // Merkle events
+    event RootChanged(bytes indexed prev_root, bytes indexed new_root);
+    event ValueInserted(uint128 indexed index, bytes indexed value);
+    event InternalNodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value);
 }


### PR DESCRIPTION
This PR adds event emission to all of the contracts. This mirrors the way events were emitted in the Cairo implementation, with a few differences:
1. Events for `Ownable` and `Initializable` are copied over from the OpenZeppelin implementations ([ref](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/v5.0.0))
2. Events for upgrades are not yet implemented as the upgradeable proxy is not yet implemented
3. We add `WalletCreated` and `MatchSettled` events, and these, along with the existing `WalletUpdated` event, also log the serialization of the public wallet shares (for indexing & recovery)

Tests asserting well-formedness of these events are deferred for later, perhaps until indexing functionality is implemented in the relayer. Additionally, these changes push the darkpool contract past the binary size limit once again, the mitigation of which is left for the next PR.