### PR TITLE
contracts-stylus: utils: properly no-op sig check if not verifying

### DIFF
--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -25,7 +25,7 @@ use stylus_sdk::{
 };
 
 use crate::{
-    assert_result,
+    assert_result, if_verifying,
     utils::{
         constants::{TREE_FULL_ERROR_MESSAGE, ZEROS},
         helpers::{assert_valid_signature, scalar_to_u256, u256_to_scalar},
@@ -145,7 +145,11 @@ where
             ],
         };
 
-        assert_valid_signature(&old_pk_root, &shares_commitment.serialize_to_bytes(), &sig)?;
+        if_verifying!(assert_valid_signature(
+            &old_pk_root,
+            &shares_commitment.serialize_to_bytes(),
+            &sig
+        )?);
 
         self.insert_helper(shares_commitment, P::HEIGHT as u8, insert_index, true)?;
 

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -224,7 +224,7 @@ pub fn assert_valid_signature(
     message: &[u8],
     signature: &[u8],
 ) -> Result<(), Vec<u8>> {
-    crate::if_verifying!(crate::assert_result!(
+    crate::assert_result!(
         ecdsa_verify::<StylusHasher, PrecompileEcRecoverBackend>(
             pk_root,
             message,
@@ -234,7 +234,7 @@ pub fn assert_valid_signature(
         )
         .map_err(|_| ECDSA_ERROR_MESSAGE)?,
         INVALID_SIGNATURE_ERROR_MESSAGE
-    ))
+    )
 }
 
 /// Expands to the given code block if the `no-verify` feature is not enabled.


### PR DESCRIPTION
This PR moves the `if_verifying!` macro invocation outside of the `assert_valid_signature` method so that it properly compiles if the `no-verify` feature is set. It previously would not compile because the method would return `()` instead of a `Result`.