### PR TITLE
integration: add upgradeability test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,8 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 name = "deploy-scripts"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "clap",
  "ethers",
  "serde_json",

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -23,6 +23,7 @@ verifier = []
 verifier-test-contract = []
 precompile-test-contract = []
 dummy-erc20 = []
+dummy-upgrade-target = []
 export-abi = ["stylus-sdk/export-abi"]
 
 [lib]

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -44,13 +44,13 @@ pub struct DarkpoolContract {
     owner: StorageAddress,
 
     /// Whether or not the darkpool has been initialized
-    pub initialized: StorageU64,
+    initialized: StorageU64,
 
     /// The address of the verifier contract
     verifier_address: StorageAddress,
 
     /// The address of the Merkle contract
-    merkle_address: StorageAddress,
+    pub(crate) merkle_address: StorageAddress,
 
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
@@ -94,11 +94,12 @@ impl DarkpoolContract {
     /// Initializes the Darkpool
     pub fn initialize<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
+        owner: Address,
         verifier_address: Address,
         merkle_address: Address,
     ) -> Result<(), Vec<u8>> {
-        // Set the caller as the owner
-        DarkpoolContract::_transfer_ownership(storage, msg::sender());
+        // Set the owner address
+        DarkpoolContract::_transfer_ownership(storage, owner);
 
         // Initialize the Merkle tree
         delegate_call_helper::<initCall>(storage, merkle_address, ());

--- a/contracts-stylus/src/contracts/mod.rs
+++ b/contracts-stylus/src/contracts/mod.rs
@@ -14,6 +14,7 @@ mod verifier;
     feature = "verifier-test-contract",
     feature = "merkle-test-contract",
     feature = "darkpool-test-contract",
-    feature = "dummy-erc20"
+    feature = "dummy-erc20",
+    feature = "dummy-upgrade-target",
 ))]
 mod test_contracts;

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -2,9 +2,12 @@ use core::borrow::BorrowMut;
 
 use alloc::vec::Vec;
 use common::{serde_def_types::SerdeScalarField, types::ExternalTransfer};
-use stylus_sdk::{abi::Bytes, alloy_primitives::U64, prelude::*};
+use stylus_sdk::{abi::Bytes, prelude::*};
 
-use crate::contracts::darkpool::DarkpoolContract;
+use crate::{
+    contracts::darkpool::DarkpoolContract,
+    utils::{helpers::delegate_call_helper, solidity::initCall},
+};
 
 #[solidity_storage]
 #[entrypoint]
@@ -30,10 +33,13 @@ impl DarkpoolTestContract {
         Ok(())
     }
 
-    pub fn clear_initializable(&mut self) -> Result<(), Vec<u8>> {
-        BorrowMut::<DarkpoolContract>::borrow_mut(self)
-            .initialized
-            .set(U64::from_limbs([0]));
+    pub fn clear_merkle(&mut self) -> Result<(), Vec<u8>> {
+        let merkle_address = BorrowMut::<DarkpoolContract>::borrow_mut(self)
+            .merkle_address
+            .get();
+
+        delegate_call_helper::<initCall>(self, merkle_address, ());
+
         Ok(())
     }
 }

--- a/contracts-stylus/src/contracts/test_contracts/dummy_upgrade_target.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_upgrade_target.rs
@@ -1,0 +1,15 @@
+//! A dummy contract intended to be used as an upgrade target for testing purposes.
+
+use alloc::vec::Vec;
+use stylus_sdk::prelude::*;
+
+#[solidity_storage]
+#[entrypoint]
+struct DummyUpgradeTargetContract {}
+
+#[external]
+impl DummyUpgradeTargetContract {
+    pub fn is_dummy_upgrade_target(&self) -> Result<bool, Vec<u8>> {
+        Ok(true)
+    }
+}

--- a/contracts-stylus/src/contracts/test_contracts/mod.rs
+++ b/contracts-stylus/src/contracts/test_contracts/mod.rs
@@ -14,3 +14,6 @@ mod darkpool_test_contract;
 
 #[cfg(feature = "dummy-erc20")]
 mod dummy_erc20;
+
+#[cfg(feature = "dummy-upgrade-target")]
+mod dummy_upgrade_target;

--- a/deploy-scripts/Cargo.toml
+++ b/deploy-scripts/Cargo.toml
@@ -8,3 +8,5 @@ ethers = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
+alloy-sol-types = { workspace = true }
+alloy-primitives = { workspace = true }

--- a/deploy-scripts/src/cli.rs
+++ b/deploy-scripts/src/cli.rs
@@ -36,17 +36,22 @@ pub enum Command {
 /// Upgrade calls can only be made to the `TransparentUpgradeableProxy` through the `ProxyAdmin`.
 #[derive(Args)]
 pub struct DeployProxyArgs {
-    /// Implementation contract address in hex
-    #[arg(short, long)]
-    pub implementation: String,
-
-    /// Proxy admin contract owner address in hex
+    /// Address of the owner for both the proxy admin contract
+    /// and the underlying darkpool contract
     #[arg(short, long)]
     pub owner: String,
 
-    /// Implementation contract calldata in hex
+    /// Darkpool implementation contract address in hex
     #[arg(short, long)]
-    pub calldata: Option<String>,
+    pub darkpool: String,
+
+    /// Verifier contract address in hex
+    #[arg(short, long)]
+    pub verifier: String,
+
+    /// Merkle contract address in hex
+    #[arg(short, long)]
+    pub merkle: String,
 }
 
 impl Command {

--- a/deploy-scripts/src/lib.rs
+++ b/deploy-scripts/src/lib.rs
@@ -8,4 +8,5 @@ pub mod cli;
 mod commands;
 mod constants;
 pub mod errors;
+mod solidity;
 pub mod utils;

--- a/deploy-scripts/src/solidity.rs
+++ b/deploy-scripts/src/solidity.rs
@@ -1,0 +1,7 @@
+//! Definitions of Solidity functions called during deployment
+
+use alloy_sol_types::sol;
+
+sol! {
+    function initialize(address memory owner, address memory verifier_address, address memory merkle_address) external;
+}

--- a/deploy-scripts/src/utils.rs
+++ b/deploy-scripts/src/utils.rs
@@ -2,13 +2,15 @@
 
 use std::{str::FromStr, sync::Arc};
 
+use alloy_primitives::{Address as AlloyAddress, hex::FromHex};
+use alloy_sol_types::SolCall;
 use ethers::{
     middleware::SignerMiddleware,
     providers::{Http, Middleware, Provider},
     signers::{LocalWallet, Signer},
 };
 
-use crate::errors::DeployError;
+use crate::{errors::DeployError, solidity::initializeCall};
 
 /// Sets up the address and client with which to instantiate a contract for testing,
 /// reading in the private key, RPC url, and contract address from the environment.
@@ -16,14 +18,31 @@ pub async fn setup_client(
     priv_key: String,
     rpc_url: String,
 ) -> Result<Arc<impl Middleware>, DeployError> {
-    let provider = Provider::<Http>::try_from(rpc_url).map_err(|_| DeployError::ClientInitialization)?;
+    let provider =
+        Provider::<Http>::try_from(rpc_url).map_err(|_| DeployError::ClientInitialization)?;
 
     let wallet = LocalWallet::from_str(&priv_key).map_err(|_| DeployError::ClientInitialization)?;
-    let chain_id = provider.get_chainid().await.map_err(|_| DeployError::ClientInitialization)?.as_u64();
+    let chain_id = provider
+        .get_chainid()
+        .await
+        .map_err(|_| DeployError::ClientInitialization)?
+        .as_u64();
     let client = Arc::new(SignerMiddleware::new(
         provider,
         wallet.clone().with_chain_id(chain_id),
     ));
 
     Ok(client)
+}
+
+/// Prepare calldata for the Darkpool contract's `initialize` method
+pub fn darkpool_initialize_calldata(
+    owner_address: &str,
+    verifier_address: &str,
+    merkle_address: &str,
+) -> Result<Vec<u8>, DeployError> {
+    let owner_address = AlloyAddress::from_hex(owner_address).map_err(|_| DeployError::CalldataConstruction)?;
+    let verifier_address = AlloyAddress::from_hex(verifier_address).map_err(|_| DeployError::CalldataConstruction)?;
+    let merkle_address = AlloyAddress::from_hex(merkle_address).map_err(|_| DeployError::CalldataConstruction)?;
+    Ok(initializeCall::new((owner_address, verifier_address, merkle_address)).encode())
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -76,3 +76,10 @@ abigen!(
         function upgradeAndCall(address proxy, address implementation, bytes memory data) external
     ]"#
 );
+
+abigen!(
+    DummyUpgradeTargetContract,
+    r#"[
+        function isDummyUpgradeTarget() external view returns (bool)
+    ]"#
+);

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,7 +5,7 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
-        function initialize(address memory verifier_address, address memory merkle_address) external
+        function initialize(address memory owner, address memory verifier_address, address memory merkle_address) external
 
         function transferOwnership(address memory new_owner) external
 
@@ -31,7 +31,7 @@ abigen!(
 
         function executeExternalTransfer(bytes memory transfer) external
 
-        function clearInitializable() external
+        function clearMerkle() external
     ]"#
 );
 
@@ -67,5 +67,12 @@ abigen!(
     r#"[
         function mint(address memory _address, uint256 memory value) external
         function balanceOf(address memory _address) external view returns (uint256)
+    ]"#
+);
+
+abigen!(
+    DarkpoolProxyAdminContract,
+    r#"[
+        function upgradeAndCall(address proxy, address implementation, bytes memory data) external
     ]"#
 );

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -34,6 +34,7 @@ pub(crate) enum Tests {
     NullifierSet,
     Merkle,
     Verifier,
+    Upgradeable,
     Ownable,
     Initializable,
     ExternalTransfer,

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -23,7 +23,9 @@ pub(crate) const VERIFIER_CONTRACT_KEY: &str = "verifier_contract";
 pub(crate) const VERIFIER_TEST_CONTRACT_KEY: &str = "verifier_test_contract";
 
 /// The darkpool test contract key in the `deployments.json` file
-pub(crate) const DARKPOOL_TEST_CONTRACT_KEY: &str = "darkpool_test_contract";
+pub(crate) const DARKPOOL_TEST_PROXY_CONTRACT_KEY: &str = "darkpool_test_proxy_contract";
+
+pub(crate) const DARKPOOL_PROXY_ADMIN_CONTRACT_KEY: &str = "darkpool_proxy_admin_contract";
 
 /// The dummy erc20 contract key in the `deployments.json` file
 pub(crate) const DUMMY_ERC20_CONTRACT_KEY: &str = "dummy_erc20_contract";

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -23,12 +23,19 @@ pub(crate) const VERIFIER_CONTRACT_KEY: &str = "verifier_contract";
 pub(crate) const VERIFIER_TEST_CONTRACT_KEY: &str = "verifier_test_contract";
 
 /// The darkpool test contract key in the `deployments.json` file
-pub(crate) const DARKPOOL_TEST_PROXY_CONTRACT_KEY: &str = "darkpool_test_proxy_contract";
+pub(crate) const DARKPOOL_TEST_CONTRACT_KEY: &str = "darkpool_test_contract";
 
+/// The darkpool proxy contract key in the `deployments.json` file
+pub(crate) const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";
+
+/// The darkpool proxy admin contract key in the `deployments.json` file
 pub(crate) const DARKPOOL_PROXY_ADMIN_CONTRACT_KEY: &str = "darkpool_proxy_admin_contract";
 
 /// The dummy erc20 contract key in the `deployments.json` file
 pub(crate) const DUMMY_ERC20_CONTRACT_KEY: &str = "dummy_erc20_contract";
+
+/// The dummy upgrade target contract key in the `deployments.json` file
+pub(crate) const DUMMY_UPGRADE_TARGET_CONTRACT_KEY: &str = "dummy_upgrade_target_contract";
 
 /// The domain size to use when testing the verifier contract
 pub(crate) const N: usize = 8192;

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -7,9 +7,9 @@ use abis::{
 use clap::Parser;
 use cli::{Cli, Tests};
 use constants::{
-    DARKPOOL_TEST_CONTRACT_KEY, DUMMY_ERC20_CONTRACT_KEY, MERKLE_TEST_CONTRACT_KEY,
-    VERIFIER_CONTRACT_KEY,
+    DARKPOOL_TEST_PROXY_CONTRACT_KEY, DUMMY_ERC20_CONTRACT_KEY, VERIFIER_CONTRACT_KEY,
 };
+use deploy_scripts::utils::setup_client;
 use eyre::Result;
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
@@ -17,7 +17,6 @@ use tests::{
     test_process_match_settle, test_update_wallet, test_verifier,
 };
 use utils::{get_test_contract_address, parse_addr_from_deployments_file};
-use deploy_scripts::utils::setup_client;
 
 mod abis;
 mod cli;
@@ -77,10 +76,12 @@ async fn main() -> Result<()> {
         }
         Tests::Ownable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());
-            let darkpool_test_contract_address =
-                parse_addr_from_deployments_file(&deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?;
+            let darkpool_test_proxy_contract_address = parse_addr_from_deployments_file(
+                &deployments_file,
+                DARKPOOL_TEST_PROXY_CONTRACT_KEY,
+            )?;
 
-            test_ownable(contract, darkpool_test_contract_address).await?;
+            test_ownable(contract, darkpool_test_proxy_contract_address).await?;
         }
         Tests::Initializable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());
@@ -97,30 +98,18 @@ async fn main() -> Result<()> {
         }
         Tests::NewWallet => {
             let contract = DarkpoolTestContract::new(contract_address, client);
-            let verifier_address =
-                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
-            let merkle_address =
-                parse_addr_from_deployments_file(&deployments_file, MERKLE_TEST_CONTRACT_KEY)?;
 
-            test_new_wallet(contract, merkle_address, verifier_address).await?;
+            test_new_wallet(contract).await?;
         }
         Tests::UpdateWallet => {
             let contract = DarkpoolTestContract::new(contract_address, client);
-            let verifier_address =
-                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
-            let merkle_address =
-                parse_addr_from_deployments_file(&deployments_file, MERKLE_TEST_CONTRACT_KEY)?;
 
-            test_update_wallet(contract, merkle_address, verifier_address).await?;
+            test_update_wallet(contract).await?;
         }
         Tests::ProcessMatchSettle => {
             let contract = DarkpoolTestContract::new(contract_address, client);
-            let verifier_address =
-                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
-            let merkle_address =
-                parse_addr_from_deployments_file(&deployments_file, MERKLE_TEST_CONTRACT_KEY)?;
 
-            test_process_match_settle(contract, merkle_address, verifier_address).await?;
+            test_process_match_settle(contract).await?;
         }
     }
 

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -29,8 +29,9 @@ use crate::{
     abis::{DarkpoolTestContract, DummyErc20Contract},
     cli::Tests,
     constants::{
-        DARKPOOL_TEST_PROXY_CONTRACT_KEY, DEPLOYMENTS_KEY, MERKLE_TEST_CONTRACT_KEY, N,
-        PRECOMPILE_TEST_CONTRACT_KEY, TRANSFER_AMOUNT, VERIFIER_TEST_CONTRACT_KEY,
+        DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, DEPLOYMENTS_KEY,
+        MERKLE_TEST_CONTRACT_KEY, N, PRECOMPILE_TEST_CONTRACT_KEY, TRANSFER_AMOUNT,
+        VERIFIER_TEST_CONTRACT_KEY,
     },
 };
 
@@ -64,7 +65,7 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
             parse_addr_from_deployments_file(deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?
         }
         Tests::NullifierSet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
         Tests::Merkle => {
             parse_addr_from_deployments_file(deployments_file, MERKLE_TEST_CONTRACT_KEY)?
@@ -72,23 +73,26 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
         Tests::Verifier => {
             parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?
         }
+        Tests::Upgradeable => {
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY)?
+        }
         Tests::Ownable => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
         Tests::Initializable => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
         Tests::ExternalTransfer => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
         Tests::NewWallet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
         Tests::UpdateWallet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
         Tests::ProcessMatchSettle => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
         }
     })
 }

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -29,7 +29,7 @@ use crate::{
     abis::{DarkpoolTestContract, DummyErc20Contract},
     cli::Tests,
     constants::{
-        DARKPOOL_TEST_CONTRACT_KEY, DEPLOYMENTS_KEY, MERKLE_TEST_CONTRACT_KEY, N,
+        DARKPOOL_TEST_PROXY_CONTRACT_KEY, DEPLOYMENTS_KEY, MERKLE_TEST_CONTRACT_KEY, N,
         PRECOMPILE_TEST_CONTRACT_KEY, TRANSFER_AMOUNT, VERIFIER_TEST_CONTRACT_KEY,
     },
 };
@@ -64,7 +64,7 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
             parse_addr_from_deployments_file(deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?
         }
         Tests::NullifierSet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
         Tests::Merkle => {
             parse_addr_from_deployments_file(deployments_file, MERKLE_TEST_CONTRACT_KEY)?
@@ -73,22 +73,22 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
             parse_addr_from_deployments_file(deployments_file, VERIFIER_TEST_CONTRACT_KEY)?
         }
         Tests::Ownable => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
         Tests::Initializable => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
         Tests::ExternalTransfer => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
         Tests::NewWallet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
         Tests::UpdateWallet => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
         Tests::ProcessMatchSettle => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_CONTRACT_KEY)?
+            parse_addr_from_deployments_file(deployments_file, DARKPOOL_TEST_PROXY_CONTRACT_KEY)?
         }
     })
 }
@@ -99,16 +99,8 @@ pub fn serialize_to_calldata<T: Serialize>(t: &T) -> Result<Bytes> {
 
 pub(crate) async fn setup_darkpool_test_contract(
     contract: &DarkpoolTestContract<impl Middleware + 'static>,
-    merkle_address: Address,
-    verifier_address: Address,
     vkeys: Vec<(Circuit, Bytes)>,
 ) -> Result<()> {
-    contract
-        .initialize(verifier_address, merkle_address)
-        .send()
-        .await?
-        .await?;
-
     // Set verification keys
     for (circuit, vkey_bytes) in vkeys {
         match circuit {


### PR DESCRIPTION
This PR adds a test ensuring that upgradeability works as expected through the proxy. This also includes some changes to the other tests wrt to initialization logic of the darkpool: namely, the `initialize` function is now called by the constructor of the proxy, which is expected to be deployed before tests begin.