### PR TITLE
contracts-core: merkle: make height exclusive of root

### DIFF
--- a/test-helpers/src/merkle.rs
+++ b/test-helpers/src/merkle.rs
@@ -77,7 +77,7 @@ impl Config for MerkleConfig {
 }
 
 pub fn new_ark_merkle_tree(height: usize) -> MerkleTree<MerkleConfig> {
-    let num_leaves = 2_u128.pow((height - 1) as u32);
+    let num_leaves = 2_u128.pow(height as u32);
     let leaves = vec![EMPTY_LEAF_VALUE; num_leaves as usize];
 
     MerkleTree::<MerkleConfig>::new(&(), &(), leaves).unwrap()


### PR DESCRIPTION
This PR changes the Merkle tree implementation to have its height parameter be exclusive of the root. This is consistent with how Merkle openings / authentication paths use the height parameter in the relayer, making integration testing far more straightforward.

Unit tests for Merkle implementation pass, as do relayer-side integration tests for the Merkle contract.