### PR TITLE
contracts-utils: generate match bundle using dummy circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -679,9 +679,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff 0.4.2",
@@ -1022,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "c12ed66a79a555082f595f7eb980d08669de95009dd4b3d61168c573ebe38fc9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "0f4645eab3431e5a8403a96bea02506a8b35d28cd0f0330977dd5d22f9c84f43"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1104,7 +1104,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "bech32",
  "bs58 0.5.0",
  "digest 0.10.7",
@@ -1127,7 +1127,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "ark-mpc",
  "base64 0.13.1",
@@ -1181,7 +1181,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1214,7 +1214,6 @@ dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff 0.4.2",
- "ark-poly",
  "ark-std 0.4.0",
  "circuit-types",
  "constants",
@@ -1255,6 +1254,7 @@ dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
+ "circuit-macros",
  "circuit-types",
  "circuits",
  "constants",
@@ -1343,11 +1343,10 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb9105919ca8e40d437fc9cbb8f1975d916f1bd28afe795a48aae32a2cc8920"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -1357,54 +1356,46 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.17"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc6598521bb5a83d491e8c1fe51db7296019d2ca3cb93cc6c2a20369a4d78a2"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -1838,7 +1829,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "hex",
  "k256",
@@ -1972,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c405f24ea3a517899ba7985385c43dc4a7eb1209af3b1e0a1a32d7dcc7f8d09"
+checksum = "9bf35eb7d2e2092ad41f584951e08ec7c077b142dba29c4f1b8f52d2efddc49c"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2003,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51258120c6b47ea9d9bec0d90f9e8af71c977fbefbef8213c91bfed385fe45eb"
+checksum = "bbdfb952aafd385b31d316ed80d7b76215ce09743c172966d840e96924427e0c"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2021,15 +2012,15 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.48",
- "toml 0.8.2",
+ "toml 0.8.8",
  "walkdir",
 ]
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e7a0f1197cee2b62dc89f63eff3201dbf87c283ff7e18d86d38f83b845483"
+checksum = "7465c814a2ecd0de0442160da13584205d1cdc08f4717a6511cad455bd5d7dc4"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2043,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
+checksum = "918b1a9ba585ea61022647def2f27c29ba19f6d2a4a4c8f68a9ae97fd5769737"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2073,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbac2c890bdbe0f1b8e549a53b00e2c4c1de86bb077c1094d1f38cdf9381a56"
+checksum = "facabf8551b4d1a3c08cb935e7fca187804b6c2525cc0dafb8e5a6dd453a24de"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -2122,7 +2113,7 @@ checksum = "25d6c0c9455d93d4990c06e049abf9b30daf148cf461ee939c11d88907c60816"
 dependencies = [
  "async-trait",
  "auto_impl",
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "const-hex",
  "enr",
@@ -2172,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64f710586d147864cff66540a6d64518b9ff37d73ef827fee430538265b595f"
+checksum = "cc2e46e3ec8ef0c986145901fa9864205dc4dcee701f9846be2d56112d34bdea"
 dependencies = [
  "cfg-if 1.0.0",
  "const-hex",
@@ -2447,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2493,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
 dependencies = [
  "bytes",
  "fnv",
@@ -2902,7 +2893,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#6e3de0b1b4ffbb24fdeeb1364f7e27b329393fa8"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0ce6a9cac9b60ca13544345c1e41310a8910c5ec"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -2946,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#6e3de0b1b4ffbb24fdeeb1364f7e27b329393fa8"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0ce6a9cac9b60ca13544345c1e41310a8910c5ec"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -2989,7 +2980,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "pem",
  "ring 0.16.20",
  "serde",
@@ -2999,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
@@ -3072,9 +3063,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libm"
@@ -3091,7 +3082,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -3297,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#6e3de0b1b4ffbb24fdeeb1364f7e27b329393fa8"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0ce6a9cac9b60ca13544345c1e41310a8910c5ec"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3331,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#6e3de0b1b4ffbb24fdeeb1364f7e27b329393fa8"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0ce6a9cac9b60ca13544345c1e41310a8910c5ec"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3485,20 +3476,20 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 3.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -3588,7 +3579,7 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3890,12 +3881,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+dependencies = [
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -4090,7 +4089,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -4158,7 +4157,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libredox",
  "thiserror",
 ]
@@ -4201,7 +4200,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -4223,7 +4222,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4289,7 +4288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4448,7 +4447,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4745,7 +4744,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5212,9 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -5382,30 +5381,41 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
@@ -5640,7 +5650,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#065788be3658b3c8673830eebef25c7aa157bb36"
+source = "git+https://github.com/renegade-fi/renegade.git#a6dc20ad616db04d868acf8a0bf6c516561ca71d"
 dependencies = [
  "chrono",
  "circuit-types",
@@ -5665,7 +5675,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "serde",
 ]
 
@@ -5675,7 +5685,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "serde",
 ]
 
@@ -6074,9 +6084,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.33"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -101,7 +101,7 @@ pub struct MatchLinkingVkeys {
 
 /// A Plonk proof, using the "fast prover" strategy described in the paper.
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct Proof {
     /// The commitments to the wire polynomials
     #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
@@ -130,7 +130,7 @@ pub struct Proof {
 }
 
 /// The proofs representing the matching and settlement of a trade
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct MatchProofs {
     /// Party 0's proof of `VALID COMMITMENTS`
     pub valid_commitments_0: Proof,
@@ -158,7 +158,7 @@ pub struct LinkingProof {
 
 /// The linking proofs used to ensure input consistency
 /// between the `MatchProofs`
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct MatchLinkingProofs {
     /// The proof of linked inputs between
     /// `PARTY 0 VALID REBLIND` <-> `PARTY 0 VALID COMMITMENTS`

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -13,7 +13,6 @@ serde_with = { workspace = true }
 
 
 [dev-dependencies]
-ark-poly = "0.4"
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-std = { workspace = true }

--- a/contracts-utils/Cargo.toml
+++ b/contracts-utils/Cargo.toml
@@ -21,6 +21,7 @@ jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { workspace = true }
 renegade-crypto = { workspace = true }
 circuit-types = { workspace = true }
+circuit-macros = { git = "https://github.com/renegade-fi/renegade.git" }
 circuits = { workspace = true }
 constants = { workspace = true }
 arbitrum-client = { workspace = true }

--- a/contracts-utils/src/constants.rs
+++ b/contracts-utils/src/constants.rs
@@ -1,0 +1,4 @@
+//! Constants used throughout the utilities
+
+/// The maximum degree to extract from any SRS for the dummy circuits
+pub const DUMMY_CIRCUIT_SRS_DEGREE: usize = 1024;

--- a/contracts-utils/src/lib.rs
+++ b/contracts-utils/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 
+mod constants;
 pub mod conversion;
 pub mod crypto;
 pub mod merkle;

--- a/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
+++ b/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
@@ -1,59 +1,202 @@
-//! Defines a mock circuit that is generic over the same statements as the Renegade
-//! protocol circuits, but is trivially satisfiable
+//! Defines mock circuits that expect the same statements & linking relationships
+//! as the Renegade protocol circuits, but are trivially satisfiable
 
-use core::marker::PhantomData;
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
+use circuit_macros::circuit_type;
 use circuit_types::{
-    traits::{CircuitBaseType, SingleProverCircuit},
+    traits::{BaseType, CircuitBaseType, CircuitVarType, SingleProverCircuit},
     PlonkCircuit,
 };
 use circuits::zk_circuits::{
     valid_commitments::ValidCommitmentsStatement,
     valid_match_settle::SizedValidMatchSettleStatement, valid_reblind::ValidReblindStatement,
     valid_wallet_create::SizedValidWalletCreateStatement,
-    valid_wallet_update::SizedValidWalletUpdateStatement,
+    valid_wallet_update::SizedValidWalletUpdateStatement, VALID_COMMITMENTS_MATCH_SETTLE_LINK0,
+    VALID_COMMITMENTS_MATCH_SETTLE_LINK1, VALID_REBLIND_COMMITMENTS_LINK,
 };
 
+use constants::Scalar;
+use contracts_common::types::ScalarField;
 use eyre::Result;
-
 use mpc_plonk::errors::PlonkError;
+use mpc_relation::{
+    proof_linking::{GroupLayout, LinkableCircuit},
+    traits::Circuit,
+    Variable,
+};
 
-/// A simple circuit that is trivially satisfiable in that it applies no constraints.
-///
-/// Defined generically over an application-level statement type.
-pub struct DummyCircuit<S: CircuitBaseType> {
-    #[doc(hidden)]
-    _phantom: PhantomData<S>,
-}
+/// The dummy version of the `VALID WALLET CREATE` circuit
+pub struct DummyValidWalletCreate;
 
-impl<S: CircuitBaseType> SingleProverCircuit for DummyCircuit<S> {
-    type Statement = S;
+impl SingleProverCircuit for DummyValidWalletCreate {
+    type Statement = SizedValidWalletCreateStatement;
     type Witness = ();
 
     fn name() -> String {
-        "Dummy Circuit".to_string()
+        "Dummy Valid Wallet Create".to_string()
     }
 
     fn apply_constraints(
         _witness_var: (),
-        _statement_var: <S as CircuitBaseType>::VarType,
+        _statement_var: <SizedValidWalletCreateStatement as CircuitBaseType>::VarType,
         _cs: &mut PlonkCircuit,
     ) -> Result<(), PlonkError> {
         Ok(())
     }
 }
 
-/// The dummy version of the `VALID WALLET CREATE` circuit
-pub type DummyValidWalletCreate = DummyCircuit<SizedValidWalletCreateStatement>;
-
 /// The dummy version of the `VALID WALLET UPDATE` circuit
-pub type DummyValidWalletUpdate = DummyCircuit<SizedValidWalletUpdateStatement>;
+pub struct DummyValidWalletUpdate;
+
+impl SingleProverCircuit for DummyValidWalletUpdate {
+    type Statement = SizedValidWalletUpdateStatement;
+    type Witness = ();
+
+    fn name() -> String {
+        "Dummy Valid Wallet Update".to_string()
+    }
+
+    fn apply_constraints(
+        _witness_var: (),
+        _statement_var: <SizedValidWalletUpdateStatement as CircuitBaseType>::VarType,
+        _cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError> {
+        Ok(())
+    }
+}
+
+/// The dummy version of the `VALID REBLIND` witness,
+/// which defines a single element to be linked with the dummy
+/// `VALID COMMITMENTS` circuit
+#[circuit_type(singleprover_circuit)]
+#[derive(Clone)]
+pub struct DummyValidReblindWitness {
+    /// The element to be linked with `VALID COMMITMENTS`
+    #[link_groups = "valid_reblind_commitments"]
+    pub valid_reblind_commitments: Scalar,
+}
 
 /// The dummy version of the `VALID REBLIND` circuit
-pub type DummyValidReblind = DummyCircuit<ValidReblindStatement>;
+pub struct DummyValidReblind;
+
+impl SingleProverCircuit for DummyValidReblind {
+    type Statement = ValidReblindStatement;
+    type Witness = DummyValidReblindWitness;
+
+    fn name() -> String {
+        "Dummy Valid Reblind".to_string()
+    }
+
+    fn apply_constraints(
+        _witness_var: <DummyValidReblindWitness as CircuitBaseType>::VarType,
+        _statement_var: <ValidReblindStatement as CircuitBaseType>::VarType,
+        _cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError> {
+        Ok(())
+    }
+
+    fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
+        Ok(vec![(VALID_REBLIND_COMMITMENTS_LINK.to_string(), None)])
+    }
+}
+
+/// The dummy version of the `VALID COMMITMENTS` witness,
+/// which defines a single element to be linked with the dummy
+/// `VALID REBLIND` circuit, and two elements to be linked with the dummy
+/// `VALID MATCH SETTLE` circuit depending on which party is settling
+#[circuit_type(singleprover_circuit)]
+#[derive(Clone)]
+pub struct DummyValidCommitmentsWitness {
+    /// The element to be linked with `VALID REBLIND`
+    #[link_groups = "valid_reblind_commitments"]
+    pub valid_reblind_commitments: Scalar,
+    /// The first element to be linked with `VALID MATCH SETTLE`
+    #[link_groups = "valid_commitments_match_settle0"]
+    pub valid_commitments_match_settle0: Scalar,
+    /// The second element to be linked with `VALID MATCH SETTLE`
+    #[link_groups = "valid_commitments_match_settle1"]
+    pub valid_commitments_match_settle1: Scalar,
+}
 
 /// The dummy version of the `VALID COMMITMENTS` circuit
-pub type DummyValidCommitments = DummyCircuit<ValidCommitmentsStatement>;
+pub struct DummyValidCommitments;
+
+impl SingleProverCircuit for DummyValidCommitments {
+    type Statement = ValidCommitmentsStatement;
+    type Witness = DummyValidCommitmentsWitness;
+
+    fn name() -> String {
+        "Dummy Valid Commitments".to_string()
+    }
+
+    fn apply_constraints(
+        _witness_var: <DummyValidCommitmentsWitness as CircuitBaseType>::VarType,
+        _statement_var: <ValidCommitmentsStatement as CircuitBaseType>::VarType,
+        _cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError> {
+        Ok(())
+    }
+
+    fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
+        let reblind_layout = DummyValidReblind::get_circuit_layout()?;
+        let layout1 = reblind_layout.get_group_layout(VALID_REBLIND_COMMITMENTS_LINK);
+
+        let match_settle_layout = DummyValidMatchSettle::get_circuit_layout()?;
+        let layout2 = match_settle_layout.get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK0);
+        let layout3 = match_settle_layout.get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK1);
+
+        Ok(vec![
+            (VALID_REBLIND_COMMITMENTS_LINK.to_string(), Some(layout1)),
+            (
+                VALID_COMMITMENTS_MATCH_SETTLE_LINK0.to_string(),
+                Some(layout2),
+            ),
+            (
+                VALID_COMMITMENTS_MATCH_SETTLE_LINK1.to_string(),
+                Some(layout3),
+            ),
+        ])
+    }
+}
+
+/// The dummy version of the `VALID MATCH SETTLE` witness,
+/// which defines two elements to be linked with the dummy
+/// `VALID COMMITMENTS` circuit depending on which party is settling
+#[circuit_type(singleprover_circuit)]
+#[derive(Clone)]
+pub struct DummyValidMatchSettleWitness {
+    /// The first element to be linked with `VALID COMMITMENTS`
+    #[link_groups = "valid_commitments_match_settle0"]
+    pub valid_commitments_match_settle0: Scalar,
+    /// The second element to be linked with `VALID COMMITMENTS`
+    #[link_groups = "valid_commitments_match_settle1"]
+    pub valid_commitments_match_settle1: Scalar,
+}
 
 /// The dummy version of the `VALID MATCH SETTLE` circuit
-pub type DummyValidMatchSettle = DummyCircuit<SizedValidMatchSettleStatement>;
+pub struct DummyValidMatchSettle;
+
+impl SingleProverCircuit for DummyValidMatchSettle {
+    type Statement = SizedValidMatchSettleStatement;
+    type Witness = DummyValidMatchSettleWitness;
+
+    fn name() -> String {
+        "Dummy Valid Match Settle".to_string()
+    }
+
+    fn apply_constraints(
+        _witness_var: <DummyValidMatchSettleWitness as CircuitBaseType>::VarType,
+        _statement_var: <SizedValidMatchSettleStatement as CircuitBaseType>::VarType,
+        _cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError> {
+        Ok(())
+    }
+
+    fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
+        Ok(vec![
+            (VALID_COMMITMENTS_MATCH_SETTLE_LINK0.to_string(), None),
+            (VALID_COMMITMENTS_MATCH_SETTLE_LINK1.to_string(), None),
+        ])
+    }
+}

--- a/contracts-utils/src/proof_system/test_circuit.rs
+++ b/contracts-utils/src/proof_system/test_circuit.rs
@@ -3,18 +3,13 @@
 use std::collections::HashMap;
 
 use arbitrum_client::conversion::to_contract_proof;
-use circuit_types::PlonkCircuit;
+use circuit_types::{PlonkCircuit, ProofLinkingHint};
 use constants::SystemCurve;
-use contracts_common::types::{
-    LinkingVerificationKey, Proof, PublicInputs, ScalarField, VerificationKey,
-};
+use contracts_common::types::{Proof, PublicInputs, ScalarField, VerificationKey};
 use eyre::Result;
 use jf_primitives::pcs::prelude::UnivariateUniversalParams;
 use mpc_plonk::{
-    proof_system::{
-        structs::{LinkingHint, ProvingKey},
-        PlonkKzgSnark, UniversalSNARK,
-    },
+    proof_system::{structs::ProvingKey, PlonkKzgSnark, UniversalSNARK},
     transcript::SolidityTranscript,
 };
 use mpc_relation::{
@@ -23,9 +18,13 @@ use mpc_relation::{
 };
 use rand::thread_rng;
 
-use crate::conversion::{to_contract_vkey, to_linking_vkey};
+use crate::conversion::to_contract_vkey;
+
+// TODO: Once the prove-verify flow with proof linking is implemented for `SingleProverCircuit`,
+// replace this with a dummy `SingleProverCircuit` a la `dummy_renegade_circuits`
 
 /// Encapsulates the information needed to add a link group to a circuit
+#[derive(Clone)]
 pub struct LinkGroupInfo {
     /// The elements of the link group
     pub linked_inputs: Vec<ScalarField>,
@@ -35,12 +34,12 @@ pub struct LinkGroupInfo {
     pub id: String,
 }
 
-/// The verification keys for a circuit
-pub struct CircuitVkeys {
+/// The data needed to verify a circuit's Plonk & linking proofs
+pub struct CircuitVerificationInfo {
     /// The Plonk verification key
     pub vkey: VerificationKey,
-    /// The linking verification keys
-    pub linking_vkeys: HashMap<String, LinkingVerificationKey>,
+    /// The link group layouts
+    pub layouts: HashMap<String, GroupLayout>,
 }
 
 /// Generates a proof for a trivially constrained circuit using the given SRS, public inputs, and
@@ -51,7 +50,7 @@ pub fn gen_test_circuit_proofs_and_vkeys(
     srs: &UnivariateUniversalParams<SystemCurve>,
     public_inputs: &PublicInputs,
     link_groups: &[LinkGroupInfo],
-) -> Result<(Proof, LinkingHint<SystemCurve>, CircuitVkeys)> {
+) -> Result<(Proof, ProofLinkingHint, CircuitVerificationInfo)> {
     let mut rng = thread_rng();
 
     let (circuit, pkey, circuit_vkeys) =
@@ -74,23 +73,23 @@ fn gen_test_circuit_and_keys(
     srs: &UnivariateUniversalParams<SystemCurve>,
     public_inputs: &PublicInputs,
     link_groups: &[LinkGroupInfo],
-) -> Result<(PlonkCircuit, ProvingKey<SystemCurve>, CircuitVkeys)> {
+) -> Result<(
+    PlonkCircuit,
+    ProvingKey<SystemCurve>,
+    CircuitVerificationInfo,
+)> {
     let circuit = gen_circuit(public_inputs, link_groups)?;
 
     let (pkey, jf_vkey) = PlonkKzgSnark::<SystemCurve>::preprocess(srs, &circuit)?;
     let vkey = to_contract_vkey(jf_vkey)?;
 
-    let mut linking_vkeys = HashMap::new();
+    let mut layouts = HashMap::new();
     for lg in link_groups {
         let layout = circuit.get_link_group_layout(&lg.id).unwrap();
-        let linking_vkey = to_linking_vkey(&layout);
-        linking_vkeys.insert(lg.id.clone(), linking_vkey);
+        layouts.insert(lg.id.clone(), layout);
     }
 
-    let circuit_vkeys = CircuitVkeys {
-        vkey,
-        linking_vkeys,
-    };
+    let circuit_vkeys = CircuitVerificationInfo { vkey, layouts };
 
     Ok((circuit, pkey, circuit_vkeys))
 }

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -7,21 +7,23 @@ use arbitrum_client::conversion::{
 };
 use ark_std::UniformRand;
 use circuit_types::{
-    keychain::PublicSigningKey, test_helpers::TESTING_SRS, traits::CircuitBaseType,
-    transfers::ExternalTransfer, PolynomialCommitment,
+    keychain::PublicSigningKey,
+    traits::{CircuitBaseType, SingleProverCircuit},
+    transfers::ExternalTransfer,
+    PolynomialCommitment, ProofLinkingHint,
 };
 use circuits::zk_circuits::{
     valid_commitments::ValidCommitmentsStatement,
     valid_match_settle::SizedValidMatchSettleStatement, valid_reblind::ValidReblindStatement,
     valid_wallet_create::SizedValidWalletCreateStatement,
-    valid_wallet_update::SizedValidWalletUpdateStatement,
+    valid_wallet_update::SizedValidWalletUpdateStatement, VALID_REBLIND_COMMITMENTS_LINK, VALID_COMMITMENTS_MATCH_SETTLE_LINK1, VALID_COMMITMENTS_MATCH_SETTLE_LINK0,
 };
 use constants::{Scalar, ScalarField, SystemCurve};
 use contracts_common::{
-    custom_serde::{BytesSerializable, ScalarSerializable},
+    custom_serde::BytesSerializable,
     types::{
-        G1Affine, MatchPayload, MatchProofs, MatchPublicInputs, MatchVkeys, Proof as ContractProof,
-        PublicInputs, ValidMatchSettleStatement as ContractValidMatchSettleStatement,
+        G1Affine, MatchLinkingProofs, MatchPayload, MatchProofs, Proof as ContractProof,
+        ValidMatchSettleStatement as ContractValidMatchSettleStatement,
         ValidWalletCreateStatement as ContractValidWalletCreateStatement,
         ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
     },
@@ -29,21 +31,29 @@ use contracts_common::{
 use contracts_core::crypto::poseidon::compute_poseidon_hash;
 use ethers::types::Bytes;
 use eyre::Result;
-use jf_primitives::pcs::prelude::{Commitment, UnivariateUniversalParams};
-use rand::{thread_rng, CryptoRng, Rng, RngCore};
+use jf_primitives::pcs::{
+    prelude::{Commitment, UnivariateUniversalParams},
+    StructuredReferenceString,
+};
+
+use mpc_plonk::{proof_system::PlonkKzgSnark, transcript::SolidityTranscript};
+use mpc_relation::proof_linking::GroupLayout;
+use rand::{CryptoRng, Rng, RngCore};
 use std::iter;
 
 use crate::{
-    conversion::to_circuit_pubkey,
+    constants::DUMMY_CIRCUIT_SRS_DEGREE,
+    conversion::{to_circuit_pubkey, to_contract_linking_proof},
     crypto::{hash_and_sign_message, random_keypair},
 };
 
 use super::{
     dummy_renegade_circuits::{
-        DummyValidCommitments, DummyValidMatchSettle, DummyValidReblind, DummyValidWalletCreate,
-        DummyValidWalletUpdate,
+        DummyValidCommitments, DummyValidCommitmentsWitness, DummyValidMatchSettle,
+        DummyValidMatchSettleWitness, DummyValidReblind, DummyValidReblindWitness,
+        DummyValidWalletCreate, DummyValidWalletUpdate,
     },
-    gen_circuit_vkey, prove_with_srs,
+    prove_with_srs,
 };
 
 /// Generates a vector of random scalars
@@ -56,9 +66,9 @@ pub fn random_commitments(n: usize, rng: &mut impl Rng) -> Vec<PolynomialCommitm
     (0..n).map(|_| Commitment(G1Affine::rand(rng))).collect()
 }
 
-/// Generates a statement type with random scalars
-pub fn dummy_statement<R: RngCore + CryptoRng, S: CircuitBaseType>(rng: &mut R) -> S {
-    S::from_scalars(&mut iter::repeat_with(|| Scalar::random(rng)))
+/// Generates a circuit type type with random scalars
+pub fn dummy_circuit_type<R: RngCore + CryptoRng, C: CircuitBaseType>(rng: &mut R) -> C {
+    C::from_scalars(&mut iter::repeat_with(|| Scalar::random(rng)))
 }
 
 /// Generates the inputs for the `new_wallet` darkpool method, namely
@@ -68,7 +78,7 @@ pub fn gen_new_wallet_data<R: CryptoRng + RngCore>(
     srs: &UnivariateUniversalParams<SystemCurve>,
 ) -> Result<(ContractProof, ContractValidWalletCreateStatement)> {
     // Generate dummy statement & proof
-    let statement: SizedValidWalletCreateStatement = dummy_statement(rng);
+    let statement: SizedValidWalletCreateStatement = dummy_circuit_type(rng);
     let (proof, _) = prove_with_srs::<DummyValidWalletCreate>(srs, (), statement.clone())?;
 
     // Convert the statement & proof types to the ones expected by the contract
@@ -121,161 +131,256 @@ pub fn gen_update_wallet_data<R: CryptoRng + RngCore>(
 /// The inputs for the `process_match_settle` darkpool method
 pub struct ProcessMatchSettleData {
     /// The first party's match payload
-    pub party_0_match_payload: MatchPayload,
-    /// The first party's `VALID COMMITMENTS` proof
-    pub party_0_valid_commitments_proof: ContractProof,
-    /// The first party's `VALID REBLIND` proof
-    pub party_0_valid_reblind_proof: ContractProof,
+    pub match_payload_0: MatchPayload,
     /// The second party's match payload
-    pub party_1_match_payload: MatchPayload,
-    /// The second party's `VALID COMMITMENTS` proof
-    pub party_1_valid_commitments_proof: ContractProof,
-    /// The second party's `VALID REBLIND` proof
-    pub party_1_valid_reblind_proof: ContractProof,
-    /// The `VALID MATCH SETTLE` proof
-    pub valid_match_settle_proof: ContractProof,
+    pub match_payload_1: MatchPayload,
     /// The `VALID MATCH SETTLE` statement
     pub valid_match_settle_statement: ContractValidMatchSettleStatement,
+    /// The Plonk proofs submitted to `process_match_settle`
+    pub match_proofs: MatchProofs,
+    /// The linking proofs submitted to `process_match_settle`
+    pub match_linking_proofs: MatchLinkingProofs,
 }
 
-/// Generates a dummy [`MatchPayload`] and associated proofs for the
-/// statements contained within it
-fn dummy_match_payload_and_proofs<R: CryptoRng + RngCore>(
+/// Generates dummy statements to be submitted to `process_match_settle`
+fn dummy_match_statements<R: CryptoRng + RngCore>(
     rng: &mut R,
-    srs: &UnivariateUniversalParams<SystemCurve>,
     merkle_root: Scalar,
-) -> eyre::Result<(MatchPayload, ContractProof, ContractProof)> {
-    let valid_commitments_statement: ValidCommitmentsStatement = dummy_statement(rng);
-    let valid_reblind_statement = dummy_valid_reblind_statement(rng, merkle_root);
+) -> (
+    [ValidCommitmentsStatement; 2],
+    [ValidReblindStatement; 2],
+    SizedValidMatchSettleStatement,
+) {
+    let valid_commitments0 = dummy_circuit_type(rng);
+    let valid_commitments1 = dummy_circuit_type(rng);
 
-    let (valid_commitments_proof, _) =
-        prove_with_srs::<DummyValidCommitments>(srs, (), valid_commitments_statement)?;
-    let (valid_reblind_proof, _) =
-        prove_with_srs::<DummyValidReblind>(srs, (), valid_reblind_statement.clone())?;
+    let valid_reblind0 = dummy_valid_reblind_statement(rng, merkle_root);
+    let valid_reblind1 = dummy_valid_reblind_statement(rng, merkle_root);
 
-    let contract_valid_commitments_statement =
-        to_contract_valid_commitments_statement(valid_commitments_statement);
-    let contract_valid_reblind_statement =
-        to_contract_valid_reblind_statement(&valid_reblind_statement);
+    let valid_match_settle = dummy_circuit_type(rng);
+
+    (
+        [valid_commitments0, valid_commitments1],
+        [valid_reblind0, valid_reblind1],
+        valid_match_settle,
+    )
+}
+
+/// Generates dummy witnesses to be used in the proofs submitted to `process_match_settle`
+fn dummy_match_witnesses<R: CryptoRng + RngCore>(
+    rng: &mut R,
+) -> (
+    [DummyValidCommitmentsWitness; 2],
+    [DummyValidReblindWitness; 2],
+    DummyValidMatchSettleWitness,
+) {
+    let valid_commitments0: DummyValidCommitmentsWitness = dummy_circuit_type(rng);
+    let valid_commitments1: DummyValidCommitmentsWitness = dummy_circuit_type(rng);
+
+    let valid_reblind0 = DummyValidReblindWitness {
+        valid_reblind_commitments: valid_commitments0.valid_reblind_commitments,
+    };
+    let valid_reblind1 = DummyValidReblindWitness {
+        valid_reblind_commitments: valid_commitments1.valid_reblind_commitments,
+    };
+
+    let valid_match_settle = DummyValidMatchSettleWitness {
+        valid_commitments_match_settle0: valid_commitments0.valid_commitments_match_settle0,
+        valid_commitments_match_settle1: valid_commitments1.valid_commitments_match_settle1,
+    };
+
+    (
+        [valid_commitments0, valid_commitments1],
+        [valid_reblind0, valid_reblind1],
+        valid_match_settle,
+    )
+}
+
+/// A type alias for the proofs and linking hints generated for the `process_match_settle` method
+type MatchProofsAndHints = (MatchProofs, [(ProofLinkingHint, ProofLinkingHint); 4]);
+
+/// Generates the proofs and linking hints to be submitted to `process_match_settle`
+fn match_proofs_and_hints(
+    srs: &UnivariateUniversalParams<SystemCurve>,
+    valid_commitments_statements: [ValidCommitmentsStatement; 2],
+    valid_commitments_witnesses: [DummyValidCommitmentsWitness; 2],
+    valid_reblind_statements: [ValidReblindStatement; 2],
+    valid_reblind_witnesses: [DummyValidReblindWitness; 2],
+    valid_match_settle_statement: SizedValidMatchSettleStatement,
+    valid_match_settle_witness: DummyValidMatchSettleWitness,
+) -> Result<MatchProofsAndHints> {
+    let (valid_commitments_0, valid_commitments_hint_0) = prove_with_srs::<DummyValidCommitments>(
+        srs,
+        valid_commitments_witnesses[0].clone(),
+        valid_commitments_statements[0],
+    )?;
+
+    let (valid_commitments_1, valid_commitments_hint_1) = prove_with_srs::<DummyValidCommitments>(
+        srs,
+        valid_commitments_witnesses[1].clone(),
+        valid_commitments_statements[1],
+    )?;
+
+    let (valid_reblind_0, valid_reblind_hint_0) = prove_with_srs::<DummyValidReblind>(
+        srs,
+        valid_reblind_witnesses[0].clone(),
+        valid_reblind_statements[0].clone(),
+    )?;
+
+    let (valid_reblind_1, valid_reblind_hint_1) = prove_with_srs::<DummyValidReblind>(
+        srs,
+        valid_reblind_witnesses[1].clone(),
+        valid_reblind_statements[1].clone(),
+    )?;
+
+    let (valid_match_settle, valid_match_settle_hint) = prove_with_srs::<DummyValidMatchSettle>(
+        srs,
+        valid_match_settle_witness.clone(),
+        valid_match_settle_statement.clone(),
+    )?;
 
     Ok((
-        MatchPayload {
-            valid_commitments_statement: contract_valid_commitments_statement,
-            valid_reblind_statement: contract_valid_reblind_statement,
+        MatchProofs {
+            valid_commitments_0,
+            valid_commitments_1,
+            valid_reblind_0,
+            valid_reblind_1,
+            valid_match_settle,
         },
-        valid_commitments_proof,
-        valid_reblind_proof,
+        [
+            (valid_reblind_hint_0, valid_commitments_hint_0.clone()),
+            (valid_reblind_hint_1, valid_commitments_hint_1.clone()),
+            (valid_commitments_hint_0, valid_match_settle_hint.clone()),
+            (valid_commitments_hint_1, valid_match_settle_hint),
+        ],
     ))
 }
 
-/// Generates the inputs for the `process_match_settle` darkpool method,
-/// listed out in the [`ProcessMatchSettleData`] struct
+/// Generates the group layouts for the linked circuits involved in settling a matched trade
+pub fn gen_match_layouts() -> Result<[GroupLayout; 3]> {
+    let valid_commitments_layout = DummyValidCommitments::get_circuit_layout()?;
+
+    let valid_reblind_commitments_layout =
+        valid_commitments_layout.get_group_layout(VALID_REBLIND_COMMITMENTS_LINK);
+
+    let valid_commitments_match_settle_0_layout = valid_commitments_layout
+        .get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK0);
+
+    let valid_commitments_match_settle_1_layout = valid_commitments_layout
+        .get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK1);
+
+    Ok([
+        valid_reblind_commitments_layout,
+        valid_commitments_match_settle_0_layout,
+        valid_commitments_match_settle_1_layout,
+    ])
+}
+
+/// Generates the linking proofs to be submitted to `process_match_settle`
+fn match_link_proofs(
+    srs: &UnivariateUniversalParams<SystemCurve>,
+    link_hints: [(ProofLinkingHint, ProofLinkingHint); 4],
+) -> Result<MatchLinkingProofs> {
+    let commit_key = srs.extract_prover_param(DUMMY_CIRCUIT_SRS_DEGREE);
+
+    let [valid_reblind_commitments_layout, valid_commitments_match_settle_0_layout, valid_commitments_match_settle_1_layout] =
+        gen_match_layouts()?;
+
+    let (valid_reblind_hint_0, valid_commitments_hint_0) = &link_hints[0];
+    let valid_reblind_commitments_0 =
+        to_contract_linking_proof(PlonkKzgSnark::<SystemCurve>::link_proofs::<
+            SolidityTranscript,
+        >(
+            valid_reblind_hint_0,
+            valid_commitments_hint_0,
+            &valid_reblind_commitments_layout,
+            &commit_key,
+        )?);
+
+    let (valid_reblind_hint_1, valid_commitments_hint_1) = &link_hints[1];
+    let valid_reblind_commitments_1 =
+        to_contract_linking_proof(PlonkKzgSnark::<SystemCurve>::link_proofs::<
+            SolidityTranscript,
+        >(
+            valid_reblind_hint_1,
+            valid_commitments_hint_1,
+            &valid_reblind_commitments_layout,
+            &commit_key,
+        )?);
+
+    let (valid_commitments_hint_0, valid_match_settle_hint_0) = &link_hints[2];
+    let valid_commitments_match_settle_0 =
+        to_contract_linking_proof(PlonkKzgSnark::<SystemCurve>::link_proofs::<
+            SolidityTranscript,
+        >(
+            valid_commitments_hint_0,
+            valid_match_settle_hint_0,
+            &valid_commitments_match_settle_0_layout,
+            &commit_key,
+        )?);
+
+    let (valid_commitments_hint_1, valid_match_settle_hint_1) = &link_hints[3];
+    let valid_commitments_match_settle_1 =
+        to_contract_linking_proof(PlonkKzgSnark::<SystemCurve>::link_proofs::<
+            SolidityTranscript,
+        >(
+            valid_commitments_hint_1,
+            valid_match_settle_hint_1,
+            &valid_commitments_match_settle_1_layout,
+            &commit_key,
+        )?);
+
+    Ok(MatchLinkingProofs {
+        valid_reblind_commitments_0,
+        valid_reblind_commitments_1,
+        valid_commitments_match_settle_0,
+        valid_commitments_match_settle_1,
+    })
+}
+
+/// Generates the data to be submitted to `process_match_settle`
 pub fn gen_process_match_settle_data<R: CryptoRng + RngCore>(
     rng: &mut R,
     srs: &UnivariateUniversalParams<SystemCurve>,
     merkle_root: Scalar,
-) -> eyre::Result<ProcessMatchSettleData> {
-    let (party_0_match_payload, party_0_valid_commitments_proof, party_0_valid_reblind_proof) =
-        dummy_match_payload_and_proofs(rng, srs, merkle_root)?;
-    let (party_1_match_payload, party_1_valid_commitments_proof, party_1_valid_reblind_proof) =
-        dummy_match_payload_and_proofs(rng, srs, merkle_root)?;
+) -> Result<ProcessMatchSettleData> {
+    let (valid_commitments_statements, valid_reblind_statements, valid_match_settle_statement) =
+        dummy_match_statements(rng, merkle_root);
+    let (valid_commitments_witnesses, valid_reblind_witnesses, valid_match_settle_witness) =
+        dummy_match_witnesses(rng);
+    let (match_proofs, link_hints) = match_proofs_and_hints(
+        srs,
+        valid_commitments_statements,
+        valid_commitments_witnesses,
+        valid_reblind_statements.clone(),
+        valid_reblind_witnesses.clone(),
+        valid_match_settle_statement.clone(),
+        valid_match_settle_witness.clone(),
+    )?;
+    let match_linking_proofs = match_link_proofs(srs, link_hints)?;
 
-    let valid_match_settle_statement: SizedValidMatchSettleStatement = dummy_statement(rng);
-    let (valid_match_settle_proof, _) =
-        prove_with_srs::<DummyValidMatchSettle>(srs, (), valid_match_settle_statement.clone())?;
-
-    let contract_valid_match_settle_statement =
-        to_contract_valid_match_settle_statement(&valid_match_settle_statement);
+    let match_payload_0 = MatchPayload {
+        valid_commitments_statement: to_contract_valid_commitments_statement(
+            valid_commitments_statements[0],
+        ),
+        valid_reblind_statement: to_contract_valid_reblind_statement(&valid_reblind_statements[0]),
+    };
+    let match_payload_1 = MatchPayload {
+        valid_commitments_statement: to_contract_valid_commitments_statement(
+            valid_commitments_statements[1],
+        ),
+        valid_reblind_statement: to_contract_valid_reblind_statement(&valid_reblind_statements[1]),
+    };
 
     Ok(ProcessMatchSettleData {
-        party_0_match_payload,
-        party_0_valid_commitments_proof,
-        party_0_valid_reblind_proof,
-        party_1_match_payload,
-        party_1_valid_commitments_proof,
-        party_1_valid_reblind_proof,
-        valid_match_settle_proof,
-        valid_match_settle_statement: contract_valid_match_settle_statement,
+        match_payload_0,
+        match_payload_1,
+        valid_match_settle_statement: to_contract_valid_match_settle_statement(
+            &valid_match_settle_statement,
+        ),
+        match_proofs,
+        match_linking_proofs,
     })
-}
-
-/// Generates the bundle of inputs expected by the verifier in its `verify_match` method
-pub fn generate_match_bundle() -> Result<(MatchVkeys, MatchProofs, MatchPublicInputs)> {
-    let mut rng = thread_rng();
-
-    // Generate random `process_match_settle` test data & destructure
-    let merkle_root = Scalar::random(&mut rng);
-    let ProcessMatchSettleData {
-        party_0_match_payload:
-            MatchPayload {
-                valid_commitments_statement: party_0_valid_commitments_statement,
-                valid_reblind_statement: party_0_valid_reblind_statement,
-            },
-        party_0_valid_commitments_proof,
-        party_0_valid_reblind_proof,
-        party_1_match_payload:
-            MatchPayload {
-                valid_commitments_statement: party_1_valid_commitments_statement,
-                valid_reblind_statement: party_1_valid_reblind_statement,
-            },
-        party_1_valid_commitments_proof,
-        party_1_valid_reblind_proof,
-        valid_match_settle_statement,
-        valid_match_settle_proof,
-    } = gen_process_match_settle_data(&mut rng, &TESTING_SRS, merkle_root)?;
-
-    // Generate verification keys for each circuit
-    let valid_commitments_vkey = gen_circuit_vkey::<DummyValidCommitments>(&TESTING_SRS)?;
-    let valid_reblind_vkey = gen_circuit_vkey::<DummyValidReblind>(&TESTING_SRS)?;
-    let valid_match_settle_vkey = gen_circuit_vkey::<DummyValidMatchSettle>(&TESTING_SRS)?;
-
-    let match_vkeys = MatchVkeys {
-        valid_commitments_vkey,
-        valid_reblind_vkey,
-        valid_match_settle_vkey,
-    };
-
-    let match_proofs = MatchProofs {
-        valid_commitments_0: party_0_valid_commitments_proof,
-        valid_reblind_0: party_0_valid_reblind_proof,
-        valid_commitments_1: party_1_valid_commitments_proof,
-        valid_reblind_1: party_1_valid_reblind_proof,
-        valid_match_settle: valid_match_settle_proof,
-    };
-
-    // Convert all statements to public inputs
-    let valid_commitments_0_public_inputs = PublicInputs(
-        party_0_valid_commitments_statement
-            .serialize_to_scalars()
-            .unwrap(),
-    );
-    let valid_reblind_0_public_inputs = PublicInputs(
-        party_0_valid_reblind_statement
-            .serialize_to_scalars()
-            .unwrap(),
-    );
-    let valid_commitments_1_public_inputs = PublicInputs(
-        party_1_valid_commitments_statement
-            .serialize_to_scalars()
-            .unwrap(),
-    );
-    let valid_reblind_1_public_inputs = PublicInputs(
-        party_1_valid_reblind_statement
-            .serialize_to_scalars()
-            .unwrap(),
-    );
-    let valid_match_settle_public_inputs =
-        PublicInputs(valid_match_settle_statement.serialize_to_scalars().unwrap());
-
-    let match_public_inputs = MatchPublicInputs {
-        valid_commitments_0: valid_commitments_0_public_inputs,
-        valid_reblind_0: valid_reblind_0_public_inputs,
-        valid_commitments_1: valid_commitments_1_public_inputs,
-        valid_reblind_1: valid_reblind_1_public_inputs,
-        valid_match_settle: valid_match_settle_public_inputs,
-    };
-
-    Ok((match_vkeys, match_proofs, match_public_inputs))
 }
 
 /// Generates a dummy [`SizedValidWalletUpdateStatement`] with the given
@@ -289,10 +394,10 @@ pub fn dummy_valid_wallet_update_statement<R: RngCore + CryptoRng>(
     // We have to individually generate each field of the statement,
     // since creating a dummy `ExternalTransfer` from random scalars will panic
     // due to an invalid value for `ExternalTransferDirection`
-    let old_shares_nullifier = dummy_statement(rng);
-    let new_private_shares_commitment = dummy_statement(rng);
-    let new_public_shares = dummy_statement(rng);
-    let timestamp = dummy_statement(rng);
+    let old_shares_nullifier = dummy_circuit_type(rng);
+    let new_private_shares_commitment = dummy_circuit_type(rng);
+    let new_public_shares = dummy_circuit_type(rng);
+    let timestamp = dummy_circuit_type(rng);
 
     SizedValidWalletUpdateStatement {
         external_transfer,
@@ -312,6 +417,6 @@ pub fn dummy_valid_reblind_statement<R: RngCore + CryptoRng>(
 ) -> ValidReblindStatement {
     ValidReblindStatement {
         merkle_root,
-        ..dummy_statement(rng)
+        ..dummy_circuit_type(rng)
     }
 }


### PR DESCRIPTION
This PR refactors the testing utilities to generate match-settle test data, including linking proofs, using the dummy Renegade circuits which implement `SingleProverCircuit`. This meant adding dummy witness types to the circuits, so that witnesses could be linked, removing much of the proof linking test data generation code, and some other DRYing up and moving code around.

**Testing:**
All unit tests pass. A unit tests for an entire match bundle (Plonk & linking proofs), as well as updating the verifier and `process_match_settle` integration tests, is deferred for a future PR.