### PR TITLE
contracts-stylus: merkle: zero out next_index in init method

### DIFF
--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -61,6 +61,7 @@ where
 
     /// Initialize this contract with a blank Merkle tree
     pub fn init(&mut self) -> Result<(), Vec<u8>> {
+        self.next_index.set(U128::ZERO);
         let root = self.setup_empty_tree(P::HEIGHT as u8, EMPTY_LEAF_VALUE);
         self.store_root(root);
         Ok(())

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -8,7 +8,7 @@ use crate::{
     contracts::darkpool::DarkpoolContract,
     utils::{
         helpers::{delegate_call_helper, u256_to_scalar},
-        solidity::clearCall,
+        solidity::initCall,
     },
 };
 
@@ -41,7 +41,7 @@ impl DarkpoolTestContract {
             .merkle_address
             .get();
 
-        delegate_call_helper::<clearCall>(self, merkle_address, ());
+        delegate_call_helper::<initCall>(self, merkle_address, ());
 
         Ok(())
     }

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -2,10 +2,7 @@
 
 use alloc::vec::Vec;
 use common::constants::TEST_MERKLE_HEIGHT;
-use stylus_sdk::{
-    alloy_primitives::{U128, U256},
-    prelude::*,
-};
+use stylus_sdk::{alloy_primitives::U256, prelude::*};
 
 use crate::contracts::merkle::{MerkleContract, MerkleParams};
 
@@ -38,15 +35,5 @@ impl TestMerkleContract {
 
     fn insert_shares_commitment(&mut self, shares: Vec<U256>) -> Result<(), Vec<u8>> {
         self.merkle.insert_shares_commitment(shares)
-    }
-
-    fn clear(&mut self) -> Result<(), Vec<u8>> {
-        self.merkle.init()?;
-        self.merkle.next_index.set(U128::ZERO);
-
-        // No straightforward way to clear the `root_history` map,
-        // so we just leave it as is.
-
-        Ok(())
     }
 }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -37,9 +37,6 @@ sol! {
     function rootInHistory(uint256 root) external view returns (bool);
     function insertSharesCommitment(uint256[] shares) external;
 
-    // Testing-only Merkle functions
-    function clear() external;
-
     // ----------
     // | EVENTS |
     // ----------


### PR DESCRIPTION
This PR removes the `clear` method from the Merkle test contract and instead zeroes out the `next_index` field of the Merkle tree within the `init` method. This interface consistency between the Merkle and Merkle test contracts makes integration testing relayer-side significantly more straightforward