### PR TITLE
contracts-core: verifier: generate domain elements by hand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,6 @@ dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff",
- "ark-poly",
  "ark-std",
  "circuit-types",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ members = [
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
 ark-ff = "0.4.0"
-ark-poly = "0.4.0"
 ark-std = "0.4.0"
 ark-serialize = "0.4.0"
 ark-crypto-primitives = { version = "0.4", default-features = false, features = [

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 ark-ff = { workspace = true }
-ark-poly = { workspace = true }
 alloy-primitives = { workspace = true }
 renegade-crypto = { workspace = true }
 serde = { workspace = true }

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -248,6 +248,7 @@ impl DarkpoolContract {
         let valid_match_settle_statement: ValidMatchSettleStatement =
             postcard::from_bytes(valid_match_settle_statement_bytes.as_slice()).unwrap();
 
+        #[allow(unused_assignments)]
         let (mut valid_commitments_vkey_bytes, mut valid_reblind_vkey_bytes) = (vec![], vec![]);
         if_verifying!({
             let vkeys_address = storage.borrow_mut().vkeys_address.get();


### PR DESCRIPTION
This PR removes the usage of `Radix2EvaluationDomain` from the verifier, replacing its functionality with hand-written analogues. The rationale for this is two-fold:
1. We previously were calculating each element of the evaluation domain using `domain.element(i)`, which would simply do `generator.pow(i)`. We now use the previous domain element to calculate the next one.
2. `RadixEvaluationDomain::new()` would incur 2 modular inverse operations that we never make use of.

**Improvements:**
As a result of these changes, we save about of 160k gas (~$0.04) per verification. `process_match_settle` currently comes in at 9,889,336 gas => ~$2.18

**Testing:**
Verification unit & integration tests pass.