### PR TITLE
scripts: generate linking verification keys

### DIFF
--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -821,7 +821,7 @@ mod tests {
                 DummyValidCommitments, DummyValidCommitmentsWitness, DummyValidMatchSettle,
                 DummyValidReblind, DummyValidReblindWitness, DummyValidWalletCreate,
             },
-            gen_circuit_vkey, gen_match_linking_vkeys, prove_with_srs,
+            gen_circuit_vkey, gen_match_linking_vkeys, gen_match_vkeys, prove_with_srs,
             test_data::{
                 dummy_circuit_type, gen_process_match_settle_data, ProcessMatchSettleData,
             },
@@ -931,21 +931,6 @@ mod tests {
         )
     }
 
-    /// Generate the verification keys for the circuits verified in `verify_match`
-    fn gen_match_vkeys() -> MatchVkeys {
-        let valid_commitments_vkey =
-            gen_circuit_vkey::<DummyValidCommitments>(&TESTING_SRS).unwrap();
-        let valid_reblind_vkey = gen_circuit_vkey::<DummyValidReblind>(&TESTING_SRS).unwrap();
-        let valid_match_settle_vkey =
-            gen_circuit_vkey::<DummyValidMatchSettle>(&TESTING_SRS).unwrap();
-
-        MatchVkeys {
-            valid_commitments_vkey,
-            valid_reblind_vkey,
-            valid_match_settle_vkey,
-        }
-    }
-
     /// Extract the public inputs from the [`ProcessMatchSettleData`] test data struct
     fn extract_match_public_inputs(data: &ProcessMatchSettleData) -> MatchPublicInputs {
         MatchPublicInputs {
@@ -980,7 +965,10 @@ mod tests {
         let merkle_root = Scalar::random(&mut rng);
         let data = gen_process_match_settle_data(&mut rng, &TESTING_SRS, merkle_root).unwrap();
 
-        let match_vkeys = gen_match_vkeys();
+        let match_vkeys =
+            gen_match_vkeys::<DummyValidCommitments, DummyValidReblind, DummyValidMatchSettle>(
+                &TESTING_SRS,
+            ).unwrap();
         let match_proofs = data.match_proofs;
         let match_public_inputs = extract_match_public_inputs(&data);
 

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -821,10 +821,9 @@ mod tests {
                 DummyValidCommitments, DummyValidCommitmentsWitness, DummyValidMatchSettle,
                 DummyValidReblind, DummyValidReblindWitness, DummyValidWalletCreate,
             },
-            gen_circuit_vkey, prove_with_srs,
+            gen_circuit_vkey, gen_match_linking_vkeys, prove_with_srs,
             test_data::{
-                dummy_circuit_type, gen_match_layouts, gen_process_match_settle_data,
-                ProcessMatchSettleData,
+                dummy_circuit_type, gen_process_match_settle_data, ProcessMatchSettleData,
             },
         },
     };
@@ -947,22 +946,6 @@ mod tests {
         }
     }
 
-    /// Generate the linking verification keys for the link groups verified in `verify_match`
-    fn gen_match_linking_vkeys() -> MatchLinkingVkeys {
-        let [valid_reblind_commitments_layout, valid_commitments_match_settle_0_layout, valid_commitments_match_settle_1_layout] =
-            gen_match_layouts().unwrap();
-
-        MatchLinkingVkeys {
-            valid_reblind_commitments: to_linking_vkey(&valid_reblind_commitments_layout),
-            valid_commitments_match_settle_0: to_linking_vkey(
-                &valid_commitments_match_settle_0_layout,
-            ),
-            valid_commitments_match_settle_1: to_linking_vkey(
-                &valid_commitments_match_settle_1_layout,
-            ),
-        }
-    }
-
     /// Extract the public inputs from the [`ProcessMatchSettleData`] test data struct
     fn extract_match_public_inputs(data: &ProcessMatchSettleData) -> MatchPublicInputs {
         MatchPublicInputs {
@@ -1001,7 +984,7 @@ mod tests {
         let match_proofs = data.match_proofs;
         let match_public_inputs = extract_match_public_inputs(&data);
 
-        let match_linking_vkeys = gen_match_linking_vkeys();
+        let match_linking_vkeys = gen_match_linking_vkeys::<DummyValidCommitments>().unwrap();
         let match_linking_proofs = data.match_linking_proofs;
         let match_linking_wire_poly_comms = MatchLinkingWirePolyComms {
             valid_reblind_0: match_proofs.valid_reblind_0.wire_comms[0],

--- a/contracts-utils/src/proof_system/mod.rs
+++ b/contracts-utils/src/proof_system/mod.rs
@@ -12,17 +12,21 @@ use circuit_types::{
     traits::{BaseType, CircuitBaseType, SingleProverCircuit},
     PlonkCircuit, ProofLinkingHint,
 };
+use circuits::zk_circuits::{
+    VALID_COMMITMENTS_MATCH_SETTLE_LINK0, VALID_COMMITMENTS_MATCH_SETTLE_LINK1,
+    VALID_REBLIND_COMMITMENTS_LINK,
+};
 use constants::{Scalar, SystemCurve};
-use contracts_common::types::{Proof, VerificationKey};
+use contracts_common::types::{MatchLinkingVkeys, Proof, VerificationKey};
 use jf_primitives::pcs::prelude::UnivariateUniversalParams;
 use mpc_plonk::{
     proof_system::{PlonkKzgSnark, UniversalSNARK},
     transcript::SolidityTranscript,
 };
-use mpc_relation::proof_linking::LinkableCircuit;
+use mpc_relation::proof_linking::{GroupLayout, LinkableCircuit};
 use rand::thread_rng;
 
-use crate::conversion::to_contract_vkey;
+use crate::conversion::{to_contract_vkey, to_linking_vkey};
 
 pub mod dummy_renegade_circuits;
 pub mod test_data;
@@ -64,6 +68,59 @@ pub fn gen_circuit_vkey<C: SingleProverCircuit>(
         PlonkKzgSnark::<SystemCurve>::preprocess(srs, &cs).map_err(ProverError::Plonk)?;
 
     to_contract_vkey(jf_vkey).map_err(Into::into)
+}
+
+/// The link group layouts involved in settling a matched trade
+pub struct MatchGroupLayouts {
+    /// The `VALID REBLIND` <-> `VALID COMMITMENTS` link group layout
+    pub valid_reblind_commitments: GroupLayout,
+    /// The first party's `VALID COMMITMENTS` <-> `VALID MATCH SETTLE` link group layout
+    pub valid_commitments_match_settle_0: GroupLayout,
+    /// The second party's `VALID COMMITMENTS` <-> `VALID MATCH SETTLE` link group layout
+    pub valid_commitments_match_settle_1: GroupLayout,
+}
+
+/// Generates the group layouts for the linked circuits involved in settling a matched trade.
+///
+/// Defined generically over the `VALID COMMITMENTS` circuit, so that this can be used in both
+/// the testing and production setting.
+pub fn gen_match_layouts<C: SingleProverCircuit>() -> Result<MatchGroupLayouts, ProofSystemError> {
+    let valid_commitments_layout = C::get_circuit_layout()
+        .map_err(|e| ProofSystemError::ProverError(ProverError::Plonk(e)))?;
+
+    let valid_reblind_commitments =
+        valid_commitments_layout.get_group_layout(VALID_REBLIND_COMMITMENTS_LINK);
+
+    let valid_commitments_match_settle_0 =
+        valid_commitments_layout.get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK0);
+
+    let valid_commitments_match_settle_1 =
+        valid_commitments_layout.get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK1);
+
+    Ok(MatchGroupLayouts {
+        valid_reblind_commitments,
+        valid_commitments_match_settle_0,
+        valid_commitments_match_settle_1,
+    })
+}
+
+/// Generates the linking verification keys for the linked circuits involved in settling a matched trade.
+///
+/// Defined generically over the `VALID COMMITMENTS` circuit, so that this can be used in both
+/// the testing and production setting.
+pub fn gen_match_linking_vkeys<C: SingleProverCircuit>(
+) -> Result<MatchLinkingVkeys, ProofSystemError> {
+    let MatchGroupLayouts {
+        valid_reblind_commitments,
+        valid_commitments_match_settle_0,
+        valid_commitments_match_settle_1,
+    } = gen_match_layouts::<C>()?;
+
+    Ok(MatchLinkingVkeys {
+        valid_reblind_commitments: to_linking_vkey(&valid_reblind_commitments),
+        valid_commitments_match_settle_0: to_linking_vkey(&valid_commitments_match_settle_0),
+        valid_commitments_match_settle_1: to_linking_vkey(&valid_commitments_match_settle_1),
+    })
 }
 
 /// Generates a proof and linking hint for a circuit using the given SRS, statement, and witness


### PR DESCRIPTION
This PR updates the `gen-vkeys` script to also generate the linking verification keys used in verification downstream of `process_match_settle`, and serializes them together with the Plonk verification keys used.

This way, the same `process_match_vkeys` call to the `VkeysContract` will return all of the verification keys needed, in the serialization expected by the `VerifierContract`.

**Testing:**
Integration tests are not yet updated, this is saved for a future PR.