### PR TITLE
scripts: remove small circuit params option

### DIFF
--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -50,4 +50,8 @@ pub const VALID_MATCH_SETTLE_CIRCUIT_ID: u8 = 4;
 /// The number of storage slots to use in the Darkpool contract's
 /// storage gap, which ensures that there are no storage collisions
 /// with the Merkle contract to which it delegatecalls
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
 pub const STORAGE_GAP_SIZE: usize = 64;

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -146,10 +146,6 @@ pub struct UploadVkeyArgs {
     /// The address of the darkpool proxy contract
     #[arg(short, long)]
     pub darkpool_address: String,
-
-    /// Whether or not to use the smaller circuit size parameters
-    #[arg(short, long)]
-    pub small: bool,
 }
 
 #[derive(ValueEnum, Copy, Clone)]

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -129,7 +129,7 @@ pub async fn upload_vkey(
         .map_err(|e| ScriptError::CalldataConstruction(e.to_string()))?;
     let darkpool = DarkpoolContract::new(darkpool_address, client);
 
-    let vkey_bytes = gen_vkey_bytes(args.circuit, args.small)?;
+    let vkey_bytes = gen_vkey_bytes(args.circuit)?;
 
     let tx = match args.circuit {
         Circuit::ValidWalletCreate => darkpool.set_valid_wallet_create_vkey(vkey_bytes.into()),

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -13,17 +13,11 @@ use alloy_sol_types::SolCall;
 use ark_bn254::Bn254;
 use circuit_types::traits::SingleProverCircuit;
 use circuits::zk_circuits::{
-    test_helpers::{MAX_BALANCES, MAX_FEES, MAX_ORDERS},
-    valid_commitments::{SizedValidCommitments, ValidCommitments},
-    valid_match_settle::{SizedValidMatchSettle, ValidMatchSettle},
-    valid_reblind::{SizedValidReblind, ValidReblind},
-    valid_wallet_create::{SizedValidWalletCreate, ValidWalletCreate},
-    valid_wallet_update::{SizedValidWalletUpdate, ValidWalletUpdate},
+    valid_commitments::SizedValidCommitments, valid_match_settle::SizedValidMatchSettle,
+    valid_reblind::SizedValidReblind, valid_wallet_create::SizedValidWalletCreate,
+    valid_wallet_update::SizedValidWalletUpdate,
 };
-use common::{
-    constants::TEST_MERKLE_HEIGHT,
-    types::{G1Affine, VerificationKey},
-};
+use common::types::{G1Affine, VerificationKey};
 use ethers::{
     middleware::SignerMiddleware,
     providers::{Http, Middleware, Provider},
@@ -231,43 +225,13 @@ pub fn convert_jf_vkey(jf_vkey: VerifyingKey<Bn254>) -> Result<VerificationKey, 
     })
 }
 
-pub fn gen_vkey_bytes(circuit: Circuit, small: bool) -> Result<Vec<u8>, ScriptError> {
+pub fn gen_vkey_bytes(circuit: Circuit) -> Result<Vec<u8>, ScriptError> {
     let jf_vkey = match circuit {
-        Circuit::ValidWalletCreate => {
-            if small {
-                ValidWalletCreate::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>::verifying_key()
-            } else {
-                SizedValidWalletCreate::verifying_key()
-            }
-        }
-        Circuit::ValidWalletUpdate => {
-            if small {
-                ValidWalletUpdate::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, TEST_MERKLE_HEIGHT>::verifying_key()
-            } else {
-                SizedValidWalletUpdate::verifying_key()
-            }
-        }
-        Circuit::ValidCommitments => {
-            if small {
-                ValidCommitments::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>::verifying_key()
-            } else {
-                SizedValidCommitments::verifying_key()
-            }
-        }
-        Circuit::ValidReblind => {
-            if small {
-                ValidReblind::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, TEST_MERKLE_HEIGHT>::verifying_key()
-            } else {
-                SizedValidReblind::verifying_key()
-            }
-        }
-        Circuit::ValidMatchSettle => {
-            if small {
-                ValidMatchSettle::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>::verifying_key()
-            } else {
-                SizedValidMatchSettle::verifying_key()
-            }
-        }
+        Circuit::ValidWalletCreate => SizedValidWalletCreate::verifying_key(),
+        Circuit::ValidWalletUpdate => SizedValidWalletUpdate::verifying_key(),
+        Circuit::ValidCommitments => SizedValidCommitments::verifying_key(),
+        Circuit::ValidReblind => SizedValidReblind::verifying_key(),
+        Circuit::ValidMatchSettle => SizedValidMatchSettle::verifying_key(),
     };
 
     let vkey = convert_jf_vkey((*jf_vkey).clone())?;


### PR DESCRIPTION
This PR removes the option for creating verification keys for the smaller circuit sizing parameters from the verification key uploading script, since we will never use this.