### PR TITLE
scripts, integration: deploy & test transfer executor contract

### DIFF
--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -5,7 +5,7 @@ use ethers::prelude::abigen;
 abigen!(
     DarkpoolTestContract,
     r#"[
-        function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address, address memory permit2_address, uint256 memory protocol_fee) external
+        function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address, address memory transfer_executor_address, address memory permit2_address, uint256 memory protocol_fee) external
 
         function owner() external view returns (address)
         function transferOwnership(address memory new_owner) external
@@ -28,9 +28,16 @@ abigen!(
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         function markNullifierSpent(uint256 memory nullifier) external
-        function executeExternalTransfer(bytes memory pk_root, bytes memory transfer, bytes memory transfer_aux_data) external
         function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool)
         function clearMerkle() external
+    ]"#
+);
+
+abigen!(
+    TransferExecutorContract,
+    r#"[
+        function init(address permit2_address) external
+        function executeExternalTransfer(bytes memory old_pk_root, bytes memory transfer, bytes memory transfer_aux_data) external
     ]"#
 );
 

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -10,7 +10,8 @@ use scripts::{
     constants::{
         DARKPOOL_CONTRACT_KEY, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY,
         DUMMY_ERC20_TICKER, DUMMY_UPGRADE_TARGET_CONTRACT_KEY, MERKLE_CONTRACT_KEY,
-        PRECOMPILE_TEST_CONTRACT_KEY, VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
+        PERMIT2_CONTRACT_KEY, PRECOMPILE_TEST_CONTRACT_KEY, TRANSFER_EXECUTOR_CONTRACT_KEY,
+        VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
     },
     utils::{parse_addr_from_deployments_file, setup_client},
 };
@@ -50,6 +51,10 @@ async fn main() -> Result<()> {
     let verifier_address =
         parse_addr_from_deployments_file(&deployments_file, VERIFIER_CONTRACT_KEY)?;
     let vkeys_address = parse_addr_from_deployments_file(&deployments_file, VKEYS_CONTRACT_KEY)?;
+    let permit2_address =
+        parse_addr_from_deployments_file(&deployments_file, PERMIT2_CONTRACT_KEY)?;
+    let transfer_executor_address =
+        parse_addr_from_deployments_file(&deployments_file, TRANSFER_EXECUTOR_CONTRACT_KEY)?;
     let dummy_erc20_address =
         parse_addr_from_deployments_file(&deployments_file, DUMMY_ERC20_TICKER)?;
     let dummy_upgrade_target_address =
@@ -93,8 +98,13 @@ async fn main() -> Result<()> {
             )
             .await?;
             test_pausable(darkpool_proxy_address, client.clone()).await?;
-            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client.clone(), &deployments_file)
-                .await?;
+            test_external_transfer(
+                transfer_executor_address,
+                permit2_address,
+                dummy_erc20_address,
+                client.clone(),
+            )
+            .await?;
             test_new_wallet(darkpool_proxy_address, client.clone()).await?;
             test_update_wallet(darkpool_proxy_address, client.clone()).await?;
             test_process_match_settle(darkpool_proxy_address, client).await
@@ -140,7 +150,13 @@ async fn main() -> Result<()> {
         }
         Tests::Pausable => test_pausable(darkpool_proxy_address, client).await,
         Tests::ExternalTransfer => {
-            test_external_transfer(darkpool_proxy_address, dummy_erc20_address, client, &deployments_file).await
+            test_external_transfer(
+                transfer_executor_address,
+                permit2_address,
+                dummy_erc20_address,
+                client,
+            )
+            .await
         }
         Tests::NewWallet => test_new_wallet(darkpool_proxy_address, client).await,
         Tests::UpdateWallet => test_update_wallet(darkpool_proxy_address, client).await,

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -160,6 +160,8 @@ pub enum StylusContract {
     Vkeys,
     /// The test verification keys contract
     TestVkeys,
+    /// The transfer executor contract
+    TransferExecutor,
     /// The dummy ERC20 contract
     DummyErc20,
     /// The dummy upgrade target contract
@@ -178,6 +180,7 @@ impl Display for StylusContract {
             StylusContract::Verifier => write!(f, "verifier"),
             StylusContract::Vkeys => write!(f, "vkeys"),
             StylusContract::TestVkeys => write!(f, "test-vkeys"),
+            StylusContract::TransferExecutor => write!(f, "transfer-executor"),
             StylusContract::DummyErc20 => write!(f, "dummy-erc20"),
             StylusContract::DummyUpgradeTarget => write!(f, "dummy-upgrade-target"),
             StylusContract::PrecompileTestContract => write!(f, "precompile-test-contract"),

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -37,8 +37,8 @@ use crate::{
         NUM_BYTES_ADDRESS, NUM_BYTES_STORAGE_SLOT, NUM_DEPLOY_CONFIRMATIONS, PERMIT2_ABI,
         PERMIT2_BYTECODE, PERMIT2_CONTRACT_KEY, PROCESS_MATCH_SETTLE_VKEYS_FILE, PROXY_ABI,
         PROXY_ADMIN_STORAGE_SLOT, PROXY_BYTECODE, TEST_FUNDING_AMOUNT,
-        VALID_WALLET_CREATE_VKEY_FILE, VALID_WALLET_UPDATE_VKEY_FILE, VERIFIER_CONTRACT_KEY,
-        VKEYS_CONTRACT_KEY,
+        TRANSFER_EXECUTOR_CONTRACT_KEY, VALID_WALLET_CREATE_VKEY_FILE,
+        VALID_WALLET_UPDATE_VKEY_FILE, VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
     },
     errors::ScriptError,
     solidity::{DummyErc20Contract, ProxyAdminContract},
@@ -143,6 +143,17 @@ pub async fn deploy_test_contracts(
     info!("Deploying Permit2 contract");
     deploy_permit2(client.clone(), deployments_path).await?;
 
+    info!("Deploying transfer executor contract");
+    deploy_stylus_args.contract = StylusContract::TransferExecutor;
+    build_and_deploy_stylus_contract(
+        deploy_stylus_args,
+        rpc_url,
+        priv_key,
+        client.clone(),
+        deployments_path,
+    )
+    .await?;
+
     info!("Deploying proxy contract");
     let deploy_proxy_args = DeployProxyArgs {
         owner: args.owner,
@@ -200,6 +211,9 @@ pub async fn deploy_proxy(
 
     let vkeys_address = parse_addr_from_deployments_file(deployments_path, VKEYS_CONTRACT_KEY)?;
 
+    let transfer_executor_address =
+        parse_addr_from_deployments_file(deployments_path, TRANSFER_EXECUTOR_CONTRACT_KEY)?;
+
     let permit2_address = parse_addr_from_deployments_file(deployments_path, PERMIT2_CONTRACT_KEY)?;
 
     let owner_address = Address::from_str(&args.owner)
@@ -211,6 +225,7 @@ pub async fn deploy_proxy(
         verifier_address,
         vkeys_address,
         merkle_address,
+        transfer_executor_address,
         permit2_address,
         protocol_fee,
     )?);

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -135,6 +135,9 @@ pub const VERIFIER_CONTRACT_KEY: &str = "verifier_contract";
 /// The vkeys contract key in the `deployments.json` file
 pub const VKEYS_CONTRACT_KEY: &str = "vkeys_contract";
 
+/// The transfer executor contract key in the `deployments.json` file
+pub const TRANSFER_EXECUTOR_CONTRACT_KEY: &str = "transfer_executor_contract";
+
 /// The ticker of the ERC20 contract deployed using `deploy_test_contracts`,
 /// which is also its contract key in the `deployments.json` file
 pub const DUMMY_ERC20_TICKER: &str = "DUMMY";

--- a/scripts/src/solidity.rs
+++ b/scripts/src/solidity.rs
@@ -4,7 +4,7 @@ use alloy_sol_types::sol;
 use ethers::contract::abigen;
 
 sol! {
-    function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address, address memory permit2_address, uint256 memory protocol_fee) external;
+    function initialize(address memory verifier_address, address memory vkeys_address, address memory merkle_address, address memory transfer_executor_address, address memory permit2_address, uint256 memory protocol_fee) external;
 }
 
 abigen!(

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -33,8 +33,8 @@ use crate::{
         MANIFEST_DIR_ENV_VAR, MERKLE_CONTRACT_KEY, NIGHTLY_TOOLCHAIN_SELECTOR, NO_VERIFY_FEATURE,
         OPT_LEVEL_3, OPT_LEVEL_FLAG, OPT_LEVEL_S, OPT_LEVEL_Z, PRECOMPILE_TEST_CONTRACT_KEY,
         RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND, STYLUS_CONTRACTS_CRATE_NAME,
-        TARGET_PATH_SEGMENT, VERIFIER_CONTRACT_KEY, VKEYS_CONTRACT_KEY, WASM_EXTENSION,
-        WASM_OPT_COMMAND, WASM_TARGET_TRIPLE, Z_FLAGS,
+        TARGET_PATH_SEGMENT, TRANSFER_EXECUTOR_CONTRACT_KEY, VERIFIER_CONTRACT_KEY,
+        VKEYS_CONTRACT_KEY, WASM_EXTENSION, WASM_OPT_COMMAND, WASM_TARGET_TRIPLE, Z_FLAGS,
     },
     errors::ScriptError,
     solidity::initializeCall,
@@ -138,6 +138,7 @@ pub fn get_contract_key(contract: StylusContract) -> &'static str {
         StylusContract::Merkle | StylusContract::MerkleTestContract => MERKLE_CONTRACT_KEY,
         StylusContract::Verifier => VERIFIER_CONTRACT_KEY,
         StylusContract::Vkeys | StylusContract::TestVkeys => VKEYS_CONTRACT_KEY,
+        StylusContract::TransferExecutor => TRANSFER_EXECUTOR_CONTRACT_KEY,
         StylusContract::DummyErc20 => DUMMY_ERC20_TICKER,
         StylusContract::DummyUpgradeTarget => DUMMY_UPGRADE_TARGET_CONTRACT_KEY,
         StylusContract::PrecompileTestContract => PRECOMPILE_TEST_CONTRACT_KEY,
@@ -149,18 +150,21 @@ pub fn darkpool_initialize_calldata(
     verifier_address: Address,
     vkeys_address: Address,
     merkle_address: Address,
+    transfer_executor_address: Address,
     permit2_address: Address,
     protocol_fee: U256,
 ) -> Result<Vec<u8>, ScriptError> {
     let verifier_address = AlloyAddress::from_slice(verifier_address.as_bytes());
     let vkeys_address = AlloyAddress::from_slice(vkeys_address.as_bytes());
     let merkle_address = AlloyAddress::from_slice(merkle_address.as_bytes());
+    let transfer_executor_address = AlloyAddress::from_slice(transfer_executor_address.as_bytes());
     let permit2_address = AlloyAddress::from_slice(permit2_address.as_bytes());
 
     Ok(initializeCall::new((
         verifier_address,
         vkeys_address,
         merkle_address,
+        transfer_executor_address,
         permit2_address,
         protocol_fee,
     ))


### PR DESCRIPTION
This PR updates the `scripts` and `integration` crates to deploy the transfer executor contract and use it accordingly in integration tests.

All integration tests pass, and in the next PR, I will add extra tests asserting the malformed signatures do not result in a transfer.