### PR TITLE
contracts-core: transcript: less mod math when squeezing challenges

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -25,6 +25,9 @@ pub const HASH_SAMPLE_BYTES: usize = 48;
 /// as well as the base field which is extended for the G2 curve group
 pub const NUM_BYTES_FELT: usize = 32;
 
+/// The index at which to split a hash output so that it can be directly converted to a field element.
+pub const SPLIT_INDEX: usize = NUM_BYTES_FELT - 1;
+
 /// The number of u64s it takes to represent a field element
 pub const NUM_U64S_FELT: usize = 4;
 


### PR DESCRIPTION
This PR changes the implementation of `get_and_append_challenge` in the `transcript` module to use less modular arithmetic when sampling a scalar from the hash output. Previously, this would invoke 25 modular multiplications and additions, it now invokes only one of each.

**Improvements:**
As a result of this, the cost of `process_match_settle` decreased from 11,358,713 gas to 11,096,155 gas, an approximate $0.06 cost reduction (now at a total cost of $2.44). Note, of course, that challenges are computed 5 times in `process_match_settle`, so one can extrapolate that this saves us about 52,511.6 gas per verification.

**Testing:**
Transcript generation unit tests, and integration tests invoking verification all pass.