### PR TITLE
contracts-stylus: darkpool, transfer_executor: add transfer executor contract

### DIFF
--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -230,7 +230,7 @@ pub struct TransferAuxData {
     /// The signature of the `PermitTransferFrom` typed data
     pub permit_signature: Option<Vec<u8>>,
     /// The signature of the external transfer
-    pub transfer_signature: Vec<u8>,
+    pub transfer_signature: Option<Vec<u8>>,
 }
 
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -18,15 +18,17 @@ serde = { workspace = true }
 [features]
 darkpool = []
 darkpool-test-contract = []
-no-verify = []
 merkle = ["stylus-sdk/storage-cache"]
 merkle-test-contract = []
 verifier = []
 vkeys = []
 test-vkeys = []
+transfer-executor = []
 precompile-test-contract = []
 dummy-erc20 = []
 dummy-upgrade-target = []
+no-verify = []
+
 export-abi = ["stylus-sdk/export-abi"]
 
 [lib]

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -377,7 +377,7 @@ impl DarkpoolContract {
         if let Some(external_transfer) = valid_wallet_update_statement.external_transfer {
             DarkpoolContract::execute_external_transfer(
                 storage,
-                &valid_wallet_update_statement.old_pk_root,
+                valid_wallet_update_statement.old_pk_root,
                 external_transfer,
                 transfer_aux_data_bytes,
             )?;
@@ -642,12 +642,12 @@ impl DarkpoolContract {
     /// Executes the given external transfer (withdrawal / deposit)
     pub fn execute_external_transfer<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
-        old_pk_root: &PublicSigningKey,
+        old_pk_root: PublicSigningKey,
         transfer: ExternalTransfer,
         transfer_aux_data_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
         let transfer_executor_address = storage.borrow_mut().transfer_executor_address.get();
-        let old_pk_root_bytes = postcard_serialize(old_pk_root)?;
+        let old_pk_root_bytes = postcard_serialize(&Some(old_pk_root))?;
         let transfer_bytes = postcard_serialize(&transfer)?;
 
         delegate_call_helper::<executeExternalTransferCall>(

--- a/contracts-stylus/src/contracts/mod.rs
+++ b/contracts-stylus/src/contracts/mod.rs
@@ -12,6 +12,9 @@ mod verifier;
 #[cfg(any(feature = "vkeys", feature = "test-vkeys"))]
 mod vkeys;
 
+#[cfg(feature = "transfer-executor")]
+mod transfer_executor;
+
 #[cfg(any(
     feature = "precompile-test-contract",
     feature = "merkle-test-contract",

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -3,17 +3,16 @@
 use core::borrow::BorrowMut;
 
 use alloc::vec::Vec;
-use contracts_common::{
-    constants::{MERKLE_ADDRESS_SELECTOR, VERIFIER_ADDRESS_SELECTOR, VKEYS_ADDRESS_SELECTOR},
-    types::{ExternalTransfer, PublicSigningKey},
+use contracts_common::constants::{
+    MERKLE_ADDRESS_SELECTOR, VERIFIER_ADDRESS_SELECTOR, VKEYS_ADDRESS_SELECTOR,
 };
-use stylus_sdk::{abi::Bytes, alloy_primitives::U256, prelude::*};
+use stylus_sdk::{alloy_primitives::U256, prelude::*};
 
 use crate::{
     contracts::darkpool::DarkpoolContract,
     utils::{
-        helpers::{delegate_call_helper, deserialize_from_calldata, u256_to_scalar},
-        solidity::{initCall, isDummyUpgradeTargetCall},
+        helpers::{delegate_call_helper, u256_to_scalar},
+        solidity::{init_0Call as initMerkleCall, isDummyUpgradeTargetCall},
     },
 };
 
@@ -33,24 +32,6 @@ impl DarkpoolTestContract {
     pub fn mark_nullifier_spent(&mut self, nullifier: U256) -> Result<(), Vec<u8>> {
         let nullifier = u256_to_scalar(nullifier)?;
         DarkpoolContract::mark_nullifier_spent(self, nullifier)
-    }
-
-    /// Executes the given external transfer
-    pub fn execute_external_transfer(
-        &mut self,
-        pk_root_bytes: Bytes,
-        transfer_bytes: Bytes,
-        transfer_aux_data_bytes: Bytes,
-    ) -> Result<(), Vec<u8>> {
-        let pk_root: PublicSigningKey = deserialize_from_calldata(&pk_root_bytes)?;
-        let external_transfer: ExternalTransfer = deserialize_from_calldata(&transfer_bytes)?;
-        DarkpoolContract::execute_external_transfer(
-            self,
-            &pk_root,
-            external_transfer,
-            transfer_aux_data_bytes,
-        )?;
-        Ok(())
     }
 
     /// Attempts to call [`DummyUpgradeTarget::is_dummy_upgrade_target`] on either
@@ -80,6 +61,6 @@ impl DarkpoolTestContract {
             .merkle_address
             .get();
 
-        delegate_call_helper::<initCall>(self, merkle_address, ()).map(|_| ())
+        delegate_call_helper::<initMerkleCall>(self, merkle_address, ()).map(|_| ())
     }
 }

--- a/contracts-stylus/src/contracts/transfer_executor.rs
+++ b/contracts-stylus/src/contracts/transfer_executor.rs
@@ -1,0 +1,126 @@
+//! The transfer executor contract, responsible for executing external transfers to/from the darkpool.
+
+use crate::utils::{
+    constants::{MERKLE_STORAGE_GAP_SIZE, MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE},
+    helpers::{assert_valid_signature, call_helper, deserialize_from_calldata, postcard_serialize},
+    solidity::{transferCall, ExternalTransfer as ExternalTransferEvent},
+};
+use alloc::vec::Vec;
+use contracts_common::{
+    solidity::{
+        permitTransferFromCall, CalldataPermitTransferFrom, SignatureTransferDetails,
+        TokenPermissions,
+    },
+    types::{ExternalTransfer, PublicSigningKey, TransferAuxData},
+};
+use stylus_sdk::{
+    abi::Bytes,
+    alloy_primitives::Address,
+    contract, evm,
+    prelude::*,
+    storage::{StorageAddress, StorageArray, StorageU256},
+};
+
+/// The transfer executor contract's storage layout
+#[solidity_storage]
+#[entrypoint]
+pub struct TransferExecutorContract {
+    /// Storage gap to prevent collisions with the Merkle contract
+    __gap: StorageArray<StorageU256, MERKLE_STORAGE_GAP_SIZE>,
+
+    /// The address of the Permit2 contract being used
+    permit2_address: StorageAddress,
+}
+
+#[external]
+impl TransferExecutorContract {
+    /// Initializes the transfer executor with the address of the Permit2 contract being used
+    // TODO: Deploy Permit2 using `CREATE2` and use a static address
+    pub fn init(&mut self, permit2_address: Address) -> Result<(), Vec<u8>> {
+        self.permit2_address.set(permit2_address);
+        Ok(())
+    }
+
+    /// Executes an external transfer to/from the darkpool,
+    /// using the auxiliary transfer data for validation as appropriate
+    /// depending on the transfer direction.
+    pub fn execute_external_transfer(
+        &mut self,
+        old_pk_root: Bytes,
+        transfer: Bytes,
+        transfer_aux_data: Bytes,
+    ) -> Result<(), Vec<u8>> {
+        let old_pk_root: PublicSigningKey = deserialize_from_calldata(&old_pk_root)?;
+        let transfer: ExternalTransfer = deserialize_from_calldata(&transfer)?;
+        let transfer_aux_data: TransferAuxData = deserialize_from_calldata(&transfer_aux_data)?;
+
+        assert_valid_signature(
+            &old_pk_root,
+            &postcard_serialize(&transfer)?,
+            &transfer_aux_data.transfer_signature,
+        )?;
+
+        let ExternalTransfer {
+            mint,
+            account_addr,
+            amount,
+            is_withdrawal,
+        } = transfer;
+
+        if is_withdrawal {
+            // In the case of a withdrawal, we make a simple `transfer` call
+            // from the darkpool to the user.
+            call_helper::<transferCall>(
+                self,
+                mint, /* address */
+                (account_addr /* to */, amount),
+            )?;
+        } else {
+            // In the case of a deposit, we make a `permitTransferFrom` call through
+            // the `Permit2` contract using the calldata-serialized `PermitPayload`
+
+            let darkpool_address = contract::address();
+            let permit2_address = self.permit2_address.get();
+
+            let permit = CalldataPermitTransferFrom {
+                permitted: TokenPermissions {
+                    amount,
+                    token: mint,
+                },
+                nonce: transfer_aux_data
+                    .permit_nonce
+                    .ok_or(MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE)?,
+                deadline: transfer_aux_data
+                    .permit_deadline
+                    .ok_or(MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE)?,
+            };
+
+            let signature_transfer_details = SignatureTransferDetails {
+                to: darkpool_address,
+                requestedAmount: amount,
+            };
+
+            call_helper::<permitTransferFromCall>(
+                self,
+                permit2_address, /* address */
+                (
+                    permit,
+                    signature_transfer_details,
+                    account_addr, /* owner */
+                    transfer_aux_data
+                        .permit_signature
+                        .ok_or(MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE)?,
+                ),
+            )?;
+        };
+
+        evm::log(ExternalTransferEvent {
+            account: account_addr,
+            mint,
+            is_withdrawal,
+            amount,
+        });
+
+        Ok(())
+    }
+}

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -84,6 +84,11 @@ pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata"
 #[cfg(feature = "transfer-executor")]
 pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
 
+/// The revert message when failing to extract a `pk_root`
+/// for an external transfer
+#[cfg(feature = "transfer-executor")]
+pub const MISSING_PK_ROOT_ERROR_MESSAGE: &[u8] = b"missing pk_root for transfer";
+
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -81,7 +81,7 @@ pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata"
 
 /// The revert message when failing to extract auxiliary
 /// data for an external transfer
-#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+#[cfg(feature = "transfer-executor")]
 pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
 
 /// The last byte of the `ecAdd` precompile address, 0x06
@@ -100,11 +100,21 @@ pub const PAIRING_CHECK_RESULT_LAST_BYTE_INDEX: usize = 31;
 /// The byte length of the input to the `ecRecover` precompile
 pub const EC_RECOVER_INPUT_LEN: usize = 128;
 
-/// The number of storage slots to use in the Darkpool contract's
-/// storage gap, which ensures that there are no storage collisions
-/// with the Merkle contract to which it delegatecalls
+/// The number of storage slots to allocate for the Merkle contract,
+/// used in creating storage gaps in contracts in the same context
+/// to ensure that there are no storage collisions
+#[cfg(any(
+    feature = "darkpool",
+    feature = "darkpool-test-contract",
+    feature = "transfer-executor"
+))]
+pub const MERKLE_STORAGE_GAP_SIZE: usize = 64;
+
+/// The number of storage slots to allocate for the transfer executor
+/// contract, used in creating storage gaps in contracts in the same
+/// context to ensure that there are no storage collisions
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
-pub const STORAGE_GAP_SIZE: usize = 64;
+pub const TRANSFER_EXECUTOR_STORAGE_GAP_SIZE: usize = 64;
 
 /// The serialized VALID WALLET CREATE verification key
 #[cfg(feature = "vkeys")]

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -153,10 +153,7 @@ pub fn static_call_helper<C: SolCall>(
 
 /// Performs a `call` to the given address, calling the function
 /// defined as a `SolCall` with the given arguments.
-#[cfg_attr(
-    not(any(feature = "darkpool", feature = "darkpool-test-contract")),
-    allow(dead_code)
-)]
+#[cfg_attr(not(feature = "transfer-executor"), allow(dead_code))]
 pub fn call_helper<C: SolCall>(
     storage: &mut impl TopLevelStorage,
     address: Address,
@@ -216,8 +213,7 @@ pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], Vec<
 /// if verification is enabled
 #[cfg_attr(
     not(any(
-        feature = "darkpool",
-        feature = "darkpool-test-contract",
+        feature = "transfer-executor",
         feature = "merkle",
         feature = "merkle-test-contract",
     )),

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -25,12 +25,16 @@ sol! {
     function verify(bytes memory verification_bundle) external view returns (bool);
     function verifyMatch(bytes memory match_bundle) external view returns (bool);
 
-    // Testing functions
-    function isDummyUpgradeTarget() external view returns (bool);
+    // Transfer executor functions
+    function init(address memory permit2_address) external;
+    function executeExternalTransfer(bytes memory old_pk_root, bytes memory transfer, bytes memory transfer_aux_data) external;
 
     /// The native `transfer` function on the ERC20 interface.
     /// Taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/token/ERC20/IERC20.sol#L41
     function transfer(address to, uint256 value) external returns (bool);
+
+    // Testing functions
+    function isDummyUpgradeTarget() external view returns (bool);
 
     // ----------
     // | EVENTS |
@@ -52,4 +56,5 @@ sol! {
     event VerifierAddressChanged(address indexed new_address);
     event VkeysAddressChanged(address indexed new_address);
     event MerkleAddressChanged(address indexed new_address);
+    event TransferExecutorAddressChanged(address indexed new_address);
 }

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -278,7 +278,7 @@ pub(crate) async fn gen_transfer_aux_data(
         permit_nonce: Some(permit_nonce),
         permit_deadline: Some(permit_deadline),
         permit_signature: Some(permit_signature),
-        transfer_signature,
+        transfer_signature: Some(transfer_signature),
     })
 }
 

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -191,10 +191,7 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
                 OPT_LEVEL_FLAG, OPT_LEVEL_S, INLINE_THRESHOLD_FLAG
             )
         }
-        StylusContract::Darkpool => {
-            format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_Z)
-        }
-        StylusContract::DarkpoolTestContract => {
+        StylusContract::DarkpoolTestContract | StylusContract::Darkpool => {
             format!(
                 "{}{} {}",
                 OPT_LEVEL_FLAG, OPT_LEVEL_Z, INLINE_THRESHOLD_FLAG


### PR DESCRIPTION
This PR introduces the `TransferExecutorContract`, which stores the Permit2 contract address and is responsible for validating & executing external transfers. With this, the Darkpool contract now deploys at 22.1kb (down from 24.7), and the transfer executor itself deploys at 10.6kb.

Changes to the `scripts` crate to deploy the `TransferExecutorContract` will come in a follow-up PR.