### PR TITLE
docs: updated README to deploy/test everything w/ new commands

### DIFF
--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -17,7 +17,7 @@ use crate::{
     errors::ScriptError,
 };
 
-/// Top-level CLI arguments
+/// Scripts for deploying & upgrading the Renegade Stylus contracts
 #[derive(Parser)]
 pub struct Cli {
     /// Private key of the deployer


### PR DESCRIPTION
This PR updates the README to use the new commands for deploying all testing contracts and running all tests, this is simpler for getting started.