### PR TITLE
contracts-stylus: `NullifierSpent` event & `ScalarField` <> `U256` conversion

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -225,9 +225,6 @@ pub struct ValidMatchSettleStatement {
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct MatchPayload {
-    /// The public secret share of the party's wallet-level blinder
-    #[serde_as(as = "ScalarFieldDef")]
-    pub wallet_blinder_share: ScalarField,
     /// The statement for the party's `VALID_COMMITMENTS` proof
     pub valid_commitments_statement: ValidCommitmentsStatement,
     /// The statement for the party's `VALID_REBLIND` proof

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -186,6 +186,7 @@ impl DarkpoolContract {
         );
 
         DarkpoolContract::log_wallet_update(
+            // We assume the wallet blinder is the last scalar serialized into the wallet shares
             *valid_wallet_create_statement
                 .public_wallet_shares
                 .last()
@@ -245,6 +246,7 @@ impl DarkpoolContract {
         }
 
         DarkpoolContract::log_wallet_update(
+            // We assume the wallet blinder is the last scalar serialized into the wallet shares
             *valid_wallet_update_statement
                 .new_public_shares
                 .last()
@@ -487,6 +489,7 @@ impl DarkpoolContract {
                 .original_shares_nullifier,
         );
 
+        // We assume the wallet blinder is the last scalar serialized into the wallet shares
         let wallet_blinder_share = scalar_to_u256(*public_wallet_shares.last().unwrap());
         evm::log(WalletUpdated {
             wallet_blinder_share,

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -71,7 +71,7 @@ where
         let mut merkle_tree: SparseMerkleTree<{ P::HEIGHT }> =
             postcard::from_bytes(&self.merkle_tree.get_bytes()).unwrap();
 
-        let shares: Vec<ScalarField> = shares.into_iter().map(u256_to_scalar).collect();
+        let shares: Vec<ScalarField> = shares.into_iter().map(|u| u256_to_scalar(u).unwrap()).collect();
 
         let shares_commitment = compute_poseidon_hash(&shares);
 

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -1,12 +1,15 @@
 use core::borrow::BorrowMut;
 
 use alloc::vec::Vec;
-use common::{serde_def_types::SerdeScalarField, types::ExternalTransfer};
-use stylus_sdk::{abi::Bytes, prelude::*};
+use common::types::ExternalTransfer;
+use stylus_sdk::{abi::Bytes, alloy_primitives::U256, prelude::*};
 
 use crate::{
     contracts::darkpool::DarkpoolContract,
-    utils::{helpers::delegate_call_helper, solidity::initCall},
+    utils::{
+        helpers::{delegate_call_helper, u256_to_scalar},
+        solidity::initCall,
+    },
 };
 
 #[solidity_storage]
@@ -20,9 +23,9 @@ struct DarkpoolTestContract {
 #[external]
 #[inherit(DarkpoolContract)]
 impl DarkpoolTestContract {
-    pub fn mark_nullifier_spent(&mut self, nullifier: Bytes) -> Result<(), Vec<u8>> {
-        let nullifier: SerdeScalarField = postcard::from_bytes(nullifier.as_slice()).unwrap();
-        DarkpoolContract::mark_nullifier_spent(self, nullifier.0);
+    pub fn mark_nullifier_spent(&mut self, nullifier: U256) -> Result<(), Vec<u8>> {
+        let nullifier = u256_to_scalar(nullifier).unwrap();
+        DarkpoolContract::mark_nullifier_spent(self, nullifier);
         Ok(())
     }
 

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 use common::constants::TEST_MERKLE_HEIGHT;
-use stylus_sdk::{abi::Bytes, prelude::*};
+use stylus_sdk::{alloy_primitives::U256, prelude::*};
 
 use crate::contracts::merkle::{MerkleContract, MerkleParams};
 
@@ -25,15 +25,15 @@ impl TestMerkleContract {
         self.merkle.init()
     }
 
-    fn root(&self) -> Result<Bytes, Vec<u8>> {
+    fn root(&self) -> Result<U256, Vec<u8>> {
         self.merkle.root()
     }
 
-    fn root_in_history(&self, root: Bytes) -> Result<bool, Vec<u8>> {
+    fn root_in_history(&self, root: U256) -> Result<bool, Vec<u8>> {
         self.merkle.root_in_history(root)
     }
 
-    fn insert_shares_commitment(&mut self, shares: Bytes) -> Result<(), Vec<u8>> {
+    fn insert_shares_commitment(&mut self, shares: Vec<U256>) -> Result<(), Vec<u8>> {
         self.merkle.insert_shares_commitment(shares)
     }
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -3,12 +3,13 @@
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use common::{
-    custom_serde::ScalarSerializable, serde_def_types::SerdeScalarField, types::ScalarField,
+    custom_serde::{BytesDeserializable, BytesSerializable, ScalarSerializable},
+    serde_def_types::SerdeScalarField,
+    types::ScalarField,
 };
 use stylus_sdk::{
-    alloy_primitives::{Address, B256},
+    alloy_primitives::{Address, U256},
     call::delegate_call,
-    crypto::keccak,
     storage::TopLevelStorage,
 };
 
@@ -47,13 +48,14 @@ pub fn delegate_call_helper<C: SolCall>(
     C::decode_returns(&res, true /* validate */).unwrap()
 }
 
-/// Computes the Keccak-256 hash of the given scalar when serialized to bytes
-#[cfg_attr(
-    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
-    allow(dead_code)
-)]
-pub fn keccak_hash_scalar(scalar: ScalarField) -> B256 {
-    keccak(postcard::to_allocvec(&SerdeScalarField(scalar)).unwrap())
+/// Converts a scalar to a U256
+pub fn scalar_to_u256(scalar: ScalarField) -> U256 {
+    U256::from_be_slice(&scalar.serialize_to_bytes())
+}
+
+/// Converts a U256 to a scalar
+pub fn u256_to_scalar(u256: U256) -> ScalarField {
+    ScalarField::deserialize_from_bytes(&u256.to_be_bytes_vec()).unwrap()
 }
 
 #[macro_export]

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use common::{
-    custom_serde::{BytesDeserializable, BytesSerializable, ScalarSerializable},
+    custom_serde::{BytesDeserializable, BytesSerializable, ScalarSerializable, SerdeError},
     serde_def_types::SerdeScalarField,
     types::ScalarField,
 };
@@ -54,8 +54,8 @@ pub fn scalar_to_u256(scalar: ScalarField) -> U256 {
 }
 
 /// Converts a U256 to a scalar
-pub fn u256_to_scalar(u256: U256) -> ScalarField {
-    ScalarField::deserialize_from_bytes(&u256.to_be_bytes_vec()).unwrap()
+pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, SerdeError> {
+    ScalarField::deserialize_from_bytes(&u256.to_be_bytes_vec())
 }
 
 #[macro_export]

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -19,9 +19,9 @@ sol_interface! {
 
     interface IMerkle {
         function init() external;
-        function root() external view returns (bytes);
-        function rootInHistory(bytes root) external view returns (bool);
-        function insertSharesCommitment(bytes shares) external;
+        function root() external view returns (uint256);
+        function rootInHistory(uint256 root) external view returns (bool);
+        function insertSharesCommitment(uint256[] shares) external;
     }
 }
 
@@ -33,22 +33,20 @@ sol! {
 
     // Merkle functions
     function init() external;
-    function root() external view returns (bytes);
-    function rootInHistory(bytes root) external view returns (bool);
-    function insertSharesCommitment(bytes shares) external;
+    function root() external view returns (uint256);
+    function rootInHistory(uint256 root) external view returns (bool);
+    function insertSharesCommitment(uint256[] shares) external;
 
     // ----------
     // | EVENTS |
     // ----------
 
-    // Indexed `bytes` event parameters are encoded as their Keccak-256 hash
-    // https://docs.soliditylang.org/en/latest/abi-spec.html#encoding-of-indexed-event-parameters
-
     // Merkle events
-    event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value);
+    event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value);
 
     // Darkpool events
     event VerificationKeySet();
-    event WalletUpdated(bytes indexed wallet_blinder_share);
+    event NullifierSpent(uint256 indexed nullifier);
+    event WalletUpdated(uint256 indexed wallet_blinder_share);
     event ExternalTransfer(address indexed account, address indexed mint, bool indexed is_withdrawal, uint256 amount);
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,27 +5,16 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
-        function initialize(address memory owner, address memory verifier_address, address memory merkle_address) external
+        function initialize(address memory verifier_address, address memory merkle_address, bytes memory valid_wallet_create_vkey, bytes memory valid_wallet_update_vkey, bytes memory valid_commitments_vkey, bytes memory valid_reblind_vkey, bytes memory valid_match_settle_vkey) external
 
-        function transferOwnership(address memory new_owner) external
+        function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
+        function markNullifierSpent(uint256 memory nullifier) external
 
-        function setVerifierAddress(address memory _address) external
-        function setMerkleAddress(address memory _address) external
+        function getRoot() external view returns (uint256)
 
-        function setValidWalletCreateVkey(bytes memory vkey) external
-        function setValidWalletUpdateVkey(bytes memory vkey) external
-        function setValidCommitmentsVkey(bytes memory vkey) external
-        function setValidReblindVkey(bytes memory vkey) external
-        function setValidMatchSettleVkey(bytes memory vkey) external
-
-        function isNullifierSpent(bytes memory nullifier) external view returns (bool)
-        function markNullifierSpent(bytes memory nullifier) external
-
-        function getRoot() external view returns (bytes)
-
-        function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
-        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
+        function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes) external
 
         function verify(uint8 memory circuit_id, bytes memory proof, bytes memory public_inputs) external view returns (bool)
 
@@ -39,9 +28,9 @@ abigen!(
     MerkleContract,
     r#"[
         function init() external
-        function root() external view returns (bytes)
-        function rootInHistory(bytes root) external view returns (bool)
-        function insertSharesCommitment(bytes shares) external
+        function root() external view returns (uint256)
+        function rootInHistory(uint256 root) external view returns (bool)
+        function insertSharesCommitment(uint256[] shares) external
     ]"#
 );
 

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -35,7 +35,6 @@ pub(crate) enum Tests {
     Merkle,
     Verifier,
     Upgradeable,
-    Ownable,
     Initializable,
     ExternalTransfer,
     NewWallet,

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -8,7 +8,6 @@ use clap::Parser;
 use cli::{Cli, Tests};
 use constants::{
     DARKPOOL_TEST_CONTRACT_KEY, DUMMY_ERC20_CONTRACT_KEY, DUMMY_UPGRADE_TARGET_CONTRACT_KEY,
-    MERKLE_TEST_CONTRACT_KEY,
 };
 use eyre::Result;
 use scripts::{
@@ -17,7 +16,7 @@ use scripts::{
 };
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable,
+    test_initializable, test_merkle, test_new_wallet, test_nullifier_set,
     test_process_match_settle, test_update_wallet, test_upgradeable, test_verifier,
 };
 use utils::get_test_contract_address;
@@ -96,15 +95,6 @@ async fn main() -> Result<()> {
                 darkpool_address,
             )
             .await?;
-        }
-        Tests::Ownable => {
-            let contract = DarkpoolTestContract::new(contract_address, client.clone());
-            let verifier_address =
-                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
-            let merkle_address =
-                parse_addr_from_deployments_file(&deployments_file, MERKLE_TEST_CONTRACT_KEY)?;
-
-            test_ownable(contract, verifier_address, merkle_address).await?;
         }
         Tests::Initializable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use ethers::providers::Middleware;
 
 use crate::{
-    commands::{build_and_deploy_stylus_contract, deploy_proxy, upgrade, upload_vkey},
+    commands::{build_and_deploy_stylus_contract, deploy_proxy, upgrade},
     errors::ScriptError,
 };
 
@@ -37,7 +37,6 @@ pub enum Command {
     DeployProxy(DeployProxyArgs),
     DeployStylus(DeployStylusArgs),
     Upgrade(UpgradeArgs),
-    UploadVkey(UploadVkeyArgs),
 }
 
 impl Command {
@@ -55,7 +54,6 @@ impl Command {
                     .await
             }
             Command::Upgrade(args) => upgrade(args, client, deployments_path).await,
-            Command::UploadVkey(args) => upload_vkey(args, client, deployments_path).await,
         }
     }
 }
@@ -118,21 +116,4 @@ pub struct UpgradeArgs {
     /// call the implementation contract when upgrading
     #[arg(short, long)]
     pub calldata: Option<String>,
-}
-
-/// Upload a new verification key
-#[derive(Args)]
-pub struct UploadVkeyArgs {
-    /// Which circuit to upload the verification key for
-    #[arg(short, long)]
-    pub circuit: Circuit,
-}
-
-#[derive(ValueEnum, Copy, Clone)]
-pub enum Circuit {
-    ValidWalletCreate,
-    ValidWalletUpdate,
-    ValidCommitments,
-    ValidReblind,
-    ValidMatchSettle,
 }

--- a/scripts/src/solidity.rs
+++ b/scripts/src/solidity.rs
@@ -4,23 +4,12 @@ use alloy_sol_types::sol;
 use ethers::contract::abigen;
 
 sol! {
-    function initialize(address memory owner, address memory verifier_address, address memory merkle_address) external;
+    function initialize(address memory verifier_address, address memory merkle_address, bytes memory valid_wallet_create_vkey, bytes memory valid_wallet_update_vkey, bytes memory valid_commitments_vkey, bytes memory valid_reblind_vkey, bytes memory valid_match_settle_vkey) external;
 }
 
 abigen!(
     ProxyAdminContract,
     r#"[
         function upgradeAndCall(address proxy, address implementation, bytes memory data) external;
-    ]"#,
-);
-
-abigen!(
-    DarkpoolContract,
-    r#"[
-        function setValidWalletCreateVkey(bytes memory vkey) external
-        function setValidWalletUpdateVkey(bytes memory vkey) external
-        function setValidCommitmentsVkey(bytes memory vkey) external
-        function setValidReblindVkey(bytes memory vkey) external
-        function setValidMatchSettleVkey(bytes memory vkey) external
     ]"#,
 );

--- a/test-helpers/src/renegade_circuits.rs
+++ b/test-helpers/src/renegade_circuits.rs
@@ -10,7 +10,7 @@ use common::{
     types::{
         ExternalTransfer, Proof, PublicSigningKey, ScalarField, ValidCommitmentsStatement,
         ValidMatchSettleStatement, ValidReblindStatement, ValidWalletCreateStatement,
-        ValidWalletUpdateStatement, VerificationKey,
+        ValidWalletUpdateStatement,
     },
 };
 use core::iter;
@@ -125,26 +125,26 @@ fn dummy_public_signing_key(rng: &mut impl Rng) -> PublicSigningKey {
     }
 }
 
-pub fn circuit_bundle_from_statement<S: RenegadeStatement>(
+pub fn proof_from_statement<S: RenegadeStatement>(
     statement: &S,
     num_public_inputs: usize,
-) -> Result<(VerificationKey, Proof)> {
+) -> Result<Proof> {
     let public_inputs = statement
         .serialize_to_scalars()
         .map_err(|_| eyre!("failed to serialize statement to scalars"))?;
     let (jf_proof, jf_vkey) = gen_jf_proof_and_vkey(num_public_inputs, &public_inputs)?;
-    let (proof, vkey) = convert_jf_proof_and_vkey(jf_proof, jf_vkey);
+    let (proof, _) = convert_jf_proof_and_vkey(jf_proof, jf_vkey);
 
-    Ok((vkey, proof))
+    Ok(proof)
 }
 
 pub fn dummy_circuit_bundle<S: RenegadeStatement>(
     num_public_inputs: usize,
     rng: &mut impl Rng,
-) -> Result<(S, VerificationKey, Proof)> {
+) -> Result<(S, Proof)> {
     let statement = S::dummy(rng);
-    let (vkey, proof) = circuit_bundle_from_statement(&statement, num_public_inputs)?;
-    Ok((statement, vkey, proof))
+    let proof = proof_from_statement(&statement, num_public_inputs)?;
+    Ok((statement, proof))
 }
 
 pub fn gen_valid_wallet_update_statement(


### PR DESCRIPTION
This PR adds the `NullifierSpent` event, and implements more semantically appropriate runtime types in the contracts, namely converting between `ScalarField` and `U256` at the contract boundary.

Additionally, this PR removes the setter methods and ownership functionality from the darkpool contract, since all of this is subsumed by upgradeability. This helps us keep the darkpool contract below the binary size limit.

Scripts and integration tests are updated to reflect these changes, but are not yet fully tested. This led to many subsequent changes (e.g., we need to be sure to use the same verification keys as the contract since we don't upload them in the same runtime as the associated test anymore), which are being deferred to the next PR for brevity.