### PR TITLE
meta, contracts-stylus: darkpool: bump stylus sdk to 0.4.2 & add storage gap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4696,9 +4696,9 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b0e971622a7a27722c2e3f2658ac4795f00b12a528874c5d08863a2e91eb6e"
+checksum = "12c2d6fedbd0393e2b9f0259ca239c7ede9f87a89933627119b9dc038902d7e9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-stylus-sdk = { version = "0.4.1" }
+stylus-sdk = { version = "0.4.2" }
 wee_alloc = "0.4.5"
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -20,14 +20,17 @@ use stylus_sdk::{
     crypto::keccak,
     evm, msg,
     prelude::*,
-    storage::{StorageAddress, StorageBool, StorageBytes, StorageMap, StorageU64},
+    storage::{
+        StorageAddress, StorageArray, StorageBool, StorageBytes, StorageMap, StorageU256,
+        StorageU64,
+    },
 };
 
 use crate::utils::{
     backends::{PrecompileEcRecoverBackend, StylusHasher},
     constants::{
-        VALID_COMMITMENTS_CIRCUIT_ID, VALID_MATCH_SETTLE_CIRCUIT_ID, VALID_REBLIND_CIRCUIT_ID,
-        VALID_WALLET_CREATE_CIRCUIT_ID, VALID_WALLET_UPDATE_CIRCUIT_ID,
+        STORAGE_GAP_SIZE, VALID_COMMITMENTS_CIRCUIT_ID, VALID_MATCH_SETTLE_CIRCUIT_ID,
+        VALID_REBLIND_CIRCUIT_ID, VALID_WALLET_CREATE_CIRCUIT_ID, VALID_WALLET_UPDATE_CIRCUIT_ID,
     },
     helpers::{delegate_call_helper, keccak_hash_scalar, serialize_statement_for_verification},
     solidity::{
@@ -39,6 +42,9 @@ use crate::utils::{
 #[solidity_storage]
 #[cfg_attr(feature = "darkpool", entrypoint)]
 pub struct DarkpoolContract {
+    /// Storage gap to prevent collisions with the Merkle contract
+    __gap: StorageArray<StorageU256, STORAGE_GAP_SIZE>,
+
     /// The owner of the darkpool contract
     owner: StorageAddress,
 

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -46,3 +46,8 @@ pub const VALID_REBLIND_CIRCUIT_ID: u8 = 3;
     allow(dead_code)
 )]
 pub const VALID_MATCH_SETTLE_CIRCUIT_ID: u8 = 4;
+
+/// The number of storage slots to use in the Darkpool contract's
+/// storage gap, which ensures that there are no storage collisions
+/// with the Merkle contract to which it delegatecalls
+pub const STORAGE_GAP_SIZE: usize = 64;

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -141,7 +141,7 @@ pub(crate) async fn test_merkle(contract: MerkleContract<impl Middleware + 'stat
     let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
     contract.init().send().await?.await?;
 
-    let num_leaves = 2_u128.pow((TEST_MERKLE_HEIGHT - 1) as u32);
+    let num_leaves = 2_u128.pow((TEST_MERKLE_HEIGHT) as u32);
     let mut rng = thread_rng();
     let leaves = random_scalars(num_leaves as usize, &mut rng);
 


### PR DESCRIPTION
This PR upgrades the Stylus SDK to version `0.4.2`, which includes a fix ensuring that delegate calls are properly issued when using the `delegatecall` helper function from the Stylus SDK. As a result, delegate calls to the Merkle contract started causing storage collisions with the darkpool contract, so a storage gap was added to the darkpool contract to avoid this.

Tests pass.