### PR TITLE
contracts-core: verifier: batch verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "circuit-types",
  "common",
  "ethers",
+ "itertools 0.12.0",
  "jf-utils",
  "rand",
  "renegade-crypto",

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -52,7 +52,7 @@ pub struct VerificationKey {
 
 /// A Plonk proof, using the "fast prover" strategy described in the paper.
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize)]
 pub struct Proof {
     /// The commitments to the wire polynomials
     #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -52,7 +52,7 @@ pub struct VerificationKey {
 
 /// A Plonk proof, using the "fast prover" strategy described in the paper.
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct Proof {
     /// The commitments to the wire polynomials
     #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -22,3 +22,4 @@ rand = { workspace = true }
 ethers = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 circuit-types = { workspace = true, features = ["test-helpers"] }
+itertools = "0.12.0"

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -32,12 +32,12 @@ impl<H: HashBackend> Transcript<H> {
     }
 
     /// Appends a message to the transcript
-    fn append_message(&mut self, message: &[u8]) {
+    pub fn append_message(&mut self, message: &[u8]) {
         self.transcript.extend_from_slice(message);
     }
 
     /// Computes a challenge and updates the transcript state
-    fn get_and_append_challenge(&mut self) -> ScalarField {
+    pub fn get_and_append_challenge(&mut self) -> ScalarField {
         let input0 = [self.state.as_ref(), self.transcript.as_ref(), &[0u8]].concat();
         let input1 = [self.state.as_ref(), self.transcript.as_ref(), &[1u8]].concat();
 
@@ -143,7 +143,7 @@ impl<H: HashBackend> Transcript<H> {
 ///
 /// This is the format expected by the transcript, whereas our serialization format
 /// is big-endian.
-fn serialize_scalars_for_transcript(scalars: &[ScalarField]) -> Vec<u8> {
+pub fn serialize_scalars_for_transcript(scalars: &[ScalarField]) -> Vec<u8> {
     scalars
         .iter()
         .flat_map(|s| s.serialize_to_bytes().into_iter().rev())

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -87,12 +87,8 @@ impl<H: HashBackend> Transcript<H> {
         vkey: &VerificationKey,
         proof: &Proof,
         public_inputs: &[ScalarField],
-        extra_transcript_init_message: &Option<Vec<u8>>,
     ) -> Result<Challenges, TranscriptError> {
         // Absorb verification key & public inputs
-        if let Some(msg) = extra_transcript_init_message {
-            self.append_message(msg);
-        }
         self.append_message(&ScalarField::MODULUS_BIT_SIZE.to_le_bytes());
         self.append_message(&vkey.n.to_le_bytes());
         self.append_message(&vkey.l.to_le_bytes());
@@ -182,7 +178,7 @@ pub mod tests {
 
         let mut stylus_transcript = Transcript::<NativeHasher>::new();
         let challenges = stylus_transcript
-            .compute_challenges(&vkey, &proof, &public_inputs, &None)
+            .compute_challenges(&vkey, &proof, &public_inputs)
             .unwrap();
 
         let jf_challenges = get_jf_challenges(&jf_vkey, &public_inputs, &jf_proof, &None).unwrap();

--- a/contracts-stylus/src/contracts/verifier.rs
+++ b/contracts-stylus/src/contracts/verifier.rs
@@ -19,7 +19,7 @@ pub fn verify(verification_bundle_ser: Vec<u8>) -> ArbResult {
     let mut verifier = Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::default();
 
     let result = verifier
-        .verify(&[vkey], &[proof], &[&public_inputs])
+        .verify(&[vkey], &[proof], &[public_inputs])
         .unwrap();
 
     Ok(vec![result as u8])

--- a/contracts-stylus/src/contracts/verifier.rs
+++ b/contracts-stylus/src/contracts/verifier.rs
@@ -16,9 +16,11 @@ pub fn verify(verification_bundle_ser: Vec<u8>) -> ArbResult {
         public_inputs,
     } = postcard::from_bytes(verification_bundle_ser.as_slice()).unwrap();
 
-    let mut verifier = Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::new(vkey);
+    let mut verifier = Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::default();
 
-    let result = verifier.verify(&proof, &public_inputs, &None).unwrap();
+    let result = verifier
+        .verify(&[vkey], &[proof], &[&public_inputs])
+        .unwrap();
 
     Ok(vec![result as u8])
 }


### PR DESCRIPTION
This PR implements batch verification in the verifier as it is done in [Jellyfish](https://github.com/renegade-fi/mpc-jellyfish/blob/main/plonk/src/proof_system/verifier.rs#L199), namely by extending the final pairing check to be over a random linear combination of the G1 elements each verification instance produces for its respective final pairing check.

Additionally, this extends the Jellyfish implementation by batch-inverting the Lagrange bases across all verification instances in the batch.

**Testing:**
Unit tests for verification pass. While the verifier contract has been adapted to this interface, it is not yet tested - this will be done in the subsequent PR.