### PR TITLE
contracts-stylus: use mini-alloc instead of wee_alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
  "ark-ff",
  "common",
  "contracts-core",
+ "mini-alloc",
  "postcard",
  "stylus-sdk",
- "wee_alloc",
 ]
 
 [[package]]
@@ -2682,6 +2682,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mini-alloc"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9993556d3850cdbd0da06a3dc81297edcfa050048952d84d75e8b944e8f5af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wee_alloc",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 stylus-sdk = { version = "0.4.2" }
-wee_alloc = "0.4.5"
+mini-alloc = "0.4.2"
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-bn254 = { workspace = true }

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -9,4 +9,4 @@ mod utils;
 extern crate alloc;
 
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;


### PR DESCRIPTION
This PR switches the global allocator from [`wee_alloc`](https://github.com/rustwasm/wee_alloc) to [`mini-alloc`](https://github.com/OffchainLabs/stylus-sdk-rs/tree/stylus/mini-alloc), recently released by Arbitrum.

This chops about 1.5-2kb off of our binary sizes, giving more breathing room to the verifier & darkpool (both of which were right at 24.0kb), and decreases our costs.

As a result, `process_match_settle` comes in at 9,003,749 gas ($1.98), `update_wallet` comes in at 3,752,203 gas ($0.83), and `new_wallet` comes in at 3,654,762 gas ($0.80).

All tests remain passing.