### PR TITLE
contracts-stylus: utils: define assert macro conditional on no-verify feature

### DIFF
--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -55,3 +55,21 @@ pub fn delegate_call_helper<C: SolCall>(
 pub fn keccak_hash_scalar(scalar: ScalarField) -> B256 {
     keccak(postcard::to_allocvec(&SerdeScalarField(scalar)).unwrap())
 }
+
+#[macro_export]
+macro_rules! assert_if_verifying {
+    ($cond:expr $(,)?) => {
+        // Note: the "no-verify" feature is ONLY for testing purposes
+        #[cfg(not(feature = "no-verify"))]
+        {
+            assert!($cond);
+        }
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        // Note: the "no-verify" feature is ONLY for testing purposes
+        #[cfg(not(feature = "no-verify"))]
+        {
+            assert!($cond, $($arg)+);
+        }
+    };
+}


### PR DESCRIPTION
This PR changes the way the `no-verify` feature is implemented by replacing all previous conditional compilation blocks with the usage of a `assert_if_verifying` macro that wraps the underlying `assert!` macro in a conditional compilation block that is active when the `no-verify` feature is unset. This allows us to cleanly avoid asserting valid historical roots, and double-spent nullifiers for the client integration tests.