### PR TITLE
integration: tests for malicious deposits/withdrawals

### DIFF
--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -237,7 +237,7 @@ pub struct TransferAuxData {
 /// Since the secp256k1 base field order is larger than that of Bn254's scalar field,
 /// it takes 2 Bn254 scalar field elements to represent each coordinate.
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct PublicSigningKey {
     /// The affine x-coordinate of the public key
     #[serde_as(as = "[ScalarFieldDef; 2]")]

--- a/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
@@ -97,7 +97,7 @@ impl<T: Erc20Params> Erc20<T> {
         });
     }
 
-    pub fn _burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
+    pub fn burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
         let mut balance = self.balances.setter(address);
         let old_balance = balance.get();
         if old_balance < value {
@@ -203,6 +203,11 @@ sol_storage! {
 impl DummyErc20 {
     pub fn mint(&mut self, address: Address, amount: U256) -> Result<(), Vec<u8>> {
         self.erc20.mint(address, amount);
+        Ok(())
+    }
+
+    pub fn burn(&mut self, address: Address, amount: U256) -> Result<(), Vec<u8>> {
+        self.erc20.burn(address, amount)?;
         Ok(())
     }
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -75,6 +75,7 @@ abigen!(
         function totalSupply() external view returns (uint256)
         function balanceOf(address account) external view returns (uint256)
         function mint(address memory _address, uint256 memory value) external
+        function burn(address memory _address, uint256 memory value) external
         function transfer(address to, uint256 value) external returns (bool)
         function allowance(address owner, address spender) external view returns (uint256)
         function approve(address spender, uint256 value) external returns (bool)

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -57,6 +57,10 @@ pub(crate) enum Tests {
     Pausable,
     /// Test deposit / withdrawal functionality of the darkpool
     ExternalTransfer,
+    /// Test that a malformed deposit is rejected
+    ExternalTransferMaliciousDeposit,
+    /// Test that a malformed withdrawal is rejected
+    ExternalTransferMaliciousWithdrawal,
     /// Test the `new_wallet` method on the darkpool
     NewWallet,
     /// Test the `update_wallet` method on the darkpool

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -16,10 +16,7 @@ use scripts::{
     utils::{parse_addr_from_deployments_file, setup_client},
 };
 use tests::{
-    test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_external_transfer__malicious_deposit, test_implementation_address_setters,
-    test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable,
-    test_pausable, test_process_match_settle, test_update_wallet, test_upgradeable, test_verifier,
+    test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer, test_external_transfer__malicious_deposit, test_external_transfer__malicious_withdrawal, test_implementation_address_setters, test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable, test_pausable, test_process_match_settle, test_update_wallet, test_upgradeable, test_verifier
 };
 
 mod abis;
@@ -105,6 +102,18 @@ async fn main() -> Result<()> {
                 client.clone(),
             )
             .await?;
+            test_external_transfer__malicious_deposit(
+                transfer_executor_address,
+                permit2_address,
+                dummy_erc20_address,
+                client.clone(),
+            ).await?;
+            test_external_transfer__malicious_withdrawal(
+                transfer_executor_address,
+                permit2_address,
+                dummy_erc20_address,
+                client.clone(),
+            ).await?;
             test_new_wallet(darkpool_proxy_address, client.clone()).await?;
             test_update_wallet(darkpool_proxy_address, client.clone()).await?;
             test_process_match_settle(darkpool_proxy_address, client).await
@@ -167,7 +176,15 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        Tests::ExternalTransferMaliciousWithdrawal => todo!(),
+        Tests::ExternalTransferMaliciousWithdrawal => {
+            test_external_transfer__malicious_withdrawal(
+                transfer_executor_address,
+                permit2_address,
+                dummy_erc20_address,
+                client,
+            )
+            .await
+        }
         Tests::NewWallet => test_new_wallet(darkpool_proxy_address, client).await,
         Tests::UpdateWallet => test_update_wallet(darkpool_proxy_address, client).await,
         Tests::ProcessMatchSettle => {

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -17,9 +17,9 @@ use scripts::{
 };
 use tests::{
     test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_implementation_address_setters, test_initializable, test_merkle, test_new_wallet,
-    test_nullifier_set, test_ownable, test_pausable, test_process_match_settle, test_update_wallet,
-    test_upgradeable, test_verifier,
+    test_external_transfer__malicious_deposit, test_implementation_address_setters,
+    test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable,
+    test_pausable, test_process_match_settle, test_update_wallet, test_upgradeable, test_verifier,
 };
 
 mod abis;
@@ -158,6 +158,16 @@ async fn main() -> Result<()> {
             )
             .await
         }
+        Tests::ExternalTransferMaliciousDeposit => {
+            test_external_transfer__malicious_deposit(
+                transfer_executor_address,
+                permit2_address,
+                dummy_erc20_address,
+                client,
+            )
+            .await
+        }
+        Tests::ExternalTransferMaliciousWithdrawal => todo!(),
         Tests::NewWallet => test_new_wallet(darkpool_proxy_address, client).await,
         Tests::UpdateWallet => test_update_wallet(darkpool_proxy_address, client).await,
         Tests::ProcessMatchSettle => {

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -203,7 +203,7 @@ pub(crate) async fn execute_transfer_and_get_balances(
     dummy_erc20_contract: &DummyErc20Contract<LocalWalletProvider<impl Middleware + 'static>>,
     permit2_address: Address,
     signing_key: &SigningKey,
-    pk_root: &PublicSigningKey,
+    pk_root: PublicSigningKey,
     transfer: &ExternalTransfer,
     account_address: Address,
 ) -> Result<(U256, U256)> {
@@ -217,7 +217,7 @@ pub(crate) async fn execute_transfer_and_get_balances(
 
     transfer_executor_contract
         .execute_external_transfer(
-            serialize_to_calldata(pk_root)?,
+            serialize_to_calldata(&Some(pk_root))?,
             serialize_to_calldata(transfer)?,
             serialize_to_calldata(&transfer_aux_data)?,
         )


### PR DESCRIPTION
This PR adds tests ensuring that one cannot deposit from or withdraw to a foreign address, taking steps to ensure that the contract methods revert due to an invalid signature and not lack of funding.

All integration tests pass.