### PR TITLE
contracts-stylus: darkpool: add protocol fee parameter

### DIFF
--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -61,7 +61,8 @@ pub struct DarkpoolContract {
     /// boolean indicating whether or not the nullifier is spent
     nullifier_set: StorageMap<U256, StorageBool>,
 
-    /// The protocol fee
+    /// The protocol fee, representing a percentage of the trade volume
+    /// as a fized-point number
     protocol_fee: StorageU256,
 }
 

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -14,6 +14,7 @@ abigen!(
         function pause() external
         function unpause() external
 
+        function setFee(uint256 memory new_fee) external
 
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
         function markNullifierSpent(uint256 memory nullifier) external

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -36,3 +36,6 @@ pub(crate) const PAUSE_METHOD_NAME: &str = "pause";
 
 /// The name of the `unpause` method on the Darkpool contract
 pub(crate) const UNPAUSE_METHOD_NAME: &str = "unpause";
+
+/// The name of the `set_fee` method on the Darkpool contract
+pub(crate) const SET_FEE_METHOD_NAME: &str = "setFee";

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -1,7 +1,5 @@
 //! Integration tests for the contracts
 
-use std::sync::Arc;
-
 use ark_ec::AffineRepr;
 use ark_ff::One;
 use ark_std::UniformRand;
@@ -29,13 +27,14 @@ use ethers::{
     middleware::SignerMiddleware,
     providers::Middleware,
     signers::LocalWallet,
-    types::{Bytes, TransactionRequest},
+    types::{Bytes, TransactionRequest, U256},
     utils::{keccak256, parse_ether},
 };
 use eyre::Result;
 use itertools::multiunzip;
 use jf_primitives::pcs::prelude::UnivariateUniversalParams;
 use rand::{thread_rng, RngCore};
+use std::sync::Arc;
 
 use crate::{
     abis::{
@@ -43,8 +42,8 @@ use crate::{
         DummyUpgradeTargetContract, MerkleContract, PrecompileTestContract, VerifierTestContract,
     },
     constants::{
-        L, PAUSE_METHOD_NAME, PROOF_BATCH_SIZE, TRANSFER_AMOUNT, TRANSFER_OWNERSHIP_METHOD_NAME,
-        UNPAUSE_METHOD_NAME,
+        L, PAUSE_METHOD_NAME, PROOF_BATCH_SIZE, SET_FEE_METHOD_NAME, TRANSFER_AMOUNT,
+        TRANSFER_OWNERSHIP_METHOD_NAME, UNPAUSE_METHOD_NAME,
     },
     utils::{
         assert_all_revert, assert_all_suceed, assert_only_owner, dummy_erc20_deposit,
@@ -444,6 +443,15 @@ pub(crate) async fn test_ownable(
         &contract_with_dummy_owner,
         UNPAUSE_METHOD_NAME,
         (),
+    )
+    .await?;
+
+    // Assert that only the owner can call the `set_fee` method
+    assert_only_owner::<_, U256>(
+        &contract,
+        &contract_with_dummy_owner,
+        SET_FEE_METHOD_NAME,
+        U256::default(),
     )
     .await?;
 

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -76,6 +76,10 @@ pub struct DeployProxyArgs {
     /// and the underlying darkpool contract
     #[arg(short, long)]
     pub owner: String,
+
+    /// The initial protocol fee with which to initialize the darkpool contract
+    #[arg(short, long)]
+    pub fee: u64,
 }
 
 /// Deploy a Stylus contract

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -77,7 +77,9 @@ pub struct DeployProxyArgs {
     #[arg(short, long)]
     pub owner: String,
 
-    /// The initial protocol fee with which to initialize the darkpool contract
+    /// The initial protocol fee with which to initialize the darkpool contract.
+    /// The fee is a percentage of the trade volume, represented as a fixed-point number.
+    /// The `u64` used here should accommodate any fee we'd want to set.
     #[arg(short, long)]
     pub fee: u64,
 }

--- a/scripts/src/solidity.rs
+++ b/scripts/src/solidity.rs
@@ -4,7 +4,7 @@ use alloy_sol_types::sol;
 use ethers::contract::abigen;
 
 sol! {
-    function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address) external;
+    function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address, uint256 memory protocol_fee) external;
 }
 
 abigen!(

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy_primitives::Address as AlloyAddress;
+use alloy_primitives::{Address as AlloyAddress, U256};
 use alloy_sol_types::SolCall;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use constants::SystemCurve;
@@ -162,12 +162,19 @@ pub fn darkpool_initialize_calldata(
     verifier_address: Address,
     vkeys_address: Address,
     merkle_address: Address,
+    protocol_fee: U256,
 ) -> Result<Vec<u8>, ScriptError> {
     let verifier_address = AlloyAddress::from_slice(verifier_address.as_bytes());
     let vkeys_address = AlloyAddress::from_slice(vkeys_address.as_bytes());
     let merkle_address = AlloyAddress::from_slice(merkle_address.as_bytes());
 
-    Ok(initializeCall::new((verifier_address, vkeys_address, merkle_address)).encode())
+    Ok(initializeCall::new((
+        verifier_address,
+        vkeys_address,
+        merkle_address,
+        protocol_fee,
+    ))
+    .encode())
 }
 
 fn command_success_or(mut cmd: Command, err_msg: &str) -> Result<(), ScriptError> {


### PR DESCRIPTION
This PR adds a `protocol_fee` parameter to the `DarkpoolContract`, which is set during initialization and can be set by the owner.

Implementation details of the protocol fee (e.g., how many decimals are in the fixed-point representation) are deferred until it is implemented throughout the protocol. As such, fee-specific tests are also deferred.

**Testing:**
The ownership test was updated to assert that only the owner can set the protocol fee, and passes.