### PR TITLE
contracts-stylus: darkpool: add implementation address setter methods

### DIFF
--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -75,3 +75,15 @@ pub const EMPTY_LEAF_VALUE: ScalarField = Fp(
     ]),
     PhantomData,
 );
+
+/// The selector for the verifier address in the `is_implementation_upgraded`
+/// method on the Darkpool test contract
+pub const VERIFIER_ADDRESS_SELECTOR: u8 = 0;
+
+/// The selector for the vkeys address in the `is_implementation_upgraded`
+/// method on the Darkpool test contract
+pub const VKEYS_ADDRESS_SELECTOR: u8 = 1;
+
+/// The selector for the merkle address in the `is_implementation_upgraded`
+/// method on the Darkpool test contract
+pub const MERKLE_ADDRESS_SELECTOR: u8 = 2;

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -48,10 +48,10 @@ pub struct DarkpoolContract {
     paused: StorageBool,
 
     /// The address of the verifier contract
-    verifier_address: StorageAddress,
+    pub(crate) verifier_address: StorageAddress,
 
     /// The address of the vkeys contract
-    vkeys_address: StorageAddress,
+    pub(crate) vkeys_address: StorageAddress,
 
     /// The address of the Merkle contract
     pub(crate) merkle_address: StorageAddress,
@@ -196,7 +196,7 @@ impl DarkpoolContract {
         storage: &mut S,
         fee: U256,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage);
+        DarkpoolContract::_assert_owner(storage);
         assert_ne!(fee, U256::ZERO);
         storage.borrow_mut().protocol_fee.set(fee);
         Ok(())
@@ -207,7 +207,7 @@ impl DarkpoolContract {
         storage: &mut S,
         verifier_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage);
+        DarkpoolContract::_assert_owner(storage);
         assert_ne!(verifier_address, Address::ZERO);
         storage.borrow_mut().verifier_address.set(verifier_address);
         Ok(())
@@ -218,7 +218,7 @@ impl DarkpoolContract {
         storage: &mut S,
         vkeys_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage);
+        DarkpoolContract::_assert_owner(storage);
         assert_ne!(vkeys_address, Address::ZERO);
         storage.borrow_mut().vkeys_address.set(vkeys_address);
         Ok(())
@@ -229,7 +229,7 @@ impl DarkpoolContract {
         storage: &mut S,
         merkle_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage);
+        DarkpoolContract::_assert_owner(storage);
         assert_ne!(merkle_address, Address::ZERO);
         storage.borrow_mut().merkle_address.set(merkle_address);
         Ok(())

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -201,6 +201,36 @@ impl DarkpoolContract {
         Ok(())
     }
 
+    /// Sets the verifier address
+    pub fn set_verifier_address<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        verifier_address: Address,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_owner(storage);
+        storage.borrow_mut().verifier_address.set(verifier_address);
+        Ok(())
+    }
+
+    /// Sets the vkeys address
+    pub fn set_vkeys_address<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        vkeys_address: Address,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_owner(storage);
+        storage.borrow_mut().vkeys_address.set(vkeys_address);
+        Ok(())
+    }
+
+    /// Sets the Merkle address
+    pub fn set_merkle_address<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        merkle_address: Address,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_owner(storage);
+        storage.borrow_mut().merkle_address.set(merkle_address);
+        Ok(())
+    }
+
     /// Adds a new wallet to the commitment tree
     pub fn new_wallet<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -197,6 +197,7 @@ impl DarkpoolContract {
         fee: U256,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage);
+        assert_ne!(fee, U256::ZERO);
         storage.borrow_mut().protocol_fee.set(fee);
         Ok(())
     }
@@ -207,6 +208,7 @@ impl DarkpoolContract {
         verifier_address: Address,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage);
+        assert_ne!(verifier_address, Address::ZERO);
         storage.borrow_mut().verifier_address.set(verifier_address);
         Ok(())
     }
@@ -217,6 +219,7 @@ impl DarkpoolContract {
         vkeys_address: Address,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage);
+        assert_ne!(vkeys_address, Address::ZERO);
         storage.borrow_mut().vkeys_address.set(vkeys_address);
         Ok(())
     }
@@ -227,6 +230,7 @@ impl DarkpoolContract {
         merkle_address: Address,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage);
+        assert_ne!(merkle_address, Address::ZERO);
         storage.borrow_mut().merkle_address.set(merkle_address);
         Ok(())
     }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -32,6 +32,9 @@ sol! {
     function verify(bytes memory verification_bundle) external view returns (bool);
     function verifyMatch(bytes memory match_bundle) external view returns (bool);
 
+    // Testing functions
+    function isDummyUpgradeTarget() external view returns (bool);
+
     // ----------
     // | EVENTS |
     // ----------

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -15,6 +15,9 @@ abigen!(
         function unpause() external
 
         function setFee(uint256 memory new_fee) external
+        function setVerifierAddress(address memory verifier_address) external
+        function setVkeysAddress(address memory vkeys_address) external
+        function setMerkleAddress(address memory merkle_address) external
 
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
         function markNullifierSpent(uint256 memory nullifier) external

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -20,7 +20,6 @@ abigen!(
         function setMerkleAddress(address memory merkle_address) external
 
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
-        function markNullifierSpent(uint256 memory nullifier) external
 
         function getRoot() external view returns (uint256)
 
@@ -28,8 +27,9 @@ abigen!(
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes) external
 
+        function markNullifierSpent(uint256 memory nullifier) external
         function executeExternalTransfer(bytes memory transfer) external
-
+        function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool)
         function clearMerkle() external
     ]"#
 );

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -39,6 +39,7 @@ pub(crate) enum Tests {
     Merkle,
     Verifier,
     Upgradeable,
+    ImplSetters,
     Initializable,
     Ownable,
     Pausable,

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -39,3 +39,12 @@ pub(crate) const UNPAUSE_METHOD_NAME: &str = "unpause";
 
 /// The name of the `set_fee` method on the Darkpool contract
 pub(crate) const SET_FEE_METHOD_NAME: &str = "setFee";
+
+/// The name of the `set_verifier_address` method on the Darkpool contract
+pub(crate) const SET_VERIFIER_ADDRESS_METHOD_NAME: &str = "setVerifierAddress";
+
+/// The name of the `set_vkeys_address` method on the Darkpool contract
+pub(crate) const SET_VKEYS_ADDRESS_METHOD_NAME: &str = "setVkeysAddress";
+
+/// The name of the `set_merkle_address` method on the Darkpool contract
+pub(crate) const SET_MERKLE_ADDRESS_METHOD_NAME: &str = "setMerkleAddress";

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -9,13 +9,17 @@ use cli::{Cli, Tests};
 use constants::{DUMMY_ERC20_CONTRACT_KEY, DUMMY_UPGRADE_TARGET_CONTRACT_KEY};
 use eyre::Result;
 use scripts::{
-    constants::{DARKPOOL_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, VERIFIER_CONTRACT_KEY},
+    constants::{
+        DARKPOOL_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, MERKLE_CONTRACT_KEY,
+        VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
+    },
     utils::{parse_addr_from_deployments_file, parse_srs_from_file, setup_client},
 };
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_initializable, test_merkle, test_new_wallet, test_nullifier_set,
-    test_process_match_settle, test_update_wallet, test_upgradeable, test_verifier, test_ownable, test_pausable,
+    test_implementation_address_setters, test_initializable, test_merkle, test_new_wallet,
+    test_nullifier_set, test_ownable, test_pausable, test_process_match_settle, test_update_wallet,
+    test_upgradeable, test_verifier,
 };
 use utils::get_test_contract_address;
 
@@ -93,6 +97,28 @@ async fn main() -> Result<()> {
                 proxy_address,
                 dummy_upgrade_target_address,
                 darkpool_address,
+            )
+            .await?;
+        }
+        Tests::ImplSetters => {
+            let contract = DarkpoolTestContract::new(contract_address, client.clone());
+            let verifier_address =
+                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
+            let vkeys_address =
+                parse_addr_from_deployments_file(&deployments_file, VKEYS_CONTRACT_KEY)?;
+            let merkle_address =
+                parse_addr_from_deployments_file(&deployments_file, MERKLE_CONTRACT_KEY)?;
+            let dummy_upgrade_target_address = parse_addr_from_deployments_file(
+                &deployments_file,
+                DUMMY_UPGRADE_TARGET_CONTRACT_KEY,
+            )?;
+
+            test_implementation_address_setters(
+                contract,
+                verifier_address,
+                vkeys_address,
+                merkle_address,
+                dummy_upgrade_target_address,
             )
             .await?;
         }

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -42,8 +42,10 @@ use crate::{
         DummyUpgradeTargetContract, MerkleContract, PrecompileTestContract, VerifierTestContract,
     },
     constants::{
-        L, PAUSE_METHOD_NAME, PROOF_BATCH_SIZE, SET_FEE_METHOD_NAME, TRANSFER_AMOUNT,
-        TRANSFER_OWNERSHIP_METHOD_NAME, UNPAUSE_METHOD_NAME,
+        L, PAUSE_METHOD_NAME, PROOF_BATCH_SIZE, SET_FEE_METHOD_NAME,
+        SET_MERKLE_ADDRESS_METHOD_NAME, SET_VERIFIER_ADDRESS_METHOD_NAME,
+        SET_VKEYS_ADDRESS_METHOD_NAME, TRANSFER_AMOUNT, TRANSFER_OWNERSHIP_METHOD_NAME,
+        UNPAUSE_METHOD_NAME,
     },
     utils::{
         assert_all_revert, assert_all_suceed, assert_only_owner, dummy_erc20_deposit,
@@ -451,7 +453,31 @@ pub(crate) async fn test_ownable(
         &contract,
         &contract_with_dummy_owner,
         SET_FEE_METHOD_NAME,
-        U256::default(),
+        U256::from(1),
+    )
+    .await?;
+
+    // Assert that only the owner can call the implementation address setters
+    let dummy_impl_address = Address::random();
+    assert_only_owner::<_, Address>(
+        &contract,
+        &contract_with_dummy_owner,
+        SET_VERIFIER_ADDRESS_METHOD_NAME,
+        dummy_impl_address,
+    )
+    .await?;
+    assert_only_owner::<_, Address>(
+        &contract,
+        &contract_with_dummy_owner,
+        SET_VKEYS_ADDRESS_METHOD_NAME,
+        dummy_impl_address,
+    )
+    .await?;
+    assert_only_owner::<_, Address>(
+        &contract,
+        &contract_with_dummy_owner,
+        SET_MERKLE_ADDRESS_METHOD_NAME,
+        dummy_impl_address,
     )
     .await?;
 

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -77,7 +77,6 @@ pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(
         contract
             .method::<T, D>(method, args)?
             .send()
-            .await?
             .await
             .is_ok(),
         "Failed to call {} as owner",
@@ -119,7 +118,7 @@ pub async fn assert_all_suceed<'a>(
 ) -> Result<()> {
     for tx in txs {
         assert!(
-            tx.await?.await.is_ok(),
+            tx.await.is_ok(),
             "Expected transaction to succeed, but it reverted"
         );
     }

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -46,6 +46,7 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
         }
         Tests::NullifierSet
         | Tests::Initializable
+        | Tests::ImplSetters
         | Tests::Ownable
         | Tests::Pausable
         | Tests::ExternalTransfer
@@ -74,11 +75,7 @@ pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(
     );
 
     assert!(
-        contract
-            .method::<T, D>(method, args)?
-            .send()
-            .await
-            .is_ok(),
+        contract.method::<T, D>(method, args)?.send().await.is_ok(),
         "Failed to call {} as owner",
         method
     );


### PR DESCRIPTION
This PR adds setter methods for the `VerifierContract`, `VkeysContract`, and `MerkleContract` implementation addresses stored in the `DarkpoolContract`.

This is the last of the necessary controls to add, so we can now think about which events will be the most useful to add (we won't be able to add events for all of the controls added).

**Testing:**
The ownership test was updated to assert that only the owner can set implementation addresses, and passes.
Additionally, I added a test for asserting that setting the implementation address does, indeed, point to a new contract. This test passes as well.