### PR TITLE
contracts-stylus: darkpool: add controls events

### DIFF
--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -42,8 +42,17 @@ sol! {
     // Merkle events
     event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value);
 
-    // Darkpool events
+    // Darkpool user interaction events
     event NullifierSpent(uint256 indexed nullifier);
     event WalletUpdated(uint256 indexed wallet_blinder_share);
     event ExternalTransfer(address indexed account, address indexed mint, bool indexed is_withdrawal, uint256 amount);
+
+    // Darkpool controls events
+    event FeeChanged(uint256 indexed new_fee);
+    event OwnershipTransferred(address indexed new_owner);
+    event Paused();
+    event Unpaused();
+    event VerifierAddressChanged(address indexed new_address);
+    event VkeysAddressChanged(address indexed new_address);
+    event MerkleAddressChanged(address indexed new_address);
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,7 +5,7 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
-        function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address) external
+        function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address, uint256 memory protocol_fee) external
 
         function owner() external view returns (address)
         function transferOwnership(address memory new_owner) external

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -129,8 +129,14 @@ async fn main() -> Result<()> {
         }
         Tests::Ownable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());
+            let verifier_address =
+                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
+            let vkeys_address =
+                parse_addr_from_deployments_file(&deployments_file, VKEYS_CONTRACT_KEY)?;
+            let merkle_address =
+                parse_addr_from_deployments_file(&deployments_file, MERKLE_CONTRACT_KEY)?;
 
-            test_ownable(contract).await?;
+            test_ownable(contract, verifier_address, vkeys_address, merkle_address).await?;
         }
         Tests::Pausable => {
             let contract = DarkpoolTestContract::new(contract_address, client.clone());

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -427,13 +427,15 @@ pub(crate) async fn test_initializable(
     let dummy_verifier_address = Address::random();
     let dummy_vkeys_address = Address::random();
     let dummy_merkle_address = Address::random();
+    let dummy_protocol_fee = U256::from(1);
 
     assert!(
         contract
             .initialize(
                 dummy_verifier_address,
                 dummy_vkeys_address,
-                dummy_merkle_address
+                dummy_merkle_address,
+                dummy_protocol_fee,
             )
             .send()
             .await
@@ -446,6 +448,9 @@ pub(crate) async fn test_initializable(
 
 pub(crate) async fn test_ownable(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
+    verifier_address: Address,
+    vkeys_address: Address,
+    merkle_address: Address,
 ) -> Result<()> {
     let initial_owner = contract.client().default_sender().unwrap();
 
@@ -522,26 +527,27 @@ pub(crate) async fn test_ownable(
     .await?;
 
     // Assert that only the owner can call the implementation address setters
-    let dummy_impl_address = Address::random();
+    // We set the implementation addresses to the original addresses to ensure
+    // that future tests have the correct implementation addresses
     assert_only_owner::<_, Address>(
         &contract,
         &contract_with_dummy_owner,
         SET_VERIFIER_ADDRESS_METHOD_NAME,
-        dummy_impl_address,
+        verifier_address,
     )
     .await?;
     assert_only_owner::<_, Address>(
         &contract,
         &contract_with_dummy_owner,
         SET_VKEYS_ADDRESS_METHOD_NAME,
-        dummy_impl_address,
+        vkeys_address,
     )
     .await?;
     assert_only_owner::<_, Address>(
         &contract,
         &contract_with_dummy_owner,
         SET_MERKLE_ADDRESS_METHOD_NAME,
-        dummy_impl_address,
+        merkle_address,
     )
     .await?;
 

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -38,6 +38,9 @@ pub const OPT_LEVEL_FLAG: &str = "-C opt-level=";
 /// The "s" optimization level (size optimization)
 pub const OPT_LEVEL_S: &str = "s";
 
+/// The "z" optimization level (aggressive size optimization)
+pub const OPT_LEVEL_Z: &str = "z";
+
 /// The 3 optimization level (maximum optimization)
 pub const OPT_LEVEL_3: &str = "3";
 
@@ -82,6 +85,9 @@ pub const WASM_OPT_COMMAND: &str = "wasm-opt";
 
 /// The most aggressive optimization flag for the `wasm-opt` command
 pub const AGGRESSIVE_OPTIMIZATION_FLAG: &str = "-O4";
+
+/// The most aggressive size optimization flag for the `wasm-opt` command
+pub const AGGRESSIVE_SIZE_OPTIMIZATION_FLAG: &str = "-Oz";
 
 /// The name of the stylus command
 pub const STYLUS_COMMAND: &str = "stylus";


### PR DESCRIPTION
This PR adds in events for each of the newly-defined controls in the `DarkpoolContract`. Fortunately, the contract still fits within the binary size limit (though _exactly_ at 24.0kb) with all of these events, without having to change its compilation flags.

**Testing:**
`test_ownership`, `test_initializable`, `test_pausable`, and `test_implementation_setters`, which might be affected by these changes, all pass.