### PR TITLE
contracts-stylus: darkpool: restructure process_match_settle arguments

### DIFF
--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         ExternalTransfer, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256,
         PublicSigningKey, ScalarField, ValidCommitmentsStatement, ValidMatchSettleStatement,
-        ValidReblindStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
+        ValidReblindStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement, PublicInputs,
     },
 };
 
@@ -365,6 +365,11 @@ pub fn pk_to_scalars(pk: &PublicSigningKey) -> Vec<ScalarField> {
     scalars.extend(pk.x);
     scalars.extend(pk.y);
     scalars
+}
+
+/// Serializes a statement type into a vector of `[ScalarField]` and wraps it in a [`PublicInputs`]
+pub fn statement_to_public_inputs<S: ScalarSerializable>(statement: &S) -> PublicInputs {
+    PublicInputs(statement.serialize_to_scalars().unwrap())
 }
 
 #[cfg(test)]

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -49,13 +49,10 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         public_inputs: PublicInputs,
     ) -> Result<bool, VerifierError> {
         // Prepare Plonk proofs for batch verification
-        let opening_elems = Self::prep_batch_plonk_proofs_opening(&[vkey], &[proof], &[public_inputs])?;
+        let opening_elems =
+            Self::prep_batch_plonk_proofs_opening(&[vkey], &[proof], &[public_inputs])?;
 
-        Self::batch_opening(
-            &opening_elems,
-            vkey.x_h,
-            vkey.h,
-        )
+        Self::batch_opening(&opening_elems, vkey.x_h, vkey.h)
     }
 
     /// Batch-verifies:
@@ -769,6 +766,7 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 mod tests {
     use core::result::Result;
 
+    use alloc::vec;
     use ark_bn254::Bn254;
     use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
     use ark_ff::One;
@@ -778,14 +776,14 @@ mod tests {
     use constants::SystemCurve;
     use contracts_common::{
         backends::G1ArithmeticError,
+        custom_serde::statement_to_public_inputs,
         types::{
-            G1Affine, G2Affine, LinkingProof, LinkingVerificationKey, MatchOpeningElems,
-            ScalarField,
+            G1Affine, G2Affine, LinkingProof, LinkingVerificationKey, OpeningElems, ScalarField,
         },
     };
     use contracts_utils::{
         constants::DUMMY_CIRCUIT_SRS_DEGREE,
-        conversion::{statement_to_public_inputs, to_contract_linking_proof, to_linking_vkey},
+        conversion::{to_contract_linking_proof, to_linking_vkey},
         crypto::NativeHasher,
         proof_system::{
             dummy_renegade_circuits::{
@@ -939,12 +937,13 @@ mod tests {
             match_public_inputs.valid_match_settle,
         ];
 
-        let opening_elems = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_batch_plonk_proofs_opening(
-            &vkey_batch,
-            &proof_batch,
-            &public_inputs_batch,
-        )
-        .unwrap();
+        let opening_elems =
+            Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_batch_plonk_proofs_opening(
+                &vkey_batch,
+                &proof_batch,
+                &public_inputs_batch,
+            )
+            .unwrap();
 
         // Verify Plonk proofs batch opening
         let result = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::batch_opening(
@@ -988,12 +987,13 @@ mod tests {
             match_public_inputs.valid_match_settle,
         ];
 
-        let opening_elems = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_batch_plonk_proofs_opening(
-            &vkey_batch,
-            &proof_batch,
-            &public_inputs_batch,
-        )
-        .unwrap();
+        let opening_elems =
+            Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_batch_plonk_proofs_opening(
+                &vkey_batch,
+                &proof_batch,
+                &public_inputs_batch,
+            )
+            .unwrap();
 
         // Verify Plonk proofs batch opening
         let result = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::batch_opening(
@@ -1085,12 +1085,13 @@ mod tests {
             generate_match_bundle(&mut rng, &TESTING_SRS).unwrap();
 
         // Prep linking proof opening elements
-        let opening_elems = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_match_linking_proofs_opening(
-            match_linking_vkeys,
-            match_linking_proofs,
-            match_linking_wire_poly_comms,
-        )
-        .unwrap();
+        let opening_elems =
+            Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_match_linking_proofs_opening(
+                match_linking_vkeys,
+                match_linking_proofs,
+                match_linking_wire_poly_comms,
+            )
+            .unwrap();
 
         // Verify linking proofs batch opening
         let result = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::batch_opening(
@@ -1113,12 +1114,13 @@ mod tests {
         mutate_random_linking_proof(&mut rng, &mut match_linking_proofs);
 
         // Prep linking proof opening elements
-        let opening_elems = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_match_linking_proofs_opening(
-            match_linking_vkeys,
-            match_linking_proofs,
-            match_linking_wire_poly_comms,
-        )
-        .unwrap();
+        let opening_elems =
+            Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_match_linking_proofs_opening(
+                match_linking_vkeys,
+                match_linking_proofs,
+                match_linking_wire_poly_comms,
+            )
+            .unwrap();
 
         // Verify linking proofs batch opening
         let result = Verifier::<ArkG1ArithmeticBackend, NativeHasher>::batch_opening(

--- a/contracts-utils/src/conversion.rs
+++ b/contracts-utils/src/conversion.rs
@@ -6,12 +6,9 @@ use circuit_types::{
     PlonkLinkProof, PolynomialCommitment,
 };
 use constants::{Scalar, SystemCurve};
-use contracts_common::{
-    custom_serde::ScalarSerializable,
-    types::{
-        G1Affine, LinkingProof as ContractLinkingProof, LinkingVerificationKey, PublicInputs,
-        PublicSigningKey as ContractPublicSigningKey, VerificationKey,
-    },
+use contracts_common::types::{
+    G1Affine, LinkingProof as ContractLinkingProof, LinkingVerificationKey,
+    PublicSigningKey as ContractPublicSigningKey, VerificationKey,
 };
 use mpc_plonk::proof_system::structs::VerifyingKey;
 use mpc_relation::proof_linking::GroupLayout;
@@ -88,9 +85,4 @@ pub fn to_circuit_pubkey(contract_pubkey: ContractPublicSigningKey) -> CircuitPu
     };
 
     CircuitPublicSigningKey { x, y }
-}
-
-/// Serializes a statement type into a vector of `[ScalarField]` and wraps it in a [`PublicInputs`]
-pub fn statement_to_public_inputs<S: ScalarSerializable>(statement: &S) -> PublicInputs {
-    PublicInputs(statement.serialize_to_scalars().unwrap())
 }

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -19,7 +19,7 @@ use circuits::zk_circuits::{
 };
 use constants::{Scalar, ScalarField, SystemCurve};
 use contracts_common::{
-    custom_serde::BytesSerializable,
+    custom_serde::{BytesSerializable, statement_to_public_inputs},
     types::{
         G1Affine, MatchLinkingProofs, MatchLinkingVkeys, MatchLinkingWirePolyComms, MatchPayload,
         MatchProofs, MatchPublicInputs, MatchVkeys, Proof as ContractProof,
@@ -42,7 +42,7 @@ use std::iter;
 
 use crate::{
     constants::DUMMY_CIRCUIT_SRS_DEGREE,
-    conversion::{statement_to_public_inputs, to_circuit_pubkey, to_contract_linking_proof},
+    conversion::{to_circuit_pubkey, to_contract_linking_proof},
     crypto::{hash_and_sign_message, random_keypair},
 };
 

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -25,7 +25,7 @@ abigen!(
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
-        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes) external
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         function markNullifierSpent(uint256 memory nullifier) external
         function executeExternalTransfer(bytes memory transfer) external
@@ -48,7 +48,7 @@ abigen!(
     VerifierContract,
     r#"[
         function verify(bytes memory verification_bundle) external view returns (bool)
-        function verifyMatch(bytes memory match_bundle) external view returns (bool)
+    function verifyMatch(bytes memory match_bundle) external view returns (bool)
     ]"#
 );
 

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -9,12 +9,12 @@ use contracts_common::{
         MERKLE_ADDRESS_SELECTOR, TEST_MERKLE_HEIGHT, VERIFIER_ADDRESS_SELECTOR,
         VKEYS_ADDRESS_SELECTOR,
     },
+    custom_serde::statement_to_public_inputs,
     serde_def_types::{SerdeG1Affine, SerdeG2Affine, SerdeScalarField},
     types::{G1Affine, G2Affine, ScalarField},
 };
 use contracts_core::crypto::{ecdsa::pubkey_to_address, poseidon::compute_poseidon_hash};
 use contracts_utils::{
-    conversion::statement_to_public_inputs,
     crypto::{hash_and_sign_message, random_keypair, NativeHasher},
     merkle::new_ark_merkle_tree,
     proof_system::test_data::{


### PR DESCRIPTION
This PR tweaks the interface of the `process_match_settle` method on the `DarkpoolContract` to expect serializations of the more ergonomic `MatchProofs` and `MatchLinkingProofs` structs. These are what's expected by the verifier, as well, allowing them to be passed through without any re-serialization.

`process_match_settle` integration tests will be updated in the next PR.