### PR TITLE
contracts-stylus, scripts: add no-verify feature for darkpool

### DIFF
--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -17,6 +17,7 @@ alloy-sol-types = { workspace = true }
 [features]
 darkpool = []
 darkpool-test-contract = []
+no-verify = []
 merkle = []
 merkle-test-contract = []
 verifier = []

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -87,6 +87,11 @@ pub struct DeployStylusArgs {
     /// The Stylus contract to deploy
     #[arg(short, long)]
     pub contract: StylusContract,
+
+    /// Whether or not to enable proof & ECDSA verification.
+    /// This only applies to the darkpool contract.
+    #[arg(long)]
+    pub no_verify: bool,
 }
 
 #[derive(ValueEnum, Copy, Clone)]

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -90,7 +90,7 @@ pub fn build_and_deploy_stylus_contract(
     rpc_url: &str,
     priv_key: &str,
 ) -> Result<(), ScriptError> {
-    let wasm_file_path = build_stylus_contract(args.contract)?;
+    let wasm_file_path = build_stylus_contract(args.contract, args.no_verify)?;
     deploy_stylus_contract(wasm_file_path, rpc_url, priv_key)
 }
 

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -45,6 +45,10 @@ pub const WASM_TARGET_TRIPLE: &str = "wasm32-unknown-unknown";
 /// The nightly toolchain selector
 pub const NIGHTLY_TOOLCHAIN_SELECTOR: &str = "+nightly";
 
+/// The name of the "no-verify" feature, used to disable
+/// proof & ECDSA verification in the darkpool
+pub const NO_VERIFY_FEATURE: &str = "no-verify";
+
 /// Nightly Z flags to add to build command
 pub const Z_FLAGS: [&str; 3] = [
     "unstable-options",


### PR DESCRIPTION
This PR adds a `no-verify` feature to the darkpool which disables proof & ECDSA verification. This is intended to be used when testing the Arbitrum client in the relayer, as proper verification logic (and thus proper inputs to verification) are out of scope for the client tests and make them quite cumbersome.

Additionally, this PR adds a flag to the `scripts` CLI for toggling the `no-verify` feature when building/deploying contracts.