### PR TITLE
contracts-stylus: darkpool: sign external transfer

### DIFF
--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -215,20 +215,22 @@ pub struct ExternalTransfer {
     pub is_withdrawal: bool,
 }
 
-/// Represents the Permit2 data that a user submits alongside a deposit.
-///
-/// [Reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer)
+/// Auxiliary data passed alongside an external transfer to verify its validity.
+/// This includes a signature over the external transfer, and in the case of a deposit,
+/// the associated Permit2 data ([reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer))
 #[serde_as]
 #[derive(Serialize, Deserialize)]
-pub struct PermitPayload {
+pub struct TransferAuxData {
     /// The `PermitTransferFrom` nonce
-    #[serde_as(as = "U256Def")]
-    pub nonce: U256,
+    #[serde_as(as = "Option<U256Def>")]
+    pub permit_nonce: Option<U256>,
     /// The `PermitTransferFrom` deadline
-    #[serde_as(as = "U256Def")]
-    pub deadline: U256,
+    #[serde_as(as = "Option<U256Def>")]
+    pub permit_deadline: Option<U256>,
     /// The signature of the `PermitTransferFrom` typed data
-    pub signature: Vec<u8>,
+    pub permit_signature: Option<Vec<u8>>,
+    /// The signature of the external transfer
+    pub transfer_signature: Vec<u8>,
 }
 
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -31,7 +31,10 @@ use crate::{
             VERIFICATION_FAILED_ERROR_MESSAGE, ZERO_ADDRESS_ERROR_MESSAGE, ZERO_FEE_ERROR_MESSAGE,
         },
         helpers::{
-            assert_valid_signature, call_helper, delegate_call_helper, deserialize_from_calldata, pk_to_u256s, postcard_serialize, scalar_to_u256, serialize_match_statements_for_verification, serialize_statement_for_verification, static_call_helper
+            assert_valid_signature, call_helper, delegate_call_helper, deserialize_from_calldata,
+            pk_to_u256s, postcard_serialize, scalar_to_u256,
+            serialize_match_statements_for_verification, serialize_statement_for_verification,
+            static_call_helper,
         },
         solidity::{
             initCall, insertSharesCommitmentCall, processMatchSettleVkeysCall, rootCall,
@@ -630,7 +633,8 @@ impl DarkpoolContract {
         transfer: ExternalTransfer,
         transfer_aux_data_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
-        let transfer_aux_data: TransferAuxData = deserialize_from_calldata(&transfer_aux_data_bytes)?;
+        let transfer_aux_data: TransferAuxData =
+            deserialize_from_calldata(&transfer_aux_data_bytes)?;
         assert_valid_signature(
             old_pk_root,
             &postcard_serialize(&transfer)?,

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -5,7 +5,7 @@ use core::borrow::BorrowMut;
 use alloc::vec::Vec;
 use contracts_common::{
     constants::{MERKLE_ADDRESS_SELECTOR, VERIFIER_ADDRESS_SELECTOR, VKEYS_ADDRESS_SELECTOR},
-    types::ExternalTransfer,
+    types::{ExternalTransfer, PublicSigningKey},
 };
 use stylus_sdk::{abi::Bytes, alloy_primitives::U256, prelude::*};
 
@@ -38,11 +38,18 @@ impl DarkpoolTestContract {
     /// Executes the given external transfer
     pub fn execute_external_transfer(
         &mut self,
-        transfer: Bytes,
-        permit_payload: Bytes,
+        pk_root_bytes: Bytes,
+        transfer_bytes: Bytes,
+        transfer_aux_data_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
-        let external_transfer: ExternalTransfer = deserialize_from_calldata(&transfer)?;
-        DarkpoolContract::execute_external_transfer(self, external_transfer, permit_payload)?;
+        let pk_root: PublicSigningKey = deserialize_from_calldata(&pk_root_bytes)?;
+        let external_transfer: ExternalTransfer = deserialize_from_calldata(&transfer_bytes)?;
+        DarkpoolContract::execute_external_transfer(
+            self,
+            &pk_root,
+            external_transfer,
+            transfer_aux_data_bytes,
+        )?;
         Ok(())
     }
 

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -81,6 +81,10 @@ pub const CALLDATA_SER_ERROR_MESSAGE: &[u8] = b"calldata ser error";
 /// returned by an external contract call
 pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata";
 
+/// The revert message when failing to extract auxiliary
+/// data for an external transfer
+pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
+
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -58,11 +58,9 @@ pub const TREE_FULL_ERROR_MESSAGE: &[u8] = b"tree full";
 
 /// The revert message when invoking the ecRecover precompile
 /// reverts
-#[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
 pub const ECDSA_ERROR_MESSAGE: &[u8] = b"ecdsa error";
 
 /// The revert message when an ECDSA signature is invalid
-#[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]
 pub const INVALID_SIGNATURE_ERROR_MESSAGE: &[u8] = b"invalid signature";
 
 /// The revert message when trying to coerce an
@@ -83,6 +81,7 @@ pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata"
 
 /// The revert message when failing to extract auxiliary
 /// data for an external transfer
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
 pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
 
 /// The last byte of the `ecAdd` precompile address, 0x06

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -24,11 +24,11 @@ abigen!(
         function getRoot() external view returns (uint256)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory permit_payload) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         function markNullifierSpent(uint256 memory nullifier) external
-        function executeExternalTransfer(bytes memory transfer, bytes memory permit_payload) external
+        function executeExternalTransfer(bytes memory pk_root, bytes memory transfer, bytes memory transfer_aux_data) external
         function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool)
         function clearMerkle() external
     ]"#

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -631,7 +631,7 @@ pub(crate) async fn test_pausable(
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
                 public_inputs_signature.clone(),
-                Bytes::new(), /* permit_payload */
+                Bytes::new(), /* transfer_aux_data */
             )
             .send(),
         contract
@@ -663,7 +663,7 @@ pub(crate) async fn test_pausable(
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
                 public_inputs_signature,
-                Bytes::new(), /* permit_payload */
+                Bytes::new(), /* transfer_aux_data */
             )
             .send(),
         contract
@@ -736,11 +736,15 @@ pub(crate) async fn test_external_transfer(
         .call()
         .await?;
 
+    let (signing_key, pk_root) = random_keypair(&mut thread_rng());
+
     // Create & execute deposit external transfer, check balances
     let deposit = dummy_erc20_deposit(account_address, mint);
     let (darkpool_balance, user_balance) = execute_transfer_and_get_balances(
         &darkpool_test_contract,
         &dummy_erc20_contract,
+        &signing_key,
+        &pk_root,
         &deposit,
         account_address,
         deployments_path,
@@ -762,6 +766,8 @@ pub(crate) async fn test_external_transfer(
     let (darkpool_balance, user_balance) = execute_transfer_and_get_balances(
         &darkpool_test_contract,
         &dummy_erc20_contract,
+        &signing_key,
+        &pk_root,
         &withdrawal,
         account_address,
         deployments_path,
@@ -844,7 +850,7 @@ pub(crate) async fn test_update_wallet(
             serialize_to_calldata(&proof)?,
             serialize_to_calldata(&statement)?,
             public_inputs_signature,
-            Bytes::new(), /* permit_payload */
+            Bytes::new(), /* transfer_aux_data */
         )
         .send()
         .await?


### PR DESCRIPTION
This PR updates the darkpool to check a signature over the external transfer struct, and updates the tests to generate this signature.

Due to binary size constraints being hit, I was unable to deploy the darkpool / run the tests. Mitigations for binary size are coming in the next PR, after which I will test this functionality.