### PR TITLE
contracts-core: transcript: custom hash to scalar to allow inlined arkworks for verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.dependencies]
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
-ark-ff = { version = "0.4.0", features = ["bin-opt"] }
+ark-ff = "0.4.0"
 ark-poly = "0.4.0"
 ark-std = "0.4.0"
 ark-serialize = "0.4.0"

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -18,6 +18,9 @@ pub const TRANSCRIPT_STATE_SIZE: usize = 64;
 /// The number of bytes in a hash digest used by the transcript
 pub const HASH_OUTPUT_SIZE: usize = 32;
 
+/// The number of bytes of hash output to sample for a challenge
+pub const HASH_SAMPLE_BYTES: usize = 48;
+
 /// The number of bytes to represent field elements of the base or scalar fields for the G1 curve group,
 /// as well as the base field which is extended for the G2 curve group
 pub const NUM_BYTES_FELT: usize = 32;

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -15,8 +15,8 @@ postcard = { workspace = true }
 alloy-sol-types = { workspace = true }
 
 [features]
-darkpool = []
-darkpool-test-contract = []
+darkpool = ["ark-ff/bin-opt"]
+darkpool-test-contract = ["ark-ff/bin-opt"]
 no-verify = []
 merkle = []
 merkle-test-contract = []


### PR DESCRIPTION
This PR replaces the invocation of `ScalarField::from_le_bytes_mod_order` in the `transcript` module with a custom implementation that replicates the functionality while avoiding the `ark-serialize` code path previously incurred.

This decreases the binary size of the verifier enough to allow for disabling the `bin-opt` feature on the `ark-ff` patch, enabling inlining and loop unrolling in the modular arithmetic implementations.

As a result, the cost of verification in `update_wallet` goes down from 1,842,783 gas to 1,572,002 gas, about a 15% improvement.

Transcript & verification unit & integration tests pass.