### PR TITLE
scripts, integration: deploy all contracts, run all tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,8 @@ dependencies = [
  "scripts",
  "serde",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -26,3 +26,5 @@ constants = { workspace = true }
 arbitrum-client = { workspace = true }
 jf-primitives = { workspace = true }
 itertools = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -48,7 +48,7 @@ abigen!(
     VerifierContract,
     r#"[
         function verify(bytes memory verification_bundle) external view returns (bool)
-    function verifyMatch(bytes memory match_bundle) external view returns (bool)
+        function verifyMatch(bytes memory match_bundle) external view returns (bool)
     ]"#
 );
 
@@ -65,8 +65,13 @@ abigen!(
 abigen!(
     DummyErc20Contract,
     r#"[
+        function totalSupply() external view returns (uint256)
+        function balanceOf(address account) external view returns (uint256)
         function mint(address memory _address, uint256 memory value) external
-        function balanceOf(address memory _address) external view returns (uint256)
+        function transfer(address to, uint256 value) external returns (bool)
+        function allowance(address owner, address spender) external view returns (uint256)
+        function approve(address spender, uint256 value) external returns (bool)
+        function transferFrom(address from, address to, uint256 value) external returns (bool)
     ]"#
 );
 

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -32,6 +32,8 @@ pub(crate) struct Cli {
 /// The possible test cases
 #[derive(ValueEnum, Clone, Copy)]
 pub(crate) enum Tests {
+    /// Run all of the integration tests
+    All,
     /// Test how the contracts call the `ecAdd` precompile
     EcAdd,
     /// Test how the contracts call the `ecMul` precompile

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -3,18 +3,14 @@
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 
-use abis::{
-    DarkpoolProxyAdminContract, DarkpoolTestContract, DummyErc20Contract, MerkleContract,
-    PrecompileTestContract, VerifierContract,
-};
 use clap::Parser;
 use cli::{Cli, Tests};
 use eyre::Result;
 use scripts::{
     constants::{
-        DARKPOOL_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, DUMMY_ERC20_CONTRACT_KEY,
-        DUMMY_UPGRADE_TARGET_CONTRACT_KEY, MERKLE_CONTRACT_KEY, VERIFIER_CONTRACT_KEY,
-        VKEYS_CONTRACT_KEY,
+        DARKPOOL_CONTRACT_KEY, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY,
+        DUMMY_ERC20_CONTRACT_KEY, DUMMY_UPGRADE_TARGET_CONTRACT_KEY, MERKLE_CONTRACT_KEY,
+        PRECOMPILE_TEST_CONTRACT_KEY, VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
     },
     utils::{parse_addr_from_deployments_file, parse_srs_from_file, setup_client},
 };
@@ -24,7 +20,6 @@ use tests::{
     test_nullifier_set, test_ownable, test_pausable, test_process_match_settle, test_update_wallet,
     test_upgradeable, test_verifier,
 };
-use utils::get_test_contract_address;
 
 mod abis;
 mod cli;
@@ -42,132 +37,117 @@ async fn main() -> Result<()> {
         rpc_url,
     } = Cli::parse();
 
+    tracing_subscriber::fmt().pretty().init();
+
     let client = setup_client(&priv_key, &rpc_url).await?;
-    let contract_address = get_test_contract_address(test, &deployments_file)?;
     let srs = parse_srs_from_file(&srs_file)?;
 
+    let darkpool_proxy_address =
+        parse_addr_from_deployments_file(&deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?;
+    let proxy_admin_address =
+        parse_addr_from_deployments_file(&deployments_file, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY)?;
+    let darkpool_impl_address =
+        parse_addr_from_deployments_file(&deployments_file, DARKPOOL_CONTRACT_KEY)?;
+    let merkle_address = parse_addr_from_deployments_file(&deployments_file, MERKLE_CONTRACT_KEY)?;
+    let verifier_address =
+        parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
+    let vkeys_address = parse_addr_from_deployments_file(&deployments_file, VKEYS_CONTRACT_KEY)?;
+    let dummy_erc20_address =
+        parse_addr_from_deployments_file(&deployments_file, DUMMY_ERC20_CONTRACT_KEY)?;
+    let dummy_upgrade_target_address =
+        parse_addr_from_deployments_file(&deployments_file, DUMMY_UPGRADE_TARGET_CONTRACT_KEY)?;
+    let precompiles_contract_address =
+        parse_addr_from_deployments_file(&deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?;
+
     match test {
-        Tests::EcAdd => {
-            let contract = PrecompileTestContract::new(contract_address, client);
-
-            test_ec_add(contract).await?;
-        }
-        Tests::EcMul => {
-            let contract = PrecompileTestContract::new(contract_address, client);
-
-            test_ec_mul(contract).await?;
-        }
-        Tests::EcPairing => {
-            let contract = PrecompileTestContract::new(contract_address, client);
-
-            test_ec_pairing(contract).await?;
-        }
-        Tests::EcRecover => {
-            let contract = PrecompileTestContract::new(contract_address, client);
-
-            test_ec_recover(contract).await?;
-        }
-        Tests::NullifierSet => {
-            let contract = DarkpoolTestContract::new(contract_address, client);
-
-            test_nullifier_set(contract).await?;
-        }
-        Tests::Merkle => {
-            let contract = MerkleContract::new(contract_address, client);
-
-            test_merkle(contract).await?;
-        }
-        Tests::Verifier => {
-            let contract = VerifierContract::new(contract_address, client);
-
-            test_verifier(contract, &srs).await?;
-        }
-        Tests::Upgradeable => {
-            let contract = DarkpoolProxyAdminContract::new(contract_address, client.clone());
-            let proxy_address =
-                parse_addr_from_deployments_file(&deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?;
-            let dummy_upgrade_target_address = parse_addr_from_deployments_file(
-                &deployments_file,
-                DUMMY_UPGRADE_TARGET_CONTRACT_KEY,
-            )?;
-            let darkpool_address =
-                parse_addr_from_deployments_file(&deployments_file, DARKPOOL_CONTRACT_KEY)?;
-
+        Tests::All => {
+            test_ec_add(precompiles_contract_address, client.clone()).await?;
+            test_ec_mul(precompiles_contract_address, client.clone()).await?;
+            test_ec_pairing(precompiles_contract_address, client.clone()).await?;
+            test_ec_recover(precompiles_contract_address, client.clone()).await?;
+            test_nullifier_set(darkpool_proxy_address, client.clone()).await?;
+            test_merkle(merkle_address, client.clone()).await?;
+            test_verifier(verifier_address, client.clone(), &srs).await?;
             test_upgradeable(
-                contract,
-                proxy_address,
+                proxy_admin_address,
+                darkpool_proxy_address,
                 dummy_upgrade_target_address,
-                darkpool_address,
+                darkpool_impl_address,
+                client.clone(),
             )
             .await?;
-        }
-        Tests::ImplSetters => {
-            let contract = DarkpoolTestContract::new(contract_address, client.clone());
-            let verifier_address =
-                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
-            let vkeys_address =
-                parse_addr_from_deployments_file(&deployments_file, VKEYS_CONTRACT_KEY)?;
-            let merkle_address =
-                parse_addr_from_deployments_file(&deployments_file, MERKLE_CONTRACT_KEY)?;
-            let dummy_upgrade_target_address = parse_addr_from_deployments_file(
-                &deployments_file,
-                DUMMY_UPGRADE_TARGET_CONTRACT_KEY,
-            )?;
-
             test_implementation_address_setters(
-                contract,
+                darkpool_proxy_address,
                 verifier_address,
                 vkeys_address,
                 merkle_address,
                 dummy_upgrade_target_address,
+                client.clone(),
             )
             .await?;
+            test_initializable(darkpool_proxy_address, client.clone()).await?;
+            test_ownable(
+                darkpool_proxy_address,
+                verifier_address,
+                vkeys_address,
+                merkle_address,
+                client.clone(),
+            )
+            .await?;
+            test_pausable(darkpool_proxy_address, client.clone(), &srs).await?;
+            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client.clone())
+                .await?;
+            test_new_wallet(darkpool_proxy_address, client.clone(), &srs).await?;
+            test_update_wallet(darkpool_proxy_address, client.clone(), &srs).await?;
+            test_process_match_settle(darkpool_proxy_address, client, &srs).await
         }
-        Tests::Initializable => {
-            let contract = DarkpoolTestContract::new(contract_address, client.clone());
-
-            test_initializable(contract).await?;
+        Tests::EcAdd => test_ec_add(precompiles_contract_address, client).await,
+        Tests::EcMul => test_ec_mul(precompiles_contract_address, client).await,
+        Tests::EcPairing => test_ec_pairing(precompiles_contract_address, client).await,
+        Tests::EcRecover => test_ec_recover(precompiles_contract_address, client).await,
+        Tests::NullifierSet => test_nullifier_set(darkpool_proxy_address, client).await,
+        Tests::Merkle => test_merkle(merkle_address, client).await,
+        Tests::Verifier => test_verifier(verifier_address, client, &srs).await,
+        Tests::Upgradeable => {
+            test_upgradeable(
+                proxy_admin_address,
+                darkpool_proxy_address,
+                dummy_upgrade_target_address,
+                darkpool_impl_address,
+                client,
+            )
+            .await
         }
+        Tests::ImplSetters => {
+            test_implementation_address_setters(
+                darkpool_proxy_address,
+                verifier_address,
+                vkeys_address,
+                merkle_address,
+                dummy_upgrade_target_address,
+                client,
+            )
+            .await
+        }
+        Tests::Initializable => test_initializable(darkpool_proxy_address, client).await,
         Tests::Ownable => {
-            let contract = DarkpoolTestContract::new(contract_address, client.clone());
-            let verifier_address =
-                parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
-            let vkeys_address =
-                parse_addr_from_deployments_file(&deployments_file, VKEYS_CONTRACT_KEY)?;
-            let merkle_address =
-                parse_addr_from_deployments_file(&deployments_file, MERKLE_CONTRACT_KEY)?;
-
-            test_ownable(contract, verifier_address, vkeys_address, merkle_address).await?;
+            test_ownable(
+                darkpool_proxy_address,
+                verifier_address,
+                vkeys_address,
+                merkle_address,
+                client,
+            )
+            .await
         }
-        Tests::Pausable => {
-            let contract = DarkpoolTestContract::new(contract_address, client.clone());
-
-            test_pausable(contract, &srs).await?;
-        }
+        Tests::Pausable => test_pausable(darkpool_proxy_address, client, &srs).await,
         Tests::ExternalTransfer => {
-            let contract = DarkpoolTestContract::new(contract_address, client.clone());
-            let dummy_erc20_address =
-                parse_addr_from_deployments_file(&deployments_file, DUMMY_ERC20_CONTRACT_KEY)?;
-            let dummy_erc20_contract = DummyErc20Contract::new(dummy_erc20_address, client);
-
-            test_external_transfer(contract, dummy_erc20_contract).await?;
+            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client).await
         }
-        Tests::NewWallet => {
-            let contract = DarkpoolTestContract::new(contract_address, client);
-
-            test_new_wallet(contract, &srs).await?;
-        }
-        Tests::UpdateWallet => {
-            let contract = DarkpoolTestContract::new(contract_address, client);
-
-            test_update_wallet(contract, &srs).await?;
-        }
+        Tests::NewWallet => test_new_wallet(darkpool_proxy_address, client, &srs).await,
+        Tests::UpdateWallet => test_update_wallet(darkpool_proxy_address, client, &srs).await,
         Tests::ProcessMatchSettle => {
-            let contract = DarkpoolTestContract::new(contract_address, client);
-
-            test_process_match_settle(contract, &srs).await?;
+            test_process_match_settle(darkpool_proxy_address, client, &srs).await
         }
     }
-
-    Ok(())
 }

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -729,6 +729,13 @@ pub(crate) async fn test_external_transfer(
     // Deposit initial funds for darkpool & user in dummy erc20 address
     mint_dummy_erc20(&dummy_erc20_contract, &[darkpool_address, account_address]).await?;
 
+    // Approve the darkpool to spend the user's funds
+    dummy_erc20_contract
+        .approve(darkpool_address, U256::from(TRANSFER_AMOUNT))
+        .send()
+        .await?
+        .await?;
+
     let darkpool_initial_balance = dummy_erc20_contract
         .balance_of(darkpool_address)
         .call()

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -21,47 +21,12 @@ use ethers::{
     types::{Bytes, U256},
 };
 use eyre::{eyre, Result};
-use scripts::{
-    constants::{
-        DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, MERKLE_CONTRACT_KEY,
-        PRECOMPILE_TEST_CONTRACT_KEY, VERIFIER_CONTRACT_KEY,
-    },
-    utils::parse_addr_from_deployments_file,
-};
 use serde::Serialize;
 
 use crate::{
     abis::{DarkpoolTestContract, DummyErc20Contract},
-    cli::Tests,
     constants::TRANSFER_AMOUNT,
 };
-
-/// Returns the deployed address of the contract to be tested
-pub(crate) fn get_test_contract_address(test: Tests, deployments_file: &str) -> Result<Address> {
-    Ok(match test {
-        Tests::EcAdd | Tests::EcMul | Tests::EcPairing | Tests::EcRecover => {
-            parse_addr_from_deployments_file(deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)?
-        }
-        Tests::Merkle => parse_addr_from_deployments_file(deployments_file, MERKLE_CONTRACT_KEY)?,
-        Tests::Verifier => {
-            parse_addr_from_deployments_file(deployments_file, VERIFIER_CONTRACT_KEY)?
-        }
-        Tests::Upgradeable => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY)?
-        }
-        Tests::NullifierSet
-        | Tests::Initializable
-        | Tests::ImplSetters
-        | Tests::Ownable
-        | Tests::Pausable
-        | Tests::ExternalTransfer
-        | Tests::NewWallet
-        | Tests::UpdateWallet
-        | Tests::ProcessMatchSettle => {
-            parse_addr_from_deployments_file(deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)?
-        }
-    })
-}
 
 /// Asserts that the given method can only be called by the owner of the darkpool contract
 pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(


### PR DESCRIPTION
This PR updates the `scripts` and `integration` crates to support deploying all testing contracts, and running all tests, using a single command for each.

This includes some small changes to the utilities & how arguments are passed to tests which are entirely ergonomic, and change nothing about the functionality.

Finally, we make a small fix to `test_external_transfer` so that the dev account approves the darkpool to spend its funds.

**Testing:**
All unit & integration tests pass.