### PR TITLE
contracts-core: merkle: use correct empty leaf value

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -1,5 +1,11 @@
 //! Constants that parameterize the Plonk proof system
 
+use core::marker::PhantomData;
+
+use ark_ff::{BigInt, Fp};
+
+use crate::types::ScalarField;
+
 /// The number of wire types in the circuit
 pub const NUM_WIRE_TYPES: usize = 5;
 
@@ -46,3 +52,17 @@ pub const MERKLE_HEIGHT: usize = 32;
 
 /// The height of the Merkle tree used in testing
 pub const TEST_MERKLE_HEIGHT: usize = 5;
+
+/// The value of an empty leaf in the Merkle tree,
+/// computed as the Keccak-256 hash of the string "renegade",
+/// reduced modulo the scalar field order when interpreted as a
+/// big-endian unsigned integer
+pub const EMPTY_LEAF_VALUE: ScalarField = Fp(
+    BigInt([
+        14542100412480080699,
+        1005430062575839833,
+        8810205500711505764,
+        2121377557688093532,
+    ]),
+    PhantomData,
+);

--- a/contracts-core/src/crypto/merkle.rs
+++ b/contracts-core/src/crypto/merkle.rs
@@ -1,7 +1,7 @@
 //! A sparse Merkle tree implementation, intended to be used in a smart contract context.
 
 use ark_ff::Zero;
-use common::{serde_def_types::ScalarFieldDef, types::ScalarField};
+use common::{constants::EMPTY_LEAF_VALUE, serde_def_types::ScalarFieldDef, types::ScalarField};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -49,11 +49,11 @@ where
         let mut tree = SparseMerkleTree {
             next_index: 0,
             root: ScalarField::zero(),
-            sibling_path: [ScalarField::zero(); HEIGHT - 1],
+            sibling_path: [EMPTY_LEAF_VALUE; HEIGHT - 1],
             zeros: [ScalarField::zero(); HEIGHT - 1],
         };
 
-        let root = setup_empty_tree(&mut tree, HEIGHT - 1, ScalarField::zero());
+        let root = setup_empty_tree(&mut tree, HEIGHT - 1, EMPTY_LEAF_VALUE);
         tree.root = root;
 
         tree
@@ -192,17 +192,15 @@ fn insert_helper<const HEIGHT: usize>(
 
 #[cfg(test)]
 mod tests {
-    use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
     use common::constants::TEST_MERKLE_HEIGHT;
     use rand::thread_rng;
-    use test_helpers::{merkle::MerkleConfig, misc::random_scalars};
+    use test_helpers::{merkle::new_ark_merkle_tree, misc::random_scalars};
 
     use super::SparseMerkleTree;
 
     #[test]
     fn test_against_arkworks() {
-        let mut ark_merkle =
-            ArkMerkleTree::<MerkleConfig>::blank(&(), &(), TEST_MERKLE_HEIGHT).unwrap();
+        let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
         let mut renegade_merkle = SparseMerkleTree::<TEST_MERKLE_HEIGHT>::default();
 
         let num_leaves = 2_u128.pow((TEST_MERKLE_HEIGHT - 1) as u32);

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -49,7 +49,7 @@ pub fn delegate_call_helper<C: SolCall>(
 
 /// Computes the Keccak-256 hash of the given scalar when serialized to bytes
 #[cfg_attr(
-    not(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "merkle")),
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
     allow(dead_code)
 )]
 pub fn keccak_hash_scalar(scalar: ScalarField) -> B256 {

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
 use ark_ec::AffineRepr;
 use ark_ff::One;
 use ark_std::UniformRand;
@@ -20,7 +19,7 @@ use eyre::Result;
 use rand::{thread_rng, RngCore};
 use test_helpers::{
     crypto::{hash_and_sign_message, random_keypair, NativeHasher},
-    merkle::MerkleConfig,
+    merkle::new_ark_merkle_tree,
     misc::random_scalars,
     proof_system::{convert_jf_proof_and_vkey, dummy_vkeys, gen_jf_proof_and_vkey},
     renegade_circuits::{
@@ -139,8 +138,7 @@ pub(crate) async fn test_ec_recover(
 }
 
 pub(crate) async fn test_merkle(contract: MerkleContract<impl Middleware + 'static>) -> Result<()> {
-    let mut ark_merkle =
-        ArkMerkleTree::<MerkleConfig>::blank(&(), &(), TEST_MERKLE_HEIGHT).unwrap();
+    let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
     contract.init().send().await?.await?;
 
     let num_leaves = 2_u128.pow((TEST_MERKLE_HEIGHT - 1) as u32);
@@ -542,8 +540,7 @@ pub(crate) async fn test_new_wallet(
         .await?;
 
     // Assert that Merkle root is correct
-    let mut ark_merkle =
-        ArkMerkleTree::<MerkleConfig>::blank(&(), &(), TEST_MERKLE_HEIGHT).unwrap();
+    let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
 
     let ark_root = insert_shares_and_get_root(
         &mut ark_merkle,
@@ -570,8 +567,7 @@ pub(crate) async fn test_update_wallet(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
     // Generate test data
-    let mut ark_merkle =
-        ArkMerkleTree::<MerkleConfig>::blank(&(), &(), TEST_MERKLE_HEIGHT).unwrap();
+    let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
 
     let mut rng = thread_rng();
 
@@ -646,8 +642,7 @@ pub(crate) async fn test_process_match_settle(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
     // Generate test data
-    let mut ark_merkle =
-        ArkMerkleTree::<MerkleConfig>::blank(&(), &(), TEST_MERKLE_HEIGHT).unwrap();
+    let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
 
     let mut rng = thread_rng();
     let data = get_process_match_settle_data(&mut rng, ark_merkle.root())?;

--- a/test-helpers/src/merkle.rs
+++ b/test-helpers/src/merkle.rs
@@ -1,13 +1,13 @@
 //! Implementation of a Merkle tree using the Poseidon2 implementation from the relayer codebase.
 
-use core::borrow::Borrow;
-
+use alloc::vec;
 use ark_crypto_primitives::{
     crh::{CRHScheme, TwoToOneCRHScheme},
-    merkle_tree::{Config, IdentityDigestConverter},
+    merkle_tree::{Config, IdentityDigestConverter, MerkleTree},
     Error as ArkError,
 };
-use common::types::ScalarField;
+use common::{constants::EMPTY_LEAF_VALUE, types::ScalarField};
+use core::borrow::Borrow;
 use rand::Rng;
 use renegade_crypto::hash::Poseidon2Sponge;
 
@@ -74,4 +74,11 @@ impl Config for MerkleConfig {
     type LeafHash = IdentityCRH;
     type TwoToOneHash = PoseidonTwoToOneCRH;
     type LeafInnerDigestConverter = IdentityDigestConverter<ScalarField>;
+}
+
+pub fn new_ark_merkle_tree(height: usize) -> MerkleTree<MerkleConfig> {
+    let num_leaves = 2_u128.pow((height - 1) as u32);
+    let leaves = vec![EMPTY_LEAF_VALUE; num_leaves as usize];
+
+    MerkleTree::<MerkleConfig>::new(&(), &(), leaves).unwrap()
 }


### PR DESCRIPTION
This PR adds a constant representing the empty leaf value used by the relayer, and makes sure that the merkle tree is initialized using this constant at the leaf layer. Tests are updated to reflect this and pass