### PR TITLE
Andrew/utils doc comments

### DIFF
--- a/contracts-utils/src/conversion.rs
+++ b/contracts-utils/src/conversion.rs
@@ -12,6 +12,7 @@ use contracts_common::types::{
 use mpc_plonk::proof_system::structs::VerifyingKey;
 use mpc_relation::proof_linking::GroupLayout;
 
+/// Converts a [`GroupLayout`] (from prover-side code) to a [`LinkingVerificationKey`]
 pub fn to_linking_vkey(group_layout: &GroupLayout) -> LinkingVerificationKey {
     LinkingVerificationKey {
         link_group_generator: group_layout.get_domain_generator(),
@@ -20,6 +21,8 @@ pub fn to_linking_vkey(group_layout: &GroupLayout) -> LinkingVerificationKey {
     }
 }
 
+/// Attempts to convert a slice of [`PolynomialCommitment`]s (from prover-side code)
+/// to a fixed-size array of [`G1Affine`]z
 fn try_unwrap_commitments<const N: usize>(
     comms: &[PolynomialCommitment],
 ) -> Result<[G1Affine; N], ConversionError> {
@@ -31,6 +34,8 @@ fn try_unwrap_commitments<const N: usize>(
         .map_err(|_| ConversionError::InvalidLength)
 }
 
+
+/// Converts a [`VerifyingKey`] (from prover-side code) to a [`VerificationKey`]
 pub fn to_contract_vkey(
     jf_vkey: VerifyingKey<SystemCurve>,
 ) -> Result<VerificationKey, ConversionError> {
@@ -49,6 +54,7 @@ pub fn to_contract_vkey(
     })
 }
 
+/// Converts a [`ContractPublicSigningKey`] (from contract-side code) to a [`CircuitPublicSigningKey`]
 pub fn to_circuit_pubkey(contract_pubkey: ContractPublicSigningKey) -> CircuitPublicSigningKey {
     let x = NonNativeScalar {
         scalar_words: contract_pubkey

--- a/contracts-utils/src/crypto.rs
+++ b/contracts-utils/src/crypto.rs
@@ -13,6 +13,8 @@ use ethers::{
 };
 use rand::{CryptoRng, RngCore};
 
+/// A hashing backend that runs natively, i.e.
+/// without using a Stylus VM-accelerated Keccak implementation
 pub struct NativeHasher;
 
 impl HashBackend for NativeHasher {
@@ -21,6 +23,8 @@ impl HashBackend for NativeHasher {
     }
 }
 
+/// Generates a random secp256k1 signing keypair, returning the [`SigningKey`] and the
+/// [`PublicSigningKey`] type
 pub fn random_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SigningKey, PublicSigningKey) {
     let signing_key = SigningKey::random(rng);
     let verifying_key = signing_key.verifying_key();
@@ -57,6 +61,8 @@ pub fn random_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SigningKey, Publi
     (signing_key, pubkey)
 }
 
+/// Hashes the given message and generates a signature over it using the signing key,
+/// as expected in ECDSA
 pub fn hash_and_sign_message(signing_key: &SigningKey, msg: &[u8]) -> Signature {
     let msg_hash = keccak256(msg);
     let (sig, recovery_id) = signing_key.sign_prehash_recoverable(&msg_hash).unwrap();

--- a/contracts-utils/src/lib.rs
+++ b/contracts-utils/src/lib.rs
@@ -1,5 +1,8 @@
 //! Common utiltiies used outside of the Stylus contracts themselves, e.g. for deploy scripts & testing
 
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+
 pub mod conversion;
 pub mod crypto;
 pub mod merkle;

--- a/contracts-utils/src/merkle.rs
+++ b/contracts-utils/src/merkle.rs
@@ -10,6 +10,7 @@ use core::borrow::Borrow;
 use rand::Rng;
 use renegade_crypto::hash::Poseidon2Sponge;
 
+/// Collision-resistant hash representing the identity function
 pub struct IdentityCRH;
 impl CRHScheme for IdentityCRH {
     type Input = ScalarField;
@@ -30,6 +31,7 @@ impl CRHScheme for IdentityCRH {
     }
 }
 
+/// Two-to-one collision-resistant hash using the Poseidon2 sponge
 pub struct PoseidonTwoToOneCRH;
 impl TwoToOneCRHScheme for PoseidonTwoToOneCRH {
     type Input = ScalarField;
@@ -62,6 +64,7 @@ impl TwoToOneCRHScheme for PoseidonTwoToOneCRH {
     }
 }
 
+/// Configuration for Poseidon2 Merkle tree as used in the Stylus contracts
 pub struct MerkleConfig;
 impl Config for MerkleConfig {
     type Leaf = ScalarField;
@@ -75,6 +78,7 @@ impl Config for MerkleConfig {
     type LeafInnerDigestConverter = IdentityDigestConverter<ScalarField>;
 }
 
+/// Create an empty Merkle tree with the given height
 pub fn new_ark_merkle_tree(height: usize) -> MerkleTree<MerkleConfig> {
     let num_leaves = 2_u128.pow(height as u32);
     let leaves = vec![EMPTY_LEAF_VALUE; num_leaves as usize];

--- a/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
+++ b/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
@@ -1,6 +1,5 @@
-//! Defines mock versions of the Renegade protocol circuits that expect the same
-//! statements & link groups, but expect no witness, abd have trivially satisfiable
-//! dummy constraints.
+//! Defines a mock circuit that is generic over the same statements as the Renegade
+//! protocol circuits, but is trivially satisfiable
 
 use core::marker::PhantomData;
 
@@ -19,7 +18,11 @@ use eyre::Result;
 
 use mpc_plonk::errors::PlonkError;
 
+/// A simple circuit that is trivially satisfiable in that it applies no constraints.
+///
+/// Defined generically over an application-level statement type.
 pub struct DummyCircuit<S: CircuitBaseType> {
+    #[doc(hidden)]
     _phantom: PhantomData<S>,
 }
 
@@ -40,32 +43,17 @@ impl<S: CircuitBaseType> SingleProverCircuit for DummyCircuit<S> {
     }
 }
 
-// -----------------------
-// | VALID WALLET CREATE |
-// -----------------------
-
+/// The dummy version of the `VALID WALLET CREATE` circuit
 pub type DummyValidWalletCreate = DummyCircuit<SizedValidWalletCreateStatement>;
 
-// -----------------------
-// | VALID WALLET UPDATE |
-// -----------------------
-
+/// The dummy version of the `VALID WALLET UPDATE` circuit
 pub type DummyValidWalletUpdate = DummyCircuit<SizedValidWalletUpdateStatement>;
 
-// -----------------
-// | VALID REBLIND |
-// -----------------
-
+/// The dummy version of the `VALID REBLIND` circuit
 pub type DummyValidReblind = DummyCircuit<ValidReblindStatement>;
 
-// ---------------------
-// | VALID COMMITMENTS |
-// ---------------------
-
+/// The dummy version of the `VALID COMMITMENTS` circuit
 pub type DummyValidCommitments = DummyCircuit<ValidCommitmentsStatement>;
 
-// ----------------------
-// | VALID MATCH SETTLE |
-// ----------------------
-
+/// The dummy version of the `VALID MATCH SETTLE` circuit
 pub type DummyValidMatchSettle = DummyCircuit<SizedValidMatchSettleStatement>;

--- a/contracts-utils/src/proof_system/mod.rs
+++ b/contracts-utils/src/proof_system/mod.rs
@@ -31,6 +31,7 @@ pub mod test_data;
 // | HIGH-LEVEL UTILITIES |
 // ------------------------
 
+/// Generates a verification key for a circuit using the given SRS
 pub fn gen_circuit_vkey<C: SingleProverCircuit>(
     srs: &UnivariateUniversalParams<SystemCurve>,
 ) -> Result<VerificationKey, ProofSystemError> {
@@ -58,7 +59,7 @@ pub fn gen_circuit_vkey<C: SingleProverCircuit>(
     to_contract_vkey(jf_vkey).map_err(Into::into)
 }
 
-// TODO: prove_with_link_hint
+/// Generates a proof for a circuit using the given SRS, statement, and witness
 pub fn prove_with_srs<C: SingleProverCircuit>(
     srs: &UnivariateUniversalParams<SystemCurve>,
     witness: C::Witness,
@@ -96,9 +97,12 @@ pub fn prove_with_srs<C: SingleProverCircuit>(
 // | ERROR TYPE |
 // --------------
 
+/// An error that occured when interacting with the proof system
 #[derive(Debug)]
 pub enum ProofSystemError {
+    /// An error that occurred when converting between prover and contract types
     ConversionError(ConversionError),
+    /// An error that occurred when computing a proof
     ProverError(ProverError),
 }
 

--- a/contracts-utils/src/proof_system/test_circuit.rs
+++ b/contracts-utils/src/proof_system/test_circuit.rs
@@ -25,17 +25,28 @@ use rand::thread_rng;
 
 use crate::conversion::{to_contract_vkey, to_linking_vkey};
 
+/// Encapsulates the information needed to add a link group to a circuit
 pub struct LinkGroupInfo {
+    /// The elements of the link group
     pub linked_inputs: Vec<ScalarField>,
+    /// The optional predefined layout of the link group
     pub layout: Option<GroupLayout>,
+    /// The link group ID
     pub id: String,
 }
 
+/// The verification keys for a circuit
 pub struct CircuitVkeys {
+    /// The Plonk verification key
     pub vkey: VerificationKey,
+    /// The linking verification keys
     pub linking_vkeys: HashMap<String, LinkingVerificationKey>,
 }
 
+/// Generates a proof for a trivially constrained circuit using the given SRS, public inputs, and
+/// link groups.
+///
+/// Returns the proof, the linking hint, and the circuit verification keys.
 pub fn gen_test_circuit_proofs_and_vkeys(
     srs: &UnivariateUniversalParams<SystemCurve>,
     public_inputs: &PublicInputs,
@@ -56,6 +67,9 @@ pub fn gen_test_circuit_proofs_and_vkeys(
     Ok((proof, link_hint, circuit_vkeys))
 }
 
+/// Generates a trivially constrained circuit using the given SRS, public inputs, and link groups.
+///
+/// Returns the circuit, the proving key, and the circuit verification keys.
 fn gen_test_circuit_and_keys(
     srs: &UnivariateUniversalParams<SystemCurve>,
     public_inputs: &PublicInputs,
@@ -81,6 +95,7 @@ fn gen_test_circuit_and_keys(
     Ok((circuit, pkey, circuit_vkeys))
 }
 
+/// Generates a trivially constrained circuit using the given public inputs and link groups.
 fn gen_circuit(
     public_inputs: &PublicInputs,
     link_groups: &[LinkGroupInfo],

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -29,22 +29,40 @@ pub(crate) struct Cli {
     pub(crate) rpc_url: String,
 }
 
+/// The possible test cases
 #[derive(ValueEnum, Clone, Copy)]
 pub(crate) enum Tests {
+    /// Test how the contracts call the `ecAdd` precompile
     EcAdd,
+    /// Test how the contracts call the `ecMul` precompile
     EcMul,
+    /// Test how the contracts call the `ecPairing` precompile
     EcPairing,
+    /// Test how the contracts call the `ecRecover` precompile
     EcRecover,
+    /// Test the nullifier set functionality
     NullifierSet,
+    /// Test the Merkle tree functionality
     Merkle,
+    /// Test the verifier functionality
     Verifier,
+    /// Test the upgradeability of the darkpool
     Upgradeable,
+    /// Test the upgradeability of the contracts the darkpool calls
+    /// (verifier, vkeys, & Merkle)
     ImplSetters,
+    /// Test the initialization of the darkpool
     Initializable,
+    /// Test the ownership of the darkpool
     Ownable,
+    /// Test the pausability of the darkpool
     Pausable,
+    /// Test deposit / withdrawal functionality of the darkpool
     ExternalTransfer,
+    /// Test the `new_wallet` method on the darkpool
     NewWallet,
+    /// Test the `update_wallet` method on the darkpool
     UpdateWallet,
+    /// Test the `process_match_settle` method on the darkpool
     ProcessMatchSettle,
 }

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,5 +1,8 @@
 //! Basic tests for Stylus programs. These assume that a devnet is already running locally.
 
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+
 use abis::{
     DarkpoolProxyAdminContract, DarkpoolTestContract, DummyErc20Contract, MerkleContract,
     PrecompileTestContract, VerifierContract,

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -58,6 +58,7 @@ use crate::{
     },
 };
 
+/// Test how the contracts call the `ecAdd` precompile
 pub(crate) async fn test_ec_add(
     contract: PrecompileTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -80,6 +81,7 @@ pub(crate) async fn test_ec_add(
     Ok(())
 }
 
+/// Test how the contracts call the `ecMul` precompile
 pub(crate) async fn test_ec_mul(
     contract: PrecompileTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -105,6 +107,7 @@ pub(crate) async fn test_ec_mul(
     Ok(())
 }
 
+/// Test how the contracts call the `ecPairing` precompile
 pub(crate) async fn test_ec_pairing(
     contract: PrecompileTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -126,6 +129,7 @@ pub(crate) async fn test_ec_pairing(
     Ok(())
 }
 
+/// Test how the contracts call the `ecRecover` precompile
 pub(crate) async fn test_ec_recover(
     contract: PrecompileTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -153,6 +157,7 @@ pub(crate) async fn test_ec_recover(
     Ok(())
 }
 
+/// Test the Merkle tree functionality
 pub(crate) async fn test_merkle(contract: MerkleContract<impl Middleware + 'static>) -> Result<()> {
     let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
     contract.init().send().await?.await?;
@@ -196,6 +201,7 @@ pub(crate) async fn test_merkle(contract: MerkleContract<impl Middleware + 'stat
     Ok(())
 }
 
+/// Test the upgradeability of the darkpool
 pub(crate) async fn test_verifier(
     contract: VerifierContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -266,6 +272,7 @@ pub(crate) async fn test_verifier(
     Ok(())
 }
 
+/// Test the upgradeability of the darkpool
 pub(crate) async fn test_upgradeable(
     proxy_admin_contract: DarkpoolProxyAdminContract<impl Middleware + 'static>,
     proxy_address: Address,
@@ -350,6 +357,8 @@ pub(crate) async fn test_upgradeable(
     Ok(())
 }
 
+/// Test the upgradeability of the contracts the darkpool calls
+/// (verifier, vkeys, & Merkle)
 pub(crate) async fn test_implementation_address_setters(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     verifier_address: Address,
@@ -411,6 +420,7 @@ pub(crate) async fn test_implementation_address_setters(
     Ok(())
 }
 
+/// Test the initialization of the darkpool
 pub(crate) async fn test_initializable(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -436,6 +446,7 @@ pub(crate) async fn test_initializable(
     Ok(())
 }
 
+/// Test the ownership of the darkpool
 pub(crate) async fn test_ownable(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     verifier_address: Address,
@@ -544,6 +555,7 @@ pub(crate) async fn test_ownable(
     Ok(())
 }
 
+/// Test the pausability of the darkpool
 pub(crate) async fn test_pausable(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     srs: &UnivariateUniversalParams<SystemCurve>,
@@ -632,6 +644,7 @@ pub(crate) async fn test_pausable(
     Ok(())
 }
 
+/// Test the nullifier set functionality
 pub(crate) async fn test_nullifier_set(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
 ) -> Result<()> {
@@ -655,6 +668,7 @@ pub(crate) async fn test_nullifier_set(
     Ok(())
 }
 
+/// Test deposit / withdrawal functionality of the darkpool
 pub(crate) async fn test_external_transfer(
     darkpool_test_contract: DarkpoolTestContract<impl Middleware + 'static>,
     dummy_erc20_contract: DummyErc20Contract<impl Middleware + 'static>,
@@ -716,6 +730,7 @@ pub(crate) async fn test_external_transfer(
     Ok(())
 }
 
+/// Test the `new_wallet` method on the darkpool
 pub(crate) async fn test_new_wallet(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     srs: &UnivariateUniversalParams<SystemCurve>,
@@ -755,6 +770,7 @@ pub(crate) async fn test_new_wallet(
     Ok(())
 }
 
+/// Test the `update_wallet` method on the darkpool
 pub(crate) async fn test_update_wallet(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     srs: &UnivariateUniversalParams<SystemCurve>,
@@ -804,6 +820,7 @@ pub(crate) async fn test_update_wallet(
     Ok(())
 }
 
+/// Test the `process_match_settle` method on the darkpool
 pub(crate) async fn test_process_match_settle(
     contract: DarkpoolTestContract<impl Middleware + 'static>,
     srs: &UnivariateUniversalParams<SystemCurve>,

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -32,6 +32,7 @@ use crate::{
     constants::{PRECOMPILE_TEST_CONTRACT_KEY, TRANSFER_AMOUNT, VERIFIER_TEST_CONTRACT_KEY},
 };
 
+/// Returns the deployed address of the contract to be tested
 pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> Result<Address> {
     Ok(match test {
         Tests::EcAdd | Tests::EcMul | Tests::EcPairing | Tests::EcRecover => {
@@ -58,6 +59,7 @@ pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> 
     })
 }
 
+/// Asserts that the given method can only be called by the owner of the darkpool contract
 pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(
     contract: &DarkpoolTestContract<impl Middleware + 'static>,
     contract_with_dummy_owner: &DarkpoolTestContract<impl Middleware + 'static>,
@@ -83,6 +85,7 @@ pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(
     Ok(())
 }
 
+/// Asserts that all the given transactions revert
 pub async fn assert_all_revert<'a>(
     txs: Vec<
         impl Future<
@@ -103,6 +106,7 @@ pub async fn assert_all_revert<'a>(
     Ok(())
 }
 
+/// Asserts that all of the given transactions successfully execute
 pub async fn assert_all_suceed<'a>(
     txs: Vec<
         impl Future<
@@ -136,10 +140,14 @@ pub fn u256_to_scalar(u256: U256) -> Result<ScalarField> {
         .map_err(|_| eyre!("failed converting U256 to scalar"))
 }
 
+/// Serialiez the given serializable type into a [`Bytes`] object
+/// that can be passed in as calldata
 pub fn serialize_to_calldata<T: Serialize>(t: &T) -> Result<Bytes> {
     Ok(postcard::to_allocvec(t)?.into())
 }
 
+/// Serializes the given bundle of verification keys, proofs, and public inputs
+/// into a [`Bytes`] object that can be passed in as calldata
 pub fn serialize_verification_bundle(
     vkey_batch: &[VerificationKey],
     proof_batch: &[Proof],
@@ -163,6 +171,7 @@ pub fn serialize_verification_bundle(
     Ok(bundle_bytes.into())
 }
 
+/// Mints [`TRANSFER_AMOUNT`] of the dummy ERC20 token to the given addresses
 pub(crate) async fn mint_dummy_erc20(
     contract: &DummyErc20Contract<impl Middleware + 'static>,
     addresses: &[Address],
@@ -178,6 +187,8 @@ pub(crate) async fn mint_dummy_erc20(
     Ok(())
 }
 
+/// Creates an [`ExternalTransfer`] object for the given account address,
+/// mint address, and transfer direction
 fn dummy_erc20_external_transfer(
     account_addr: Address,
     mint: Address,
@@ -191,14 +202,17 @@ fn dummy_erc20_external_transfer(
     }
 }
 
+/// Creates an [`ExternalTransfer`] object representing a deposit
 pub(crate) fn dummy_erc20_deposit(account_addr: Address, mint: Address) -> ExternalTransfer {
     dummy_erc20_external_transfer(account_addr, mint, false)
 }
 
+/// Creates an [`ExternalTransfer`] object representing a withdrawal
 pub(crate) fn dummy_erc20_withdrawal(account_addr: Address, mint: Address) -> ExternalTransfer {
     dummy_erc20_external_transfer(account_addr, mint, true)
 }
 
+/// Executes the given transfer and returns the resulting balances of the darkpool and user
 pub(crate) async fn execute_transfer_and_get_balances(
     darkpool_test_contract: &DarkpoolTestContract<impl Middleware + 'static>,
     dummy_erc20_contract: &DummyErc20Contract<impl Middleware + 'static>,
@@ -222,6 +236,8 @@ pub(crate) async fn execute_transfer_and_get_balances(
     Ok((darkpool_balance, user_balance))
 }
 
+/// Computes a commitment to the given wallet shares, inserts them
+/// into the given Arkworks Merkle tree, and returns the new root
 pub(crate) fn insert_shares_and_get_root(
     ark_merkle: &mut ArkMerkleTree<MerkleConfig>,
     private_shares_commitment: ScalarField,

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -14,6 +14,7 @@ use crate::{
     errors::ScriptError,
 };
 
+/// Top-level CLI arguments
 #[derive(Parser)]
 pub struct Cli {
     /// Private key of the deployer
@@ -29,20 +30,28 @@ pub struct Cli {
     #[arg(short, long)]
     pub deployments_path: String,
 
+    /// The command to run
     #[command(subcommand)]
     pub command: Command,
 }
 
+/// The possible CLI commands
 #[derive(Subcommand)]
 pub enum Command {
+    /// Deploy the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts
     DeployProxy(DeployProxyArgs),
+    /// Deploy a Stylus contract
     DeployStylus(DeployStylusArgs),
+    /// Upgrade the darkpool implementation
     Upgrade(UpgradeArgs),
+    /// Generate a structured reference string
     GenSrs(GenSrsArgs),
+    /// Generate verification keys for the protocol circuits
     GenVkeys(GenVkeysArgs),
 }
 
 impl Command {
+    /// Run the command
     pub async fn run(
         self,
         client: Arc<impl Middleware>,
@@ -97,17 +106,28 @@ pub struct DeployStylusArgs {
     pub no_verify: bool,
 }
 
+/// The possible Stylus contracts to deploy
 #[derive(ValueEnum, Copy, Clone)]
 pub enum StylusContract {
+    /// The darkpool contract
     Darkpool,
+    /// The darkpool test contract
     DarkpoolTestContract,
+    /// The Merkle contract
     Merkle,
+    /// The Merkle test contract
     MerkleTestContract,
+    /// The verifier contract
     Verifier,
+    /// The verification keys contract
     Vkeys,
+    /// The test verification keys contract
     TestVkeys,
+    /// The dummy ERC20 contract
     DummyErc20,
+    /// The dummy upgrade target contract
     DummyUpgradeTarget,
+    /// The precompile test contract
     PrecompileTestContract,
 }
 

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -45,6 +45,7 @@ use crate::{
     },
 };
 
+/// Deploys the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts
 pub async fn deploy_proxy(
     args: DeployProxyArgs,
     client: Arc<impl Middleware>,
@@ -139,6 +140,7 @@ pub async fn deploy_proxy(
     Ok(())
 }
 
+/// Builds and deploys a Stylus contract
 pub async fn build_and_deploy_stylus_contract(
     args: DeployStylusArgs,
     rpc_url: &str,
@@ -158,6 +160,7 @@ pub async fn build_and_deploy_stylus_contract(
     .await
 }
 
+/// Upgrades the darkpool implementation
 pub async fn upgrade(
     args: UpgradeArgs,
     client: Arc<impl Middleware>,
@@ -192,6 +195,7 @@ pub async fn upgrade(
     Ok(())
 }
 
+/// Generates a structured reference string
 pub fn gen_srs(args: GenSrsArgs) -> Result<(), ScriptError> {
     let mut rng = thread_rng();
 
@@ -203,6 +207,7 @@ pub fn gen_srs(args: GenSrsArgs) -> Result<(), ScriptError> {
     write_srs_to_file(&args.srs_path, &srs)
 }
 
+/// Generates verification keys for the protocol circuits
 pub fn gen_vkeys(args: GenVkeysArgs) -> Result<(), ScriptError> {
     let srs = parse_srs_from_file(&args.srs_path)?;
 

--- a/scripts/src/lib.rs
+++ b/scripts/src/lib.rs
@@ -1,9 +1,5 @@
 //! Scripts for deploying and intializing the Renegade smart contracts.
 
-// TODO: For now, we're just having `main` deploy the upgradeable proxy contract.
-// In the future, we'll have deploy scripts for the other contracts, and use them
-// in the `integration` crate
-
 pub mod cli;
 mod commands;
 pub mod constants;

--- a/scripts/src/lib.rs
+++ b/scripts/src/lib.rs
@@ -1,5 +1,8 @@
 //! Scripts for deploying and intializing the Renegade smart contracts.
 
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+
 pub mod cli;
 mod commands;
 pub mod constants;

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -67,6 +67,7 @@ pub async fn setup_client(
     Ok(client)
 }
 
+/// Parses the JSON file at the given path
 pub fn get_json_from_file(file_path: &str) -> Result<JsonValue, ScriptError> {
     let mut file_contents = String::new();
     File::open(file_path)
@@ -77,6 +78,8 @@ pub fn get_json_from_file(file_path: &str) -> Result<JsonValue, ScriptError> {
     json::parse(&file_contents).map_err(|e| ScriptError::ReadFile(e.to_string()))
 }
 
+/// Parses a the given contract's deployment address from the
+/// deployments file at the given path
 pub fn parse_addr_from_deployments_file(
     file_path: &str,
     contract_key: &str,
@@ -95,6 +98,7 @@ pub fn parse_addr_from_deployments_file(
     .map_err(|e| ScriptError::ReadFile(e.to_string()))
 }
 
+/// Parses a structured reference string from the file at the given path
 pub fn parse_srs_from_file(
     file_path: &str,
 ) -> Result<UnivariateUniversalParams<SystemCurve>, ScriptError> {
@@ -106,6 +110,8 @@ pub fn parse_srs_from_file(
     Ok(srs)
 }
 
+/// Writes the given address for the deployed contract
+/// to the deployments file at the given path
 pub fn write_deployed_address(
     file_path: &str,
     contract_key: &str,
@@ -125,6 +131,7 @@ pub fn write_deployed_address(
     Ok(())
 }
 
+/// Writes the structured reference string to the file at the given path
 pub fn write_srs_to_file(
     file_path: &str,
     srs: &UnivariateUniversalParams<SystemCurve>,
@@ -138,6 +145,7 @@ pub fn write_srs_to_file(
         .map_err(|e| ScriptError::Serde(e.to_string()))
 }
 
+/// Writes the verification key to the file at the given directory & path
 pub fn write_vkey_file(
     vkeys_dir: &str,
     vkey_file_name: &str,
@@ -149,6 +157,7 @@ pub fn write_vkey_file(
     fs::write(vkey_file_path, vkey_bytes).map_err(|e| ScriptError::WriteFile(e.to_string()))
 }
 
+/// Returns the JSON key used in the deployments file for the given contract
 pub fn get_contract_key(contract: StylusContract) -> &'static str {
     match contract {
         StylusContract::Darkpool | StylusContract::DarkpoolTestContract => DARKPOOL_CONTRACT_KEY,
@@ -181,6 +190,7 @@ pub fn darkpool_initialize_calldata(
     .encode())
 }
 
+/// Executes a command, returning an error if the command fails
 fn command_success_or(mut cmd: Command, err_msg: &str) -> Result<(), ScriptError> {
     if !cmd
         .output()
@@ -194,6 +204,8 @@ fn command_success_or(mut cmd: Command, err_msg: &str) -> Result<(), ScriptError
     }
 }
 
+/// Returns the RUSTFLAGS environment variable to use in the
+/// compilation of the given contract
 pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
     let opt_level = match contract {
         StylusContract::Verifier => OPT_LEVEL_S,
@@ -204,6 +216,8 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
     format!("{}{}", OPT_LEVEL_FLAG, opt_level)
 }
 
+/// Returns the wasm-opt flags to use in the optimization of the
+/// given contract
 pub fn get_wasm_opt_flags_for_contract(contract: StylusContract) -> &'static str {
     match contract {
         StylusContract::Verifier | StylusContract::DarkpoolTestContract => {
@@ -299,6 +313,7 @@ pub fn build_stylus_contract(
     Ok(opt_wasm_file_path)
 }
 
+/// Deploys the given compiled Stylus contract, saving its deployment address
 pub async fn deploy_stylus_contract(
     wasm_file_path: PathBuf,
     rpc_url: &str,


### PR DESCRIPTION
This PR adds doc comments to the `contracts-utils`, `integration`, and `scripts` crates in accordance with the `missing_docs` and `clippy::missing_docs_in_private_items` lint rules.