### PR TITLE
contracts-stylus: verbose reverts

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,10 +1,3 @@
-[target.wasm32-unknown-unknown]
-rustflags = [
-  "-C", "link-arg=-zstack-size=32768",
-  "-C", "inline-threshold=0",
-  "-Zlocation-detail=none",
-]
-
 [target.aarch64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "contracts-core",
  "mini-alloc",
  "postcard",
+ "serde",
  "stylus-sdk",
 ]
 

--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -87,3 +87,15 @@ pub const VKEYS_ADDRESS_SELECTOR: u8 = 1;
 /// The selector for the merkle address in the `is_implementation_upgraded`
 /// method on the Darkpool test contract
 pub const MERKLE_ADDRESS_SELECTOR: u8 = 2;
+
+/// The revert message when failing to convert a
+/// u256 to a scalar
+pub const SCALAR_CONVERSION_ERROR_MESSAGE: &[u8] = b"scalar conversion error";
+
+/// The revert message when attempting to verify a proof
+/// with malformed inputs
+pub const INVALID_INPUTS_ERROR_MESSAGE: &[u8] = b"invalid inputs";
+
+/// The revert message when an EC arithmetic backend
+/// operation fails
+pub const ARITHMETIC_BACKEND_ERROR_MESSAGE: &[u8] = b"arithmetic backend error";

--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -368,8 +368,8 @@ pub fn pk_to_scalars(pk: &PublicSigningKey) -> Vec<ScalarField> {
 }
 
 /// Serializes a statement type into a vector of `[ScalarField]` and wraps it in a [`PublicInputs`]
-pub fn statement_to_public_inputs<S: ScalarSerializable>(statement: &S) -> PublicInputs {
-    PublicInputs(statement.serialize_to_scalars().unwrap())
+pub fn statement_to_public_inputs<S: ScalarSerializable>(statement: &S) -> Result<PublicInputs, SerdeError> {
+    Ok(PublicInputs(statement.serialize_to_scalars()?))
 }
 
 #[cfg(test)]

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -5,7 +5,7 @@ use ark_ff::{BigInt, BigInteger, PrimeField};
 use contracts_common::{
     backends::HashBackend,
     constants::{HASH_SAMPLE_BYTES, NUM_BYTES_FELT, SPLIT_INDEX, TRANSCRIPT_STATE_SIZE},
-    custom_serde::{bigint_from_le_bytes, BytesSerializable, TranscriptG1},
+    custom_serde::{bigint_from_le_bytes, BytesSerializable, SerdeError, TranscriptG1},
     types::{Challenges, G1Affine, Proof, PublicInputs, ScalarField, VerificationKey},
 };
 use core::marker::PhantomData;
@@ -39,7 +39,7 @@ impl<H: HashBackend> Transcript<H> {
     }
 
     /// Computes a challenge and updates the transcript state
-    pub fn get_and_append_challenge(&mut self) -> ScalarField {
+    pub fn get_and_append_challenge(&mut self) -> Result<ScalarField, SerdeError> {
         let input0 = [self.state.as_ref(), self.transcript.as_ref(), &[0u8]].concat();
         let input1 = [self.state.as_ref(), self.transcript.as_ref(), &[1u8]].concat();
 
@@ -55,14 +55,13 @@ impl<H: HashBackend> Transcript<H> {
         // and converting them into a scalar directly, as no reduction is needed.
         let (bytes_to_directly_convert, remaining_bytes) =
             self.state[..HASH_SAMPLE_BYTES].split_at(SPLIT_INDEX);
-        let res =
-            ScalarField::from_bigint(bigint_from_le_bytes(bytes_to_directly_convert).unwrap())
-                .unwrap();
+        let res = ScalarField::from_bigint(bigint_from_le_bytes(bytes_to_directly_convert)?)
+            .ok_or(SerdeError::ScalarConversion)?;
 
         // Next, we interpret the remaining bytes in little-endian order as a scalar.
         // Again, no reduction is needed.
-        let mut rem_scalar =
-            ScalarField::from_bigint(bigint_from_le_bytes(remaining_bytes).unwrap()).unwrap();
+        let mut rem_scalar = ScalarField::from_bigint(bigint_from_le_bytes(remaining_bytes)?)
+            .ok_or(SerdeError::ScalarConversion)?;
 
         // Now, we shift the latter scalar left by 31 bytes, which is equivalent to multiplying by 2^248.
         // Reduction is done for us by using modular multiplication for the shift.
@@ -70,12 +69,12 @@ impl<H: HashBackend> Transcript<H> {
         // 2^248 in big endian = 1 followed by 248 zeroes
         let mut shift_bits = [false; (SPLIT_INDEX) * 8 + 1];
         shift_bits[0] = true;
-        let shift_by_31_bytes =
-            ScalarField::from_bigint(BigInt::from_bits_be(&shift_bits)).unwrap();
+        let shift_by_31_bytes = ScalarField::from_bigint(BigInt::from_bits_be(&shift_bits))
+            .ok_or(SerdeError::ScalarConversion)?;
         rem_scalar *= shift_by_31_bytes;
 
         // Finally, we add the two scalars together. Again, reduction is done for us by using modular addition.
-        res + rem_scalar
+        Ok(res + rem_scalar)
     }
 
     /// Appends a serializable Arkworks type to the transcript
@@ -90,7 +89,7 @@ impl<H: HashBackend> Transcript<H> {
         vkey: &VerificationKey,
         proof: &Proof,
         public_inputs: &PublicInputs,
-    ) -> Challenges {
+    ) -> Result<Challenges, SerdeError> {
         // Absorb verification key & public inputs
         self.append_message(&ScalarField::MODULUS_BIT_SIZE.to_le_bytes());
         self.append_message(&vkey.n.to_le_bytes());
@@ -106,39 +105,39 @@ impl<H: HashBackend> Transcript<H> {
         self.append_serializable(&to_transcript_g1s(&proof.wire_comms).as_slice());
         // Here, for consistency with the Jellyfish implementation, we squeeze an unused challenge
         // `tau`, which would be used for Plookup
-        self.get_and_append_challenge();
+        self.get_and_append_challenge()?;
 
         // Prover round 2: squeeze beta & gamma challenges, absorb grand product polynomial commitment
-        let beta = self.get_and_append_challenge();
-        let gamma = self.get_and_append_challenge();
+        let beta = self.get_and_append_challenge()?;
+        let gamma = self.get_and_append_challenge()?;
         self.append_serializable(&TranscriptG1(proof.z_comm));
 
         // Prover round 3: squeeze alpha challenge, absorb split quotient polynomial commitments
-        let alpha = self.get_and_append_challenge();
+        let alpha = self.get_and_append_challenge()?;
         self.append_serializable(&to_transcript_g1s(&proof.quotient_comms).as_slice());
 
         // Prover round 4: squeeze zeta challenge, absorb wire, permutation, and grand product polynomial evaluations
-        let zeta = self.get_and_append_challenge();
+        let zeta = self.get_and_append_challenge()?;
         self.append_message(&serialize_scalars_for_transcript(&proof.wire_evals));
         self.append_message(&serialize_scalars_for_transcript(&proof.sigma_evals));
         self.append_message(&serialize_scalars_for_transcript(&[proof.z_bar]));
 
         // Prover round 5: squeeze v challenge, absorb opening proofs
-        let v = self.get_and_append_challenge();
+        let v = self.get_and_append_challenge()?;
         self.append_serializable(&TranscriptG1(proof.w_zeta));
         self.append_serializable(&TranscriptG1(proof.w_zeta_omega));
 
         // Squeeze u challenge
-        let u = self.get_and_append_challenge();
+        let u = self.get_and_append_challenge()?;
 
-        Challenges {
+        Ok(Challenges {
             beta,
             gamma,
             alpha,
             zeta,
             v,
             u,
-        }
+        })
     }
 
     /// Compute the eta challenge used in the proof linking protocol,
@@ -149,7 +148,7 @@ impl<H: HashBackend> Transcript<H> {
         wire_poly_comm_1: G1Affine,
         wire_poly_comm_2: G1Affine,
         linking_quotient_poly_comm: G1Affine,
-    ) -> ScalarField {
+    ) -> Result<ScalarField, SerdeError> {
         self.append_serializable(&TranscriptG1(wire_poly_comm_1));
         self.append_serializable(&TranscriptG1(wire_poly_comm_2));
         self.append_serializable(&TranscriptG1(linking_quotient_poly_comm));

--- a/contracts-core/src/verifier/errors.rs
+++ b/contracts-core/src/verifier/errors.rs
@@ -1,20 +1,23 @@
 //! Errors stemming from verifier operations
 
-use contracts_common::{backends::G1ArithmeticError, custom_serde::SerdeError};
+use alloc::vec::Vec;
+use contracts_common::{
+    backends::G1ArithmeticError,
+    constants::{
+        ARITHMETIC_BACKEND_ERROR_MESSAGE, INVALID_INPUTS_ERROR_MESSAGE,
+        SCALAR_CONVERSION_ERROR_MESSAGE,
+    },
+};
 
 /// Errors that can occur during Plonk verification
 #[derive(Debug)]
 pub enum VerifierError {
     /// An error that occurred when interpreting the verification inputs
     InvalidInputs,
-    /// An error that occurred when computing a modular inverse
-    Inversion,
-    /// An error that occurred when doing an MSM over different-length scalar & point slices
-    MsmLength,
     /// An error that occurred in the operations of the G1 arithmetic backend
     ArithmeticBackend,
-    /// An error that occurred when trying to de/serialize a type
-    SerdeError(SerdeError)
+    /// An error that occurred when converting to/from scalar types
+    ScalarConversion,
 }
 
 impl From<G1ArithmeticError> for VerifierError {
@@ -23,8 +26,12 @@ impl From<G1ArithmeticError> for VerifierError {
     }
 }
 
-impl From<SerdeError> for VerifierError {
-    fn from(value: SerdeError) -> Self {
-        VerifierError::SerdeError(value)
+impl From<VerifierError> for Vec<u8> {
+    fn from(value: VerifierError) -> Self {
+        match value {
+            VerifierError::InvalidInputs => INVALID_INPUTS_ERROR_MESSAGE.to_vec(),
+            VerifierError::ArithmeticBackend => ARITHMETIC_BACKEND_ERROR_MESSAGE.to_vec(),
+            VerifierError::ScalarConversion => SCALAR_CONVERSION_ERROR_MESSAGE.to_vec(),
+        }
     }
 }

--- a/contracts-core/src/verifier/errors.rs
+++ b/contracts-core/src/verifier/errors.rs
@@ -1,6 +1,6 @@
 //! Errors stemming from verifier operations
 
-use contracts_common::backends::G1ArithmeticError;
+use contracts_common::{backends::G1ArithmeticError, custom_serde::SerdeError};
 
 /// Errors that can occur during Plonk verification
 #[derive(Debug)]
@@ -13,10 +13,18 @@ pub enum VerifierError {
     MsmLength,
     /// An error that occurred in the operations of the G1 arithmetic backend
     ArithmeticBackend,
+    /// An error that occurred when trying to de/serialize a type
+    SerdeError(SerdeError)
 }
 
 impl From<G1ArithmeticError> for VerifierError {
     fn from(_value: G1ArithmeticError) -> Self {
         VerifierError::ArithmeticBackend
+    }
+}
+
+impl From<SerdeError> for VerifierError {
+    fn from(value: SerdeError) -> Self {
+        VerifierError::SerdeError(value)
     }
 }

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -13,6 +13,7 @@ contracts-common = { path = "../contracts-common" }
 contracts-core = { path = "../contracts-core" }
 postcard = { workspace = true }
 alloy-sol-types = { workspace = true }
+serde = { workspace = true }
 
 [features]
 darkpool = ["stylus-sdk/storage-cache"]

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -515,12 +515,11 @@ impl DarkpoolContract {
         private_shares_commitment: ScalarField,
         public_wallet_shares: &[ScalarField],
     ) -> Vec<U256> {
-        let mut total_wallet_shares = vec![private_shares_commitment];
-        total_wallet_shares.extend(public_wallet_shares);
+        let mut total_wallet_shares = vec![scalar_to_u256(private_shares_commitment)];
+        for share in public_wallet_shares {
+            total_wallet_shares.push(scalar_to_u256(*share));
+        }
         total_wallet_shares
-            .into_iter()
-            .map(scalar_to_u256)
-            .collect()
     }
 
     /// Prepares the private shares commitment & public wallet shares for insertion into the Merkle

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -32,8 +32,7 @@ impl DarkpoolTestContract {
     /// Marks the given nullifier as spent
     pub fn mark_nullifier_spent(&mut self, nullifier: U256) -> Result<(), Vec<u8>> {
         let nullifier = u256_to_scalar(nullifier).unwrap();
-        DarkpoolContract::mark_nullifier_spent(self, nullifier);
-        Ok(())
+        DarkpoolContract::mark_nullifier_spent(self, nullifier)
     }
 
     /// Executes the given external transfer
@@ -46,7 +45,7 @@ impl DarkpoolTestContract {
 
     /// Attempts to call [`DummyUpgradeTarget::is_dummy_upgrade_target`] on either
     /// the verifier, vkeys, or Merkle contract, depending on the given address selector.
-    /// 
+    ///
     /// A succesful call implies that the verifier / vkeys / Merkle contract has been upgraded
     /// to the dummy upgrade target.
     pub fn is_implementation_upgraded(&mut self, address_selector: u8) -> Result<bool, Vec<u8>> {
@@ -59,7 +58,7 @@ impl DarkpoolTestContract {
         };
 
         let (is_dummy_upgrade_target,) =
-            delegate_call_helper::<isDummyUpgradeTargetCall>(self, implementation_address, ())
+            delegate_call_helper::<isDummyUpgradeTargetCall>(self, implementation_address, ())?
                 .into();
 
         Ok(is_dummy_upgrade_target)
@@ -71,8 +70,6 @@ impl DarkpoolTestContract {
             .merkle_address
             .get();
 
-        delegate_call_helper::<initCall>(self, merkle_address, ());
-
-        Ok(())
+        delegate_call_helper::<initCall>(self, merkle_address, ()).map(|_| ())
     }
 }

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -12,7 +12,7 @@ use stylus_sdk::{abi::Bytes, alloy_primitives::U256, prelude::*};
 use crate::{
     contracts::darkpool::DarkpoolContract,
     utils::{
-        helpers::{delegate_call_helper, u256_to_scalar},
+        helpers::{delegate_call_helper, deserialize_from_calldata, u256_to_scalar},
         solidity::{initCall, isDummyUpgradeTargetCall},
     },
 };
@@ -31,15 +31,14 @@ struct DarkpoolTestContract {
 impl DarkpoolTestContract {
     /// Marks the given nullifier as spent
     pub fn mark_nullifier_spent(&mut self, nullifier: U256) -> Result<(), Vec<u8>> {
-        let nullifier = u256_to_scalar(nullifier).unwrap();
+        let nullifier = u256_to_scalar(nullifier)?;
         DarkpoolContract::mark_nullifier_spent(self, nullifier)
     }
 
     /// Executes the given external transfer
     pub fn execute_external_transfer(&mut self, transfer: Bytes) -> Result<(), Vec<u8>> {
-        let external_transfer: ExternalTransfer =
-            postcard::from_bytes(transfer.as_slice()).unwrap();
-        DarkpoolContract::execute_external_transfer(self, &external_transfer);
+        let external_transfer: ExternalTransfer = deserialize_from_calldata(&transfer)?;
+        DarkpoolContract::execute_external_transfer(self, &external_transfer)?;
         Ok(())
     }
 

--- a/contracts-stylus/src/contracts/verifier.rs
+++ b/contracts-stylus/src/contracts/verifier.rs
@@ -21,7 +21,7 @@ impl VerifierContract {
         let (vkey, proof, public_inputs) = deserialize_from_calldata(&verification_bundle)?;
 
         Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::verify(vkey, proof, public_inputs)
-            .map_err(|_| vec![])
+            .map_err(Into::into)
     }
 
     /// Batch-verify the proofs involved in matching a trade
@@ -41,6 +41,6 @@ impl VerifierContract {
             match_public_inputs,
             match_linking_proofs,
         )
-        .map_err(|_| vec![])
+        .map_err(Into::into)
     }
 }

--- a/contracts-stylus/src/contracts/verifier.rs
+++ b/contracts-stylus/src/contracts/verifier.rs
@@ -1,13 +1,13 @@
 //! The verifier smart contract, responsible for verifying Plonk proofs.
 
 use alloc::{vec, vec::Vec};
-use contracts_common::types::{
-    MatchLinkingProofs, MatchLinkingVkeys, MatchProofs, MatchPublicInputs, MatchVkeys,
-};
 use contracts_core::verifier::Verifier;
 use stylus_sdk::{abi::Bytes, prelude::*};
 
-use crate::utils::backends::{PrecompileG1ArithmeticBackend, StylusHasher};
+use crate::utils::{
+    backends::{PrecompileG1ArithmeticBackend, StylusHasher},
+    helpers::deserialize_from_calldata,
+};
 
 /// The verifier contract, which itself is stateless
 #[solidity_storage]
@@ -18,7 +18,7 @@ struct VerifierContract;
 impl VerifierContract {
     /// Verify the given proof, using the given verification bundle
     pub fn verify(&self, verification_bundle: Bytes) -> Result<bool, Vec<u8>> {
-        let (vkey, proof, public_inputs) = postcard::from_bytes(&verification_bundle).unwrap();
+        let (vkey, proof, public_inputs) = deserialize_from_calldata(&verification_bundle)?;
 
         Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::verify(vkey, proof, public_inputs)
             .map_err(|_| vec![])
@@ -32,13 +32,7 @@ impl VerifierContract {
             match_proofs,
             match_public_inputs,
             match_linking_proofs,
-        ): (
-            MatchVkeys,
-            MatchLinkingVkeys,
-            MatchProofs,
-            MatchPublicInputs,
-            MatchLinkingProofs,
-        ) = postcard::from_bytes(&match_bundle).unwrap();
+        ) = deserialize_from_calldata(&match_bundle)?;
 
         Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::verify_match(
             match_vkeys,

--- a/contracts-stylus/src/utils/backends.rs
+++ b/contracts-stylus/src/utils/backends.rs
@@ -151,7 +151,6 @@ impl EcRecoverBackend for PrecompileEcRecoverBackend {
             )
             .map_err(|_| EcdsaError)?;
 
-        // Unwrapping is safe here as we've limited the return data to the last 20 bytes
-        Ok(res.try_into().unwrap())
+        res.try_into().map_err(|_| EcdsaError)
     }
 }

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -65,6 +65,26 @@ pub const ECDSA_ERROR_MESSAGE: &[u8] = b"ecdsa error";
 #[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
 pub const INVALID_SIGNATURE_ERROR_MESSAGE: &[u8] = b"invalid signature";
 
+/// The revert message when trying to coerce an
+/// incorrectly-sized vector into a fixed-size array
+pub const INVALID_ARR_LEN_ERROR_MESSAGE: &[u8] = b"invalid array length";
+
+/// The revert message when failing to deserialize a byte-serialized
+/// type from calldata
+pub const CALLDATA_DESER_ERROR_MESSAGE: &[u8] = b"calldata deser error";
+
+/// The revert message when failing to serialize a
+/// type for calldata
+pub const CALLDATA_SER_ERROR_MESSAGE: &[u8] = b"calldata ser error";
+
+/// The revert message when failing to decode the data
+/// returned by an external contract call
+pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata";
+
+/// The revert message when failing to convert a
+/// u256 to a scalar
+pub const SCALAR_CONVERSION_ERROR_MESSAGE: &[u8] = b"scalar conversion error";
+
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -7,6 +7,64 @@ use contracts_common::{
 };
 use core::marker::PhantomData;
 
+/// The revert message when a contract/owner address
+/// is attempted to be set to the zero address
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const ZERO_ADDRESS_ERROR_MESSAGE: &[u8] = b"zero address";
+
+/// The revert message when the protocol fee
+/// is attempted to be set to zero
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const ZERO_FEE_ERROR_MESSAGE: &[u8] = b"zero fee";
+
+/// The revert message when verification fails
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const VERIFICATION_FAILED_ERROR_MESSAGE: &[u8] = b"verification failed";
+
+/// The revert message when attempting to initialize
+/// the darkpool contract to a past version
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const INVALID_VERSION_ERROR_MESSAGE: &[u8] = b"invalid version";
+
+/// The revert message when calling an owner-only method
+/// when the caller is not the owner
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const NOT_OWNER_ERROR_MESSAGE: &[u8] = b"not owner";
+
+/// The revert message when calling an unpaused-only method
+/// when the contract is paused
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const PAUSED_ERROR_MESSAGE: &[u8] = b"paused";
+
+/// The revert message when calling an paused-only method
+/// when the contract is unpaused
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const UNPAUSED_ERROR_MESSAGE: &[u8] = b"unpaused";
+
+/// The revert message when attempting to mark
+/// a spent nullifier as spent again
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const NULLIFIER_SPENT_ERROR_MESSAGE: &[u8] = b"nullifier spent";
+
+/// The revert message when checking an invalid
+/// historic root
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const ROOT_NOT_IN_HISTORY_ERROR_MESSAGE: &[u8] = b"root not in history";
+
+/// The revert message when attempting to insert
+/// into a full Merkle tree
+#[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
+pub const TREE_FULL_ERROR_MESSAGE: &[u8] = b"tree full";
+
+/// The revert message when invoking the ecRecover precompile
+/// reverts
+#[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
+pub const ECDSA_ERROR_MESSAGE: &[u8] = b"ecdsa error";
+
+/// The revert message when an ECDSA signature is invalid
+#[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
+pub const INVALID_SIGNATURE_ERROR_MESSAGE: &[u8] = b"invalid signature";
+
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -81,10 +81,6 @@ pub const CALLDATA_SER_ERROR_MESSAGE: &[u8] = b"calldata ser error";
 /// returned by an external contract call
 pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata";
 
-/// The revert message when failing to convert a
-/// u256 to a scalar
-pub const SCALAR_CONVERSION_ERROR_MESSAGE: &[u8] = b"scalar conversion error";
-
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -7,18 +7,32 @@ use contracts_common::{
     constants::NUM_SCALARS_PK,
     custom_serde::{
         bigint_from_le_bytes, pk_to_scalars, statement_to_public_inputs, BytesSerializable,
-        ScalarSerializable, SerdeError,
+        ScalarSerializable,
     },
     types::{
         MatchPublicInputs, PublicSigningKey, ScalarField, ValidCommitmentsStatement,
         ValidMatchSettleStatement, ValidReblindStatement,
     },
 };
+use serde::Deserialize;
 use stylus_sdk::{
+    abi::Bytes,
     alloy_primitives::{Address, U256},
     call::{delegate_call, static_call},
     storage::TopLevelStorage,
 };
+
+use super::constants::{
+    CALLDATA_DESER_ERROR_MESSAGE, CALLDATA_SER_ERROR_MESSAGE, CALL_RETDATA_DECODING_ERROR_MESSAGE,
+    INVALID_ARR_LEN_ERROR_MESSAGE, SCALAR_CONVERSION_ERROR_MESSAGE,
+};
+
+/// Deserializes a byte-serialized type from calldata
+pub fn deserialize_from_calldata<'a, D: Deserialize<'a>>(
+    calldata: &'a Bytes,
+) -> Result<D, Vec<u8>> {
+    postcard::from_bytes(calldata.as_slice()).map_err(|_| CALLDATA_DESER_ERROR_MESSAGE.to_vec())
+}
 
 /// Serializes the given statement into scalars, and then into bytes,
 /// as expected by the verifier contract.
@@ -28,8 +42,9 @@ use stylus_sdk::{
 )]
 pub fn serialize_statement_for_verification<S: ScalarSerializable>(
     statement: &S,
-) -> postcard::Result<Vec<u8>> {
+) -> Result<Vec<u8>, Vec<u8>> {
     postcard::to_allocvec(&statement_to_public_inputs(statement))
+        .map_err(|_| CALLDATA_SER_ERROR_MESSAGE.to_vec())
 }
 
 /// Serializes the statements used in verifying the settlement of a
@@ -45,7 +60,7 @@ pub fn serialize_match_statements_for_verification(
     valid_reblind_0: &ValidReblindStatement,
     valid_reblind_1: &ValidReblindStatement,
     valid_match_settle: &ValidMatchSettleStatement,
-) -> postcard::Result<Vec<u8>> {
+) -> Result<Vec<u8>, Vec<u8>> {
     let match_public_inputs = MatchPublicInputs {
         valid_commitments_0: statement_to_public_inputs(valid_commitments_0),
         valid_commitments_1: statement_to_public_inputs(valid_commitments_1),
@@ -53,7 +68,18 @@ pub fn serialize_match_statements_for_verification(
         valid_reblind_1: statement_to_public_inputs(valid_reblind_1),
         valid_match_settle: statement_to_public_inputs(valid_match_settle),
     };
-    postcard::to_allocvec(&match_public_inputs)
+    postcard::to_allocvec(&match_public_inputs).map_err(|_| CALLDATA_SER_ERROR_MESSAGE.to_vec())
+}
+
+/// Maps an error returned from an external contract call to a `Vec<u8>`,
+/// which is the expected return type of external contract methods.
+pub fn map_call_error(e: stylus_sdk::call::Error) -> Vec<u8> {
+    match e {
+        stylus_sdk::call::Error::Revert(msg) => msg,
+        stylus_sdk::call::Error::AbiDecodingFailed(_) => {
+            CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec()
+        }
+    }
 }
 
 /// Performs a `delegatecall` to the given address, calling the function
@@ -68,13 +94,9 @@ pub fn delegate_call_helper<C: SolCall>(
     args: <C::Arguments<'_> as SolType>::RustType,
 ) -> Result<C::Return, Vec<u8>> {
     let calldata = C::new(args).encode();
-    let res = unsafe {
-        delegate_call(storage, address, &calldata).map_err(|e| match e {
-            stylus_sdk::call::Error::Revert(msg) => msg,
-            stylus_sdk::call::Error::AbiDecodingFailed(_) => b"abi decoding failed".to_vec(),
-        })?
-    };
-    Ok(C::decode_returns(&res, true /* validate */).unwrap())
+    let res = unsafe { delegate_call(storage, address, &calldata).map_err(map_call_error)? };
+    C::decode_returns(&res, true /* validate */)
+        .map_err(|_| CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec())
 }
 
 /// Performs a `staticcall` to the given address, calling the function
@@ -87,10 +109,11 @@ pub fn static_call_helper<C: SolCall>(
     storage: &mut impl TopLevelStorage,
     address: Address,
     args: <C::Arguments<'_> as SolType>::RustType,
-) -> C::Return {
+) -> Result<C::Return, Vec<u8>> {
     let calldata = C::new(args).encode();
-    let res = static_call(storage, address, &calldata).unwrap();
-    C::decode_returns(&res, true /* validate */).unwrap()
+    let res = static_call(storage, address, &calldata).map_err(map_call_error)?;
+    C::decode_returns(&res, true /* validate */)
+        .map_err(|_| CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec())
 }
 
 /// Converts a scalar to a U256
@@ -116,9 +139,10 @@ pub fn scalar_to_u256(scalar: ScalarField) -> U256 {
     )),
     allow(dead_code)
 )]
-pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, SerdeError> {
-    let bigint = bigint_from_le_bytes(&u256.to_le_bytes_vec())?;
-    ScalarField::from_bigint(bigint).ok_or(SerdeError::ScalarConversion)
+pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, Vec<u8>> {
+    let bigint = bigint_from_le_bytes(&u256.to_le_bytes_vec())
+        .map_err(|_| SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())?;
+    ScalarField::from_bigint(bigint).ok_or(SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())
 }
 
 /// Converts a [`PublicSigningKey`] into the [`U256`] array representing its scalar serialization
@@ -126,14 +150,14 @@ pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, SerdeError> {
     not(any(feature = "darkpool", feature = "darkpool-test-contract")),
     allow(dead_code)
 )]
-pub fn pk_to_u256s(pk: &PublicSigningKey) -> [U256; NUM_SCALARS_PK] {
+pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], Vec<u8>> {
     let scalars = pk_to_scalars(pk);
     scalars
         .into_iter()
         .map(scalar_to_u256)
         .collect::<Vec<_>>()
         .try_into()
-        .unwrap()
+        .map_err(|_| INVALID_ARR_LEN_ERROR_MESSAGE.to_vec())
 }
 
 /// Expands to the given code block if the `no-verify` feature is not enabled.

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use ark_ff::PrimeField;
 use contracts_common::{
-    constants::NUM_SCALARS_PK,
+    constants::{NUM_SCALARS_PK, SCALAR_CONVERSION_ERROR_MESSAGE},
     custom_serde::{
         bigint_from_le_bytes, pk_to_scalars, statement_to_public_inputs, BytesSerializable,
         ScalarSerializable,
@@ -24,7 +24,7 @@ use stylus_sdk::{
 
 use super::constants::{
     CALLDATA_DESER_ERROR_MESSAGE, CALLDATA_SER_ERROR_MESSAGE, CALL_RETDATA_DECODING_ERROR_MESSAGE,
-    INVALID_ARR_LEN_ERROR_MESSAGE, SCALAR_CONVERSION_ERROR_MESSAGE,
+    INVALID_ARR_LEN_ERROR_MESSAGE,
 };
 
 /// Deserializes a byte-serialized type from calldata

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -430,13 +430,17 @@ fn extract_match_public_inputs(data: &ProcessMatchSettleData) -> MatchPublicInpu
     MatchPublicInputs {
         valid_commitments_0: statement_to_public_inputs(
             &data.match_payload_0.valid_commitments_statement,
-        ),
+        )
+        .unwrap(),
         valid_commitments_1: statement_to_public_inputs(
             &data.match_payload_1.valid_commitments_statement,
-        ),
-        valid_reblind_0: statement_to_public_inputs(&data.match_payload_0.valid_reblind_statement),
-        valid_reblind_1: statement_to_public_inputs(&data.match_payload_1.valid_reblind_statement),
-        valid_match_settle: statement_to_public_inputs(&data.valid_match_settle_statement),
+        )
+        .unwrap(),
+        valid_reblind_0: statement_to_public_inputs(&data.match_payload_0.valid_reblind_statement)
+            .unwrap(),
+        valid_reblind_1: statement_to_public_inputs(&data.match_payload_1.valid_reblind_statement)
+            .unwrap(),
+        valid_match_settle: statement_to_public_inputs(&data.valid_match_settle_statement).unwrap(),
     }
 }
 

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -232,7 +232,7 @@ pub(crate) async fn test_verifier(
 
     // Test valid single proof verification
     let (statement, mut proof, vkey) = gen_verification_bundle(&mut rng, srs);
-    let public_inputs = statement_to_public_inputs(&statement);
+    let public_inputs = statement_to_public_inputs(&statement).unwrap();
 
     let verification_bundle_calldata =
         serialize_verification_bundle(&vkey, &proof, &public_inputs).unwrap();

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -32,6 +32,12 @@ pub const MANIFEST_DIR_ENV_VAR: &str = "CARGO_MANIFEST_DIR";
 /// The name of the environment variable used to configure the Rust compiler
 pub const RUSTFLAGS_ENV_VAR: &str = "RUSTFLAGS";
 
+/// The default flags to add to RUSTFLAGS for all contract compilations
+pub const DEFAULT_RUSTFLAGS: &str = "-Clink-arg=-zstack-size=65536 -Zlocation-detail=none";
+
+/// The inline threshold flag for the Rust compiler
+pub const INLINE_THRESHOLD_FLAG: &str = "-Cinline-threshold=0";
+
 /// The optimization level flag for the Rust compiler
 pub const OPT_LEVEL_FLAG: &str = "-C opt-level=";
 
@@ -40,6 +46,9 @@ pub const OPT_LEVEL_S: &str = "s";
 
 /// The "z" optimization level (aggressive size optimization)
 pub const OPT_LEVEL_Z: &str = "z";
+
+/// The 2 optimization level (aggressive optimization)
+pub const OPT_LEVEL_2: &str = "2";
 
 /// The 3 optimization level (maximum optimization)
 pub const OPT_LEVEL_3: &str = "3";

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -220,9 +220,9 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
 /// given contract
 pub fn get_wasm_opt_flags_for_contract(contract: StylusContract) -> &'static str {
     match contract {
-        StylusContract::Verifier | StylusContract::DarkpoolTestContract => {
-            AGGRESSIVE_SIZE_OPTIMIZATION_FLAG
-        }
+        StylusContract::Verifier
+        | StylusContract::Darkpool
+        | StylusContract::DarkpoolTestContract => AGGRESSIVE_SIZE_OPTIMIZATION_FLAG,
         _ => AGGRESSIVE_OPTIMIZATION_FLAG,
     }
 }

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -31,13 +31,13 @@ use crate::{
     cli::StylusContract,
     constants::{
         AGGRESSIVE_OPTIMIZATION_FLAG, AGGRESSIVE_SIZE_OPTIMIZATION_FLAG, BUILD_COMMAND,
-        CARGO_COMMAND, DARKPOOL_CONTRACT_KEY, DEPLOYMENTS_KEY, DEPLOY_COMMAND,
-        DUMMY_ERC20_CONTRACT_KEY, DUMMY_UPGRADE_TARGET_CONTRACT_KEY, MANIFEST_DIR_ENV_VAR,
-        MERKLE_CONTRACT_KEY, NIGHTLY_TOOLCHAIN_SELECTOR, NO_VERIFY_FEATURE, OPT_LEVEL_3,
-        OPT_LEVEL_FLAG, OPT_LEVEL_S, OPT_LEVEL_Z, PRECOMPILE_TEST_CONTRACT_KEY,
-        RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND, STYLUS_CONTRACTS_CRATE_NAME,
-        TARGET_PATH_SEGMENT, VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY, WASM_EXTENSION,
-        WASM_OPT_COMMAND, WASM_TARGET_TRIPLE, Z_FLAGS,
+        CARGO_COMMAND, DARKPOOL_CONTRACT_KEY, DEFAULT_RUSTFLAGS, DEPLOYMENTS_KEY, DEPLOY_COMMAND,
+        DUMMY_ERC20_CONTRACT_KEY, DUMMY_UPGRADE_TARGET_CONTRACT_KEY, INLINE_THRESHOLD_FLAG,
+        MANIFEST_DIR_ENV_VAR, MERKLE_CONTRACT_KEY, NIGHTLY_TOOLCHAIN_SELECTOR, NO_VERIFY_FEATURE,
+        OPT_LEVEL_2, OPT_LEVEL_3, OPT_LEVEL_FLAG, OPT_LEVEL_S, OPT_LEVEL_Z,
+        PRECOMPILE_TEST_CONTRACT_KEY, RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND,
+        STYLUS_CONTRACTS_CRATE_NAME, TARGET_PATH_SEGMENT, VERIFIER_CONTRACT_KEY,
+        VKEYS_CONTRACT_KEY, WASM_EXTENSION, WASM_OPT_COMMAND, WASM_TARGET_TRIPLE, Z_FLAGS,
     },
     errors::ScriptError,
     solidity::initializeCall,
@@ -207,13 +207,19 @@ fn command_success_or(mut cmd: Command, err_msg: &str) -> Result<(), ScriptError
 /// Returns the RUSTFLAGS environment variable to use in the
 /// compilation of the given contract
 pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
-    let opt_level = match contract {
-        StylusContract::Verifier => OPT_LEVEL_S,
-        StylusContract::DarkpoolTestContract => OPT_LEVEL_Z,
-        _ => OPT_LEVEL_3,
+    let rustflags = match contract {
+        StylusContract::Verifier => {
+            format!(
+                "{}{} {}",
+                OPT_LEVEL_FLAG, OPT_LEVEL_S, INLINE_THRESHOLD_FLAG
+            )
+        }
+        StylusContract::Darkpool => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_2),
+        StylusContract::DarkpoolTestContract => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_Z),
+        _ => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_3),
     };
 
-    format!("{}{}", OPT_LEVEL_FLAG, opt_level)
+    format!("{} {}", rustflags, DEFAULT_RUSTFLAGS)
 }
 
 /// Returns the wasm-opt flags to use in the optimization of the


### PR DESCRIPTION
This PR removes all of the `assert` and `unwrap` invocations throughout contract code (covering the `contracts-stylus`, `contracts-core` and `contracts-common` crates) and replaces them with `Result` propagation so that top-level contract methods can return UTF-8 encoded error messages.

This included making some changes to compilation flags (unfortunately, had to bump the `DarkpoolContract` down to optimization level 2), and other tweaks to bring the verifier contract within the binary size limit.

**Testing:**
All unit and integration tests pass, and ad-hoc testing showed that errors are propagated correctly even across contract call boundaries.