### PR TITLE
contracts-stylus: darkpool: use `permit2` for deposits

### DIFF
--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -36,9 +36,9 @@ impl DarkpoolTestContract {
     }
 
     /// Executes the given external transfer
-    pub fn execute_external_transfer(&mut self, transfer: Bytes) -> Result<(), Vec<u8>> {
+    pub fn execute_external_transfer(&mut self, transfer: Bytes, permit_payload: Bytes) -> Result<(), Vec<u8>> {
         let external_transfer: ExternalTransfer = deserialize_from_calldata(&transfer)?;
-        DarkpoolContract::execute_external_transfer(self, &external_transfer)?;
+        DarkpoolContract::execute_external_transfer(self, &external_transfer, permit_payload)?;
         Ok(())
     }
 

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -1,5 +1,6 @@
 //! Various Solidity definitions, including ABI-compatible interfaces, events, functions, etc.
 
+use alloc::vec::Vec;
 use alloy_sol_types::sol;
 use stylus_sdk::stylus_proc::sol_interface;
 
@@ -10,6 +11,7 @@ sol_interface! {
     }
 }
 
+// Various methods and events defined in the Renegade smart contracts
 sol! {
 
     // -------------
@@ -55,4 +57,47 @@ sol! {
     event VerifierAddressChanged(address indexed new_address);
     event VkeysAddressChanged(address indexed new_address);
     event MerkleAddressChanged(address indexed new_address);
+}
+
+// Types & methods from the Permit2 `ISignatureTransfer` interface, taken from https://github.com/Uniswap/permit2/blob/main/src/interfaces/ISignatureTransfer.sol
+sol! {
+    /// The token and amount details for a transfer signed in the permit transfer signature
+    struct TokenPermissions {
+        // ERC20 token address
+        address token;
+        // the maximum amount that can be spent
+        uint256 amount;
+    }
+
+    /// The signed permit message for a single token transfer
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        // a unique value for every token owner's signature to prevent signature replays
+        uint256 nonce;
+        // deadline on the permit signature
+        uint256 deadline;
+    }
+
+    /// Specifies the recipient address and amount for batched transfers.
+    /// Recipients and amounts correspond to the index of the signed token permissions array.
+    /// Reverts if the requested amount is greater than the permitted signed amount.
+    struct SignatureTransferDetails {
+        // recipient address
+        address to;
+        // spender requested amount
+        uint256 requestedAmount;
+    }
+
+    /// Transfers a token using a signed permit message
+    /// Reverts if the requested amount is greater than the permitted signed amount
+    /// permit The permit data signed over by the owner
+    /// owner The owner of the tokens to transfer
+    /// transferDetails The spender's requested transfer details for the permitted token
+    /// signature The signature to verify
+    function permitTransferFrom(
+        PermitTransferFrom memory permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
 }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -2,14 +2,6 @@
 
 use alloc::vec::Vec;
 use alloy_sol_types::sol;
-use stylus_sdk::stylus_proc::sol_interface;
-
-sol_interface! {
-    // Taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/token/ERC20/IERC20.sol
-    interface IERC20 {
-        function transferFrom(address from, address to, uint256 value) external returns (bool);
-    }
-}
 
 // Various methods and events defined in the Renegade smart contracts
 sol! {
@@ -88,6 +80,12 @@ sol! {
         uint256 requestedAmount;
     }
 
+    /// Convenience type bundling together the permit and the signature
+    struct PermitPayload {
+        PermitTransferFrom permit;
+        bytes signature;
+    }
+
     /// Transfers a token using a signed permit message
     /// Reverts if the requested amount is greater than the permitted signed amount
     /// permit The permit data signed over by the owner
@@ -100,4 +98,8 @@ sol! {
         address owner,
         bytes calldata signature
     ) external;
+
+    /// The native `transfer` function on the ERC20 interface.
+    /// Taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/token/ERC20/IERC20.sol#L41
+    function transfer(address to, uint256 value) external returns (bool);
 }

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -192,7 +192,7 @@ pub struct DeployErc20sArgs {
     #[arg(short, long)]
     pub funding_amount: u128,
 
-    /// A comma-separated list of private keys corresponding to the accounts
+    /// A space-separated list of private keys corresponding to the accounts
     /// which will be funded with the ERC20s and
     /// for which the darkpool will be approved to transfer ERC20s
     #[arg(short, long, value_parser, num_args = 0.., value_delimiter = ' ')]

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -185,7 +185,7 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
                 OPT_LEVEL_FLAG, OPT_LEVEL_S, INLINE_THRESHOLD_FLAG
             )
         }
-        StylusContract::DarkpoolTestContract => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_Z),
+        StylusContract::DarkpoolTestContract | StylusContract::Darkpool => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_Z),
         _ => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_3),
     };
 


### PR DESCRIPTION
This PR changes the Darkpool contract implementation to pull in deposits through the `permit2` contract, expecting a calldata-serialized Permit2 message and signature to be passed alongside the other arguments to `update_wallet`.

We use the [`permitTransferFrom` method](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permittransferfrom) on the Permit2 contract. A good overview of the Permit2 pattern can be found [here](https://github.com/dragonfly-xyz/useful-solidity-patterns/tree/main/patterns/permit2).

Testing is deferred to the next PR for brevity.