### PR TITLE
contracts-stylus: merkle: log new node values

### DIFF
--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -45,7 +45,7 @@ sol! {
     // https://docs.soliditylang.org/en/latest/abi-spec.html#encoding-of-indexed-event-parameters
 
     // Merkle events
-    event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value);
+    event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value);
 
     // Darkpool events
     event VerificationKeySet();


### PR DESCRIPTION
This PR changes the `NodeChanged` event emitted by the Merkle contract to also log the new value of the node (not just the hash). This is depended on by the relayer to construct the authentication path for a given commitment in the tree.