### PR TITLE
contracts-stylus: darkpool: expect signature over wallet shares

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -43,6 +43,9 @@ pub const NUM_BYTES_U256: usize = 32;
 /// The number of scalars it takes to encode an unsigned 256-bit integer
 pub const NUM_SCALARS_U256: usize = 2;
 
+/// The number of scalars it takes to encode a secp256k1 public key
+pub const NUM_SCALARS_PK: usize = 4;
+
 /// The number of bytes it takes to represent an Ethereum address
 pub const NUM_BYTES_ADDRESS: usize = 20;
 

--- a/common/src/custom_serde.rs
+++ b/common/src/custom_serde.rs
@@ -10,12 +10,13 @@ use ark_serialize::Flags;
 
 use crate::{
     constants::{
-        NUM_BYTES_ADDRESS, NUM_BYTES_FELT, NUM_BYTES_U64, NUM_SCALARS_U256, NUM_U64S_FELT,
+        NUM_BYTES_ADDRESS, NUM_BYTES_FELT, NUM_BYTES_U64, NUM_SCALARS_PK, NUM_SCALARS_U256,
+        NUM_U64S_FELT,
     },
     types::{
-        ExternalTransfer, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256, ScalarField,
-        ValidCommitmentsStatement, ValidMatchSettleStatement, ValidReblindStatement,
-        ValidWalletCreateStatement, ValidWalletUpdateStatement,
+        ExternalTransfer, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256,
+        PublicSigningKey, ScalarField, ValidCommitmentsStatement, ValidMatchSettleStatement,
+        ValidReblindStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
     },
 };
 
@@ -225,8 +226,7 @@ impl ScalarSerializable for ValidWalletUpdateStatement {
                 .as_ref()
                 .unwrap_or(&ExternalTransfer::default()),
         )?);
-        scalars.extend(self.old_pk_root.x);
-        scalars.extend(self.old_pk_root.y);
+        scalars.extend(pk_to_scalars(&self.old_pk_root));
         scalars.push(self.timestamp.into());
         Ok(scalars)
     }
@@ -355,6 +355,13 @@ fn external_transfer_to_scalars(
     scalars.extend(u256_to_scalars(external_transfer.amount)?);
     scalars.push(external_transfer.is_withdrawal.into());
     Ok(scalars)
+}
+
+pub fn pk_to_scalars(pk: &PublicSigningKey) -> Vec<ScalarField> {
+    let mut scalars = Vec::with_capacity(NUM_SCALARS_PK);
+    scalars.extend(pk.x);
+    scalars.extend(pk.y);
+    scalars
 }
 
 #[cfg(test)]

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -1,12 +1,15 @@
 //! Testing contract for the Merkle tree which using the test height
 
 use alloc::vec::Vec;
-use common::{constants::TEST_MERKLE_HEIGHT, types::ScalarField};
-use stylus_sdk::{alloy_primitives::U256, prelude::*};
+use common::{
+    constants::{NUM_SCALARS_PK, TEST_MERKLE_HEIGHT},
+    types::ScalarField,
+};
+use stylus_sdk::{abi::Bytes, alloy_primitives::U256, prelude::*};
 
 use crate::{
-    utils::constants::TEST_ZEROS,
     contracts::merkle::{MerkleContract, MerkleParams},
+    utils::constants::TEST_ZEROS,
 };
 
 struct TestMerkleParams;
@@ -39,5 +42,15 @@ impl TestMerkleContract {
 
     fn insert_shares_commitment(&mut self, shares: Vec<U256>) -> Result<(), Vec<u8>> {
         self.merkle.insert_shares_commitment(shares)
+    }
+
+    pub fn verify_state_sig_and_insert(
+        &mut self,
+        shares: Vec<U256>,
+        sig: Bytes,
+        old_pk_root: [U256; NUM_SCALARS_PK],
+    ) -> Result<(), Vec<u8>> {
+        self.merkle
+            .verify_state_sig_and_insert(shares, sig, old_pk_root)
     }
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -4,8 +4,11 @@ use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use ark_ff::PrimeField;
 use common::{
-    custom_serde::{bigint_from_le_bytes, BytesSerializable, ScalarSerializable, SerdeError},
-    types::{PublicInputs, ScalarField},
+    constants::NUM_SCALARS_PK,
+    custom_serde::{
+        bigint_from_le_bytes, pk_to_scalars, BytesSerializable, ScalarSerializable, SerdeError,
+    },
+    types::{PublicInputs, PublicSigningKey, ScalarField},
 };
 use stylus_sdk::{
     alloy_primitives::{Address, U256},
@@ -83,6 +86,20 @@ pub fn scalar_to_u256(scalar: ScalarField) -> U256 {
 pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, SerdeError> {
     let bigint = bigint_from_le_bytes(&u256.to_le_bytes_vec())?;
     ScalarField::from_bigint(bigint).ok_or(SerdeError::ScalarConversion)
+}
+
+#[cfg_attr(
+    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
+    allow(dead_code)
+)]
+pub fn pk_to_u256s(pk: &PublicSigningKey) -> [U256; NUM_SCALARS_PK] {
+    let scalars = pk_to_scalars(pk);
+    scalars
+        .into_iter()
+        .map(scalar_to_u256)
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap()
 }
 
 #[macro_export]

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -21,6 +21,7 @@ sol! {
     function root() external view returns (uint256);
     function rootInHistory(uint256 root) external view returns (bool);
     function insertSharesCommitment(uint256[] shares) external;
+    function verifyStateSigAndInsert(uint256[] shares, bytes sig, uint256[4] old_pk_root) external;
 
     // Vkeys functions
     function validWalletCreateVkey() external view returns (bytes);

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -517,16 +517,16 @@ pub(crate) async fn test_update_wallet(
 
     let proof = proof_from_statement(srs, &valid_wallet_update_statement, N)?;
 
-    let signed_statement_excerpt = [
-        vec![valid_wallet_update_statement.new_private_shares_commitment],
-        valid_wallet_update_statement.new_public_shares.clone(),
-    ]
-    .concat()
-    .as_slice()
-    .serialize_to_bytes();
+    let shares_commitment = compute_poseidon_hash(
+        &[
+            vec![valid_wallet_update_statement.new_private_shares_commitment],
+            valid_wallet_update_statement.new_public_shares.clone(),
+        ]
+        .concat(),
+    );
 
     let public_inputs_signature = Bytes::from(
-        hash_and_sign_message(&signing_key, &signed_statement_excerpt).to_vec(),
+        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).to_vec(),
     );
 
     // Call `update_wallet` with valid data

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -86,7 +86,7 @@ pub struct DeployStylusArgs {
     pub contract: StylusContract,
 
     /// Whether or not to enable proof & ECDSA verification.
-    /// This only applies to the darkpool contract.
+    /// This only applies to the darkpool & Merkle contracts.
     #[arg(long)]
     pub no_verify: bool,
 }


### PR DESCRIPTION
This PR changes the implementation of `update_wallet` to expect the `public_inputs_signature` to be over the big-endian representation of `poseidon_hash(private_shares_commitment || public_wallet_shares)`, as opposed to over the entire serialized `ValidWalletUpdateStatement`. This way, we expect the user to sign _exactly_ the state that is committed to in the Merkle tree. This required moving the ECDSA verification logic into the Merkle contract (where we compute said Poseidon hash).

**Testing:**
The `update_wallet` test passes, all other code paths are untouched.