### PR TITLE
integration: external transfer test w/ permit2 passing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ name = "contracts-common"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -2823,6 +2824,7 @@ name = "integration"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "arbitrum-client",
  "ark-crypto-primitives",
  "ark-ec",

--- a/contracts-common/Cargo.toml
+++ b/contracts-common/Cargo.toml
@@ -8,6 +8,7 @@ ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-sol-types = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 ark-serialize = { workspace = true }

--- a/contracts-common/src/lib.rs
+++ b/contracts-common/src/lib.rs
@@ -10,4 +10,5 @@ pub mod backends;
 pub mod constants;
 pub mod custom_serde;
 pub mod serde_def_types;
+pub mod solidity;
 pub mod types;

--- a/contracts-common/src/solidity.rs
+++ b/contracts-common/src/solidity.rs
@@ -1,0 +1,72 @@
+//! Solidity type definitions used throughout the project
+
+#![allow(missing_docs)]
+
+use alloc::vec::Vec;
+use alloy_sol_types::sol;
+
+// Types & methods from the Permit2 `ISignatureTransfer` interface, taken from https://github.com/Uniswap/permit2/blob/main/src/interfaces/ISignatureTransfer.sol
+sol! {
+    /// The token and amount details for a transfer signed in the permit transfer signature
+    struct TokenPermissions {
+        /// ERC20 token address
+        address token;
+        /// the maximum amount that can be spent
+        uint256 amount;
+    }
+
+    /// The signed permit message for a single token transfer
+    ///
+    /// NOTE: This differs from the `PermitTransferFrom` struct in the `ISignatureTransfer` interface
+    /// in that it includes the `spender` field. This field is signed and thus must be included in the
+    /// EIP-712 hash, but is not included in the Solidity definition of the  `PermitTransferFrom` struct
+    /// (as this field is injected by the Permit2 contract).
+    struct PermitTransferFrom {
+        /// The token permissions for the transfer
+        TokenPermissions permitted;
+        /// The address to which the transfer is made
+        address spender;
+        /// a unique value for every token owner's signature to prevent signature replays
+        uint256 nonce;
+        /// deadline on the permit signature
+        uint256 deadline;
+    }
+
+    /// The permit message for a single token transfer
+    ///
+    /// This exactly matches the `PermitTransferFrom` struct in the `ISignatureTransfer` interface,
+    /// and is what's expected as an argument to the `permitTransferFrom` method. It must be named
+    /// differently so that the `PermitTransferFrom` name can be used in the EIP712 type hash of the
+    /// struct above.
+    struct CalldataPermitTransferFrom {
+        /// The token permissions for the transfer
+        TokenPermissions permitted;
+        /// a unique value for every token owner's signature to prevent signature replays
+        uint256 nonce;
+        /// deadline on the permit signature
+        uint256 deadline;
+    }
+
+    /// Specifies the recipient address and amount for batched transfers.
+    /// Recipients and amounts correspond to the index of the signed token permissions array.
+    /// Reverts if the requested amount is greater than the permitted signed amount.
+    struct SignatureTransferDetails {
+        /// recipient address
+        address to;
+        /// spender requested amount
+        uint256 requestedAmount;
+    }
+
+    /// Transfers a token using a signed permit message
+    /// Reverts if the requested amount is greater than the permitted signed amount
+    /// permit The permit data signed over by the owner
+    /// owner The owner of the tokens to transfer
+    /// transferDetails The spender's requested transfer details for the permitted token
+    /// signature The signature to verify
+    function permitTransferFrom(
+        CalldataPermitTransferFrom memory permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
+}

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -215,6 +215,22 @@ pub struct ExternalTransfer {
     pub is_withdrawal: bool,
 }
 
+/// Represents the Permit2 data that a user submits alongside a deposit.
+///
+/// [Reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer)
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct PermitPayload {
+    /// The `PermitTransferFrom` nonce
+    #[serde_as(as = "U256Def")]
+    pub nonce: U256,
+    /// The `PermitTransferFrom` deadline
+    #[serde_as(as = "U256Def")]
+    pub deadline: U256,
+    /// The signature of the `PermitTransferFrom` typed data
+    pub signature: Vec<u8>,
+}
+
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.
 /// Since the secp256k1 base field order is larger than that of Bn254's scalar field,
 /// it takes 2 Bn254 scalar field elements to represent each coordinate.

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -36,9 +36,13 @@ impl DarkpoolTestContract {
     }
 
     /// Executes the given external transfer
-    pub fn execute_external_transfer(&mut self, transfer: Bytes, permit_payload: Bytes) -> Result<(), Vec<u8>> {
+    pub fn execute_external_transfer(
+        &mut self,
+        transfer: Bytes,
+        permit_payload: Bytes,
+    ) -> Result<(), Vec<u8>> {
         let external_transfer: ExternalTransfer = deserialize_from_calldata(&transfer)?;
-        DarkpoolContract::execute_external_transfer(self, &external_transfer, permit_payload)?;
+        DarkpoolContract::execute_external_transfer(self, external_transfer, permit_payload)?;
         Ok(())
     }
 

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -28,6 +28,14 @@ use super::constants::{
 };
 
 /// Deserializes a byte-serialized type from calldata
+#[cfg_attr(
+    not(any(
+        feature = "darkpool",
+        feature = "darkpool-test-contract",
+        feature = "verifier"
+    )),
+    allow(dead_code)
+)]
 pub fn deserialize_from_calldata<'a, D: Deserialize<'a>>(
     calldata: &'a Bytes,
 ) -> Result<D, Vec<u8>> {

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -1,9 +1,8 @@
 //! Various Solidity definitions, including ABI-compatible interfaces, events, functions, etc.
 
-use alloc::vec::Vec;
 use alloy_sol_types::sol;
 
-// Various methods and events defined in the Renegade smart contracts
+// Various methods and events used in the Renegade smart contracts
 sol! {
 
     // -------------
@@ -29,6 +28,10 @@ sol! {
     // Testing functions
     function isDummyUpgradeTarget() external view returns (bool);
 
+    /// The native `transfer` function on the ERC20 interface.
+    /// Taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/token/ERC20/IERC20.sol#L41
+    function transfer(address to, uint256 value) external returns (bool);
+
     // ----------
     // | EVENTS |
     // ----------
@@ -49,57 +52,4 @@ sol! {
     event VerifierAddressChanged(address indexed new_address);
     event VkeysAddressChanged(address indexed new_address);
     event MerkleAddressChanged(address indexed new_address);
-}
-
-// Types & methods from the Permit2 `ISignatureTransfer` interface, taken from https://github.com/Uniswap/permit2/blob/main/src/interfaces/ISignatureTransfer.sol
-sol! {
-    /// The token and amount details for a transfer signed in the permit transfer signature
-    struct TokenPermissions {
-        // ERC20 token address
-        address token;
-        // the maximum amount that can be spent
-        uint256 amount;
-    }
-
-    /// The signed permit message for a single token transfer
-    struct PermitTransferFrom {
-        TokenPermissions permitted;
-        // a unique value for every token owner's signature to prevent signature replays
-        uint256 nonce;
-        // deadline on the permit signature
-        uint256 deadline;
-    }
-
-    /// Specifies the recipient address and amount for batched transfers.
-    /// Recipients and amounts correspond to the index of the signed token permissions array.
-    /// Reverts if the requested amount is greater than the permitted signed amount.
-    struct SignatureTransferDetails {
-        // recipient address
-        address to;
-        // spender requested amount
-        uint256 requestedAmount;
-    }
-
-    /// Convenience type bundling together the permit and the signature
-    struct PermitPayload {
-        PermitTransferFrom permit;
-        bytes signature;
-    }
-
-    /// Transfers a token using a signed permit message
-    /// Reverts if the requested amount is greater than the permitted signed amount
-    /// permit The permit data signed over by the owner
-    /// owner The owner of the tokens to transfer
-    /// transferDetails The spender's requested transfer details for the permitted token
-    /// signature The signature to verify
-    function permitTransferFrom(
-        PermitTransferFrom memory permit,
-        SignatureTransferDetails calldata transferDetails,
-        address owner,
-        bytes calldata signature
-    ) external;
-
-    /// The native `transfer` function on the ERC20 interface.
-    /// Taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/token/ERC20/IERC20.sol#L41
-    function transfer(address to, uint256 value) external returns (bool);
 }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true }
 postcard = { workspace = true }
 serde = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-sol-types = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 circuit-types = { workspace = true, features = ["test-helpers"] }
 circuits = { workspace = true }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -24,11 +24,11 @@ abigen!(
         function getRoot() external view returns (uint256)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory permit_payload) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         function markNullifierSpent(uint256 memory nullifier) external
-        function executeExternalTransfer(bytes memory transfer) external
+        function executeExternalTransfer(bytes memory transfer, bytes memory permit_payload) external
         function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool)
         function clearMerkle() external
     ]"#

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -27,3 +27,6 @@ pub(crate) const SET_VKEYS_ADDRESS_METHOD_NAME: &str = "setVkeysAddress";
 
 /// The name of the `set_merkle_address` method on the Darkpool contract
 pub(crate) const SET_MERKLE_ADDRESS_METHOD_NAME: &str = "setMerkleAddress";
+
+/// The name of the domain separator for Permit2 typed data
+pub(crate) const PERMIT2_EIP712_DOMAIN_NAME: &str = "Permit2";

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
             )
             .await?;
             test_pausable(darkpool_proxy_address, client.clone()).await?;
-            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client.clone())
+            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client.clone(), &deployments_file)
                 .await?;
             test_new_wallet(darkpool_proxy_address, client.clone()).await?;
             test_update_wallet(darkpool_proxy_address, client.clone()).await?;
@@ -140,7 +140,7 @@ async fn main() -> Result<()> {
         }
         Tests::Pausable => test_pausable(darkpool_proxy_address, client).await,
         Tests::ExternalTransfer => {
-            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client).await
+            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client, &deployments_file).await
         }
         Tests::NewWallet => test_new_wallet(darkpool_proxy_address, client).await,
         Tests::UpdateWallet => test_update_wallet(darkpool_proxy_address, client).await,

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -33,7 +33,7 @@ use ethers::{
 };
 use eyre::{eyre, Result};
 use rand::{thread_rng, Rng, RngCore};
-use scripts::constants::TEST_FUNDING_AMOUNT;
+use scripts::{constants::TEST_FUNDING_AMOUNT, utils::LocalWalletProvider};
 use std::sync::Arc;
 use tracing::log::info;
 
@@ -58,7 +58,7 @@ use crate::{
 /// Test how the contracts call the `ecAdd` precompile
 pub(crate) async fn test_ec_add(
     precompiles_contract_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_ec_add`");
     let contract = PrecompileTestContract::new(precompiles_contract_address, client);
@@ -85,7 +85,7 @@ pub(crate) async fn test_ec_add(
 /// Test how the contracts call the `ecMul` precompile
 pub(crate) async fn test_ec_mul(
     precompiles_contract_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_ec_mul`");
     let contract = PrecompileTestContract::new(precompiles_contract_address, client);
@@ -115,7 +115,7 @@ pub(crate) async fn test_ec_mul(
 /// Test how the contracts call the `ecPairing` precompile
 pub(crate) async fn test_ec_pairing(
     precompiles_contract_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_ec_pairing`");
     let contract = PrecompileTestContract::new(precompiles_contract_address, client);
@@ -141,7 +141,7 @@ pub(crate) async fn test_ec_pairing(
 /// Test how the contracts call the `ecRecover` precompile
 pub(crate) async fn test_ec_recover(
     precompiles_contract_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_ec_recover`");
     let contract = PrecompileTestContract::new(precompiles_contract_address, client);
@@ -173,7 +173,7 @@ pub(crate) async fn test_ec_recover(
 /// Test the Merkle tree functionality
 pub(crate) async fn test_merkle(
     merkle_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_merkle`");
     let contract = MerkleContract::new(merkle_address, client);
@@ -223,7 +223,7 @@ pub(crate) async fn test_merkle(
 /// Test the verifier functionality
 pub(crate) async fn test_verifier(
     verifier_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_verifier`");
     let contract = VerifierContract::new(verifier_address, client);
@@ -306,7 +306,7 @@ pub(crate) async fn test_upgradeable(
     proxy_address: Address,
     dummy_upgrade_target_address: Address,
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_upgradeable`");
     let proxy_admin_contract = DarkpoolProxyAdminContract::new(proxy_admin_address, client.clone());
@@ -392,7 +392,7 @@ pub(crate) async fn test_implementation_address_setters(
     vkeys_address: Address,
     merkle_address: Address,
     dummy_upgrade_target_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_implementation_address_setters`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);
@@ -455,7 +455,7 @@ pub(crate) async fn test_implementation_address_setters(
 /// Test the initialization of the darkpool
 pub(crate) async fn test_initializable(
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_initializable`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);
@@ -491,7 +491,7 @@ pub(crate) async fn test_ownable(
     verifier_address: Address,
     vkeys_address: Address,
     merkle_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_ownable`");
     let contract = DarkpoolTestContract::new(darkpool_address, client.clone());
@@ -597,7 +597,7 @@ pub(crate) async fn test_ownable(
 /// Test the pausability of the darkpool
 pub(crate) async fn test_pausable(
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_pausable`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);
@@ -631,6 +631,7 @@ pub(crate) async fn test_pausable(
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
                 public_inputs_signature.clone(),
+                Bytes::new(), /* permit_payload */
             )
             .send(),
         contract
@@ -662,6 +663,7 @@ pub(crate) async fn test_pausable(
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
                 public_inputs_signature,
+                Bytes::new(), /* permit_payload */
             )
             .send(),
         contract
@@ -686,7 +688,7 @@ pub(crate) async fn test_pausable(
 /// Test the nullifier set functionality
 pub(crate) async fn test_nullifier_set(
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_nullifier_set`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);
@@ -715,7 +717,8 @@ pub(crate) async fn test_nullifier_set(
 pub(crate) async fn test_external_transfer(
     darkpool_address: Address,
     dummy_erc20_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
+    deployments_path: &str,
 ) -> Result<()> {
     info!("Running `test_external_transfer`");
     let darkpool_test_contract = DarkpoolTestContract::new(darkpool_address, client.clone());
@@ -740,6 +743,7 @@ pub(crate) async fn test_external_transfer(
         &dummy_erc20_contract,
         &deposit,
         account_address,
+        deployments_path,
     )
     .await?;
     assert_eq!(
@@ -760,6 +764,7 @@ pub(crate) async fn test_external_transfer(
         &dummy_erc20_contract,
         &withdrawal,
         account_address,
+        deployments_path,
     )
     .await?;
     assert_eq!(
@@ -778,7 +783,7 @@ pub(crate) async fn test_external_transfer(
 /// Test the `new_wallet` method on the darkpool
 pub(crate) async fn test_new_wallet(
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_new_wallet`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);
@@ -820,7 +825,7 @@ pub(crate) async fn test_new_wallet(
 /// Test the `update_wallet` method on the darkpool
 pub(crate) async fn test_update_wallet(
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_update_wallet`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);
@@ -839,6 +844,7 @@ pub(crate) async fn test_update_wallet(
             serialize_to_calldata(&proof)?,
             serialize_to_calldata(&statement)?,
             public_inputs_signature,
+            Bytes::new(), /* permit_payload */
         )
         .send()
         .await?
@@ -873,7 +879,7 @@ pub(crate) async fn test_update_wallet(
 /// Test the `process_match_settle` method on the darkpool
 pub(crate) async fn test_process_match_settle(
     darkpool_address: Address,
-    client: Arc<impl Middleware + 'static>,
+    client: Arc<LocalWalletProvider<impl Middleware + 'static>>,
 ) -> Result<()> {
     info!("Running `test_process_match_settle`");
     let contract = DarkpoolTestContract::new(darkpool_address, client);

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -14,6 +14,7 @@ use crate::{
         deploy_test_contracts, gen_vkeys, upgrade,
     },
     errors::ScriptError,
+    utils::LocalWalletProvider,
 };
 
 /// Scripts for deploying & upgrading the Renegade Stylus contracts
@@ -60,7 +61,7 @@ impl Command {
     /// Run the command
     pub async fn run(
         self,
-        client: Arc<impl Middleware>,
+        client: Arc<LocalWalletProvider<impl Middleware>>,
         rpc_url: &str,
         priv_key: &str,
         deployments_path: &str,

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -45,7 +45,7 @@ use crate::{
     utils::{
         build_stylus_contract, darkpool_initialize_calldata, deploy_stylus_contract,
         get_contract_key, parse_addr_from_deployments_file, setup_client, write_deployed_address,
-        write_vkey_file,
+        write_vkey_file, LocalWalletProvider,
     },
 };
 
@@ -56,7 +56,7 @@ pub async fn deploy_test_contracts(
     args: DeployTestContractsArgs,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<impl Middleware>,
+    client: Arc<LocalWalletProvider<impl Middleware>>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     info!("Generating testing verification keys");
@@ -173,7 +173,7 @@ pub async fn deploy_test_contracts(
 /// Deploys the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts
 pub async fn deploy_proxy(
     args: DeployProxyArgs,
-    client: Arc<impl Middleware>,
+    client: Arc<LocalWalletProvider<impl Middleware>>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     // Get proxy contract ABI and bytecode
@@ -268,7 +268,7 @@ pub async fn deploy_proxy(
 
 /// Deploys the `Permit2` contract
 pub async fn deploy_permit2(
-    client: Arc<impl Middleware>,
+    client: Arc<LocalWalletProvider<impl Middleware>>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     // Get Permit2 contract ABI and bytecode
@@ -308,7 +308,7 @@ pub async fn deploy_erc20s(
     args: DeployErc20sArgs,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<impl Middleware>,
+    client: Arc<LocalWalletProvider<impl Middleware>>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     let wasm_file_path =
@@ -382,7 +382,7 @@ pub async fn build_and_deploy_stylus_contract(
     args: DeployStylusArgs,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<impl Middleware>,
+    client: Arc<LocalWalletProvider<impl Middleware>>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     let wasm_file_path = build_stylus_contract(args.contract, args.no_verify)?;
@@ -402,7 +402,7 @@ pub async fn build_and_deploy_stylus_contract(
 /// Upgrades the darkpool implementation
 pub async fn upgrade(
     args: UpgradeArgs,
-    client: Arc<impl Middleware>,
+    client: Arc<LocalWalletProvider<impl Middleware>>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     let proxy_admin_address =

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -43,7 +43,7 @@ pub const MANIFEST_DIR_ENV_VAR: &str = "CARGO_MANIFEST_DIR";
 pub const RUSTFLAGS_ENV_VAR: &str = "RUSTFLAGS";
 
 /// The default flags to add to RUSTFLAGS for all contract compilations
-pub const DEFAULT_RUSTFLAGS: &str = "-Clink-arg=-zstack-size=65536 -Zlocation-detail=none";
+pub const DEFAULT_RUSTFLAGS: &str = "-Clink-arg=-zstack-size=131072 -Zlocation-detail=none";
 
 /// The inline threshold flag for the Rust compiler
 pub const INLINE_THRESHOLD_FLAG: &str = "-Cinline-threshold=0";


### PR DESCRIPTION
This PR updates the external transfer test to employ the Permit2 pattern by appropriately encoding and signing a `PermitTransferFrom` struct. We do this both in the case of deposit & withdrawal for simplicity, but of course it is only used contract-side for deposits.

Implementing & running this test led to another change, namely that we now use `serde` for serialization of the relevant Permit2 data that must be passed to the contract, which is just the permit nonce, deadline, and signature. Everything else can be gathered from the external transfer struct. This technically limits the Permit2 functionality, one could approve more funds than necessary for transfer, but now we implicitly constrain that the permitted funds must be exactly equal to what is in the external transfer struct.

The reason for this change is binary size - using `serde` in this way led to a smaller binary for the darkpool / darkpool testing contract than the ABI serialization round trip we were invoking before, and smaller even than passing the nonce, deadline, and signature as separate method arguments to `update_wallet` (which clutters the interface, anyway).

All integration tests pass.