### PR TITLE
contracts-stylus: darkpool: disable storage cache

### DIFF
--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -16,7 +16,7 @@ alloy-sol-types = { workspace = true }
 serde = { workspace = true }
 
 [features]
-darkpool = ["stylus-sdk/storage-cache"]
+darkpool = []
 darkpool-test-contract = []
 no-verify = []
 merkle = ["stylus-sdk/storage-cache"]

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -47,9 +47,6 @@ pub const OPT_LEVEL_S: &str = "s";
 /// The "z" optimization level (aggressive size optimization)
 pub const OPT_LEVEL_Z: &str = "z";
 
-/// The 2 optimization level (aggressive optimization)
-pub const OPT_LEVEL_2: &str = "2";
-
 /// The 3 optimization level (maximum optimization)
 pub const OPT_LEVEL_3: &str = "3";
 

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -31,10 +31,10 @@ use crate::{
         CARGO_COMMAND, DARKPOOL_CONTRACT_KEY, DEFAULT_RUSTFLAGS, DEPLOYMENTS_KEY, DEPLOY_COMMAND,
         DUMMY_ERC20_TICKER, DUMMY_UPGRADE_TARGET_CONTRACT_KEY, INLINE_THRESHOLD_FLAG,
         MANIFEST_DIR_ENV_VAR, MERKLE_CONTRACT_KEY, NIGHTLY_TOOLCHAIN_SELECTOR, NO_VERIFY_FEATURE,
-        OPT_LEVEL_2, OPT_LEVEL_3, OPT_LEVEL_FLAG, OPT_LEVEL_S, OPT_LEVEL_Z,
-        PRECOMPILE_TEST_CONTRACT_KEY, RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND,
-        STYLUS_CONTRACTS_CRATE_NAME, TARGET_PATH_SEGMENT, VERIFIER_CONTRACT_KEY,
-        VKEYS_CONTRACT_KEY, WASM_EXTENSION, WASM_OPT_COMMAND, WASM_TARGET_TRIPLE, Z_FLAGS,
+        OPT_LEVEL_3, OPT_LEVEL_FLAG, OPT_LEVEL_S, OPT_LEVEL_Z, PRECOMPILE_TEST_CONTRACT_KEY,
+        RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND, STYLUS_CONTRACTS_CRATE_NAME,
+        TARGET_PATH_SEGMENT, VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY, WASM_EXTENSION,
+        WASM_OPT_COMMAND, WASM_TARGET_TRIPLE, Z_FLAGS,
     },
     errors::ScriptError,
     solidity::initializeCall,
@@ -185,7 +185,6 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
                 OPT_LEVEL_FLAG, OPT_LEVEL_S, INLINE_THRESHOLD_FLAG
             )
         }
-        StylusContract::Darkpool => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_2),
         StylusContract::DarkpoolTestContract => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_Z),
         _ => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_3),
     };
@@ -197,9 +196,9 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
 /// given contract
 pub fn get_wasm_opt_flags_for_contract(contract: StylusContract) -> &'static str {
     match contract {
-        StylusContract::Verifier
-        | StylusContract::Darkpool
-        | StylusContract::DarkpoolTestContract => AGGRESSIVE_SIZE_OPTIMIZATION_FLAG,
+        StylusContract::Verifier | StylusContract::DarkpoolTestContract => {
+            AGGRESSIVE_SIZE_OPTIMIZATION_FLAG
+        }
         _ => AGGRESSIVE_OPTIMIZATION_FLAG,
     }
 }


### PR DESCRIPTION
This PR disables the Stylus storage cache for the darkpool contract. After the pubkey serialization PR, it seems the darkpool contract itself inflated just over the binary size limit. Interestingly, changing its compilation flags even to the max-compression flags used by the darkpool testing contract did not help (I think this is to do with how the `#[external]` proc macro is expanded). The simplest approach to getting the production darkpool contract within the binary size limit is to disable the storage cache. Given the storage access patterns in the darkpool, we don't get much performance out of it, anyway. This gave us enough breathing room to re-enable the max-perf compilation flags for it.