### PR TITLE
contracts-stylus: darkpool: VALID OFFLINE FEE SETTLEMENT contract method

### DIFF
--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -247,6 +247,22 @@ pub struct PublicSigningKey {
     pub y: [ScalarField; 2],
 }
 
+/// Represents an affine point on the BabyJubJub curve,
+/// whose base field is the scalar field of the Bn254 curve.
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct BabyJubJubPoint {
+    /// The x-coordinate of the point
+    #[serde_as(as = "ScalarFieldDef")]
+    pub x: ScalarField,
+    /// The y-coordinate of the point
+    #[serde_as(as = "ScalarFieldDef")]
+    pub y: ScalarField,
+}
+
+/// An EC-ElGamal public encryption key over the BabyJubJub curve
+pub type PublicEncryptionKey = BabyJubJubPoint;
+
 /// Statement for `VALID_WALLET_CREATE` circuit
 #[serde_as]
 #[derive(Serialize, Deserialize)]
@@ -376,6 +392,44 @@ pub struct ValidRelayerFeeSettlementStatement {
     pub recipient_updated_public_shares: Vec<ScalarField>,
     /// The public root key of the recipient, rotated out after this update
     pub recipient_pk_root: PublicSigningKey,
+}
+
+/// The EC-ElGamal encryption of a fee note
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct NoteCiphertext(
+    pub BabyJubJubPoint,
+    #[serde_as(as = "ScalarFieldDef")] pub ScalarField,
+    #[serde_as(as = "ScalarFieldDef")] pub ScalarField,
+    #[serde_as(as = "ScalarFieldDef")] pub ScalarField,
+);
+
+/// Statement for the `VALID OFFLINE FEE SETTLEMENT` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidOfflineFeeSettlementStatement {
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the old wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root: ScalarField,
+    /// The nullifier of the old wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub nullifier: ScalarField,
+    /// A commitment to the new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub updated_wallet_commitment: ScalarField,
+    /// The blinded public secret shares of the new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub updated_wallet_public_shares: Vec<ScalarField>,
+    /// The ciphertext of the fee note
+    pub note_ciphertext: NoteCiphertext,
+    /// The commitment to the note
+    #[serde_as(as = "ScalarFieldDef")]
+    pub note_commitment: ScalarField,
+    /// The protocol's public encryption key
+    pub protocol_key: PublicEncryptionKey,
+    /// Whether the fee is a protocol fee or a relayer fee
+    pub is_protocol_fee: bool,
 }
 
 /// Represents the public inputs to a Plonk proof

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -250,7 +250,7 @@ pub struct PublicSigningKey {
 /// Represents an affine point on the BabyJubJub curve,
 /// whose base field is the scalar field of the Bn254 curve.
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct BabyJubJubPoint {
     /// The x-coordinate of the point
     #[serde_as(as = "ScalarFieldDef")]
@@ -260,7 +260,7 @@ pub struct BabyJubJubPoint {
     pub y: ScalarField,
 }
 
-/// An EC-ElGamal public encryption key over the BabyJubJub curve
+/// A BabyJubJub EC-ElGamal public encryption key
 pub type PublicEncryptionKey = BabyJubJubPoint;
 
 /// Statement for `VALID_WALLET_CREATE` circuit

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -3,7 +3,9 @@
 
 use alloc::{vec, vec::Vec};
 use contracts_common::types::{
-    ExternalTransfer, MatchPayload, PublicEncryptionKey, PublicSigningKey, ScalarField, ValidMatchSettleStatement, ValidOfflineFeeSettlementStatement, ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement
+    ExternalTransfer, MatchPayload, PublicEncryptionKey, PublicSigningKey, ScalarField,
+    ValidMatchSettleStatement, ValidOfflineFeeSettlementStatement,
+    ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
 };
 use core::borrow::{Borrow, BorrowMut};
 use stylus_sdk::{
@@ -32,8 +34,8 @@ use crate::{
         },
         solidity::{
             executeExternalTransferCall, init_0Call as initMerkleCall,
-            init_1Call as initTransferExecutorCall, insertSharesCommitmentCall,
-            processMatchSettleVkeysCall, rootCall, rootInHistoryCall,
+            init_1Call as initTransferExecutorCall, insertNoteCommitmentCall,
+            insertSharesCommitmentCall, processMatchSettleVkeysCall, rootCall, rootInHistoryCall,
             validOfflineFeeSettlementVkeyCall, validRelayerFeeSettlementVkeyCall,
             validWalletCreateVkeyCall, validWalletUpdateVkeyCall, verifyCall, verifyMatchCall,
             verifyStateSigAndInsertCall, FeeChanged, MerkleAddressChanged, NullifierSpent,
@@ -601,7 +603,14 @@ impl DarkpoolContract {
             &valid_offline_fee_settlement_statement.updated_wallet_public_shares,
         )?;
 
-        // TODO: Insert note commitment into Merkle tree
+        let note_commitment_u256 =
+            scalar_to_u256(valid_offline_fee_settlement_statement.note_commitment);
+        let merkle_address = storage.borrow_mut().merkle_address.get();
+        delegate_call_helper::<insertNoteCommitmentCall>(
+            storage,
+            merkle_address,
+            (note_commitment_u256,),
+        )?;
 
         Ok(())
     }

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -107,7 +107,12 @@ where
 
         let shares_commitment = self.compute_shares_commitment(shares)?;
 
-        self.insert_helper(shares_commitment, P::HEIGHT as u8, insert_index, true)?;
+        self.insert_helper(
+            shares_commitment,
+            P::HEIGHT as u8,
+            insert_index,
+            true, /* subtree_filled */
+        )?;
 
         Ok(())
     }
@@ -151,7 +156,30 @@ where
             &sig
         )?);
 
-        self.insert_helper(shares_commitment, P::HEIGHT as u8, insert_index, true)?;
+        self.insert_helper(
+            shares_commitment,
+            P::HEIGHT as u8,
+            insert_index,
+            true, /* subtree_filled */
+        )?;
+
+        Ok(())
+    }
+
+    /// Inserts a note commitment into the Merkle tree
+    pub fn insert_note_commitment(&mut self, note_commitment: U256) -> Result<(), Vec<u8>> {
+        let insert_index: u128 = self.next_index.get().to();
+        assert_result!(
+            insert_index < 2_u128.pow(P::HEIGHT as u32),
+            TREE_FULL_ERROR_MESSAGE
+        )?;
+
+        self.insert_helper(
+            u256_to_scalar(note_commitment)?,
+            P::HEIGHT as u8,
+            insert_index,
+            true, /* subtree_filled */
+        )?;
 
         Ok(())
     }
@@ -292,5 +320,10 @@ impl ProdMerkleContract {
     ) -> Result<(), Vec<u8>> {
         self.merkle
             .verify_state_sig_and_insert(shares, sig, old_pk_root)
+    }
+
+    #[doc(hidden)]
+    pub fn insert_note_commitment(&mut self, note_commitment: U256) -> Result<(), Vec<u8>> {
+        self.merkle.insert_note_commitment(note_commitment)
     }
 }

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -61,4 +61,9 @@ impl TestMerkleContract {
         self.merkle
             .verify_state_sig_and_insert(shares, sig, old_pk_root)
     }
+
+    #[doc(hidden)]
+    pub fn insert_note_commitment(&mut self, note_commitment: U256) -> Result<(), Vec<u8>> {
+        self.merkle.insert_note_commitment(note_commitment)
+    }
 }

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -62,6 +62,11 @@ pub const INVALID_ORDER_SETTLEMENT_INDICES_ERROR_MESSAGE: &[u8] =
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
 pub const INVALID_PROTOCOL_FEE_ERROR_MESSAGE: &[u8] = b"invalid protocol fee";
 
+/// The revert message when the protocol public encryption key is
+/// incorrect in a VALID OFFLINE FEE SETTLEMENT statement
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
+pub const INVALID_PROTOCOL_PUBKEY_ERROR_MESSAGE: &[u8] = b"invalid protocol pubkey";
+
 /// The revert message when attempting to insert
 /// into a full Merkle tree
 #[cfg(any(feature = "merkle", feature = "merkle-test-contract"))]

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -15,6 +15,7 @@ sol! {
     function rootInHistory(uint256 root) external view returns (bool);
     function insertSharesCommitment(uint256[] shares) external;
     function verifyStateSigAndInsert(uint256[] shares, bytes sig, uint256[4] old_pk_root) external;
+    function insertNoteCommitment(uint256 note_commitment) external;
 
     // Vkeys functions
     function validWalletCreateVkey() external view returns (bytes);

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -53,6 +53,7 @@ sol! {
 
     // Darkpool controls events
     event FeeChanged(uint256 indexed new_fee);
+    event PubkeyRotated(uint256 indexed new_pubkey_x, uint256 indexed new_pubkey_y);
     event OwnershipTransferred(address indexed new_owner);
     event Paused();
     event Unpaused();


### PR DESCRIPTION
This PR adds the `settle_offline_fee` method to the darkpool, encapsulating the contract logic involved in settling an offline fee into a note via the `VALID OFFLINE FEE SETTLEMENT` circuit.

I make reasonable assumptions on the structure and ordering of the `ValidOfflineFeeSettlementStatement` statement fields.

This PR adds the protocol public encryption key as a settable storage variable on the contract. We assert that the pubkey in the statement matches this, as opposed to injecting it into the statement. The reason for this is that in the case that the protocol pubkey is incorrect, the contract can return a verbose error indicating this, as opposed to an opaque failure to verify.

Finally, this required an extra method on the Merkle contract to allow for inserting a note commitment directly to the tree.

As before, testing is deferred until all fees changes are made and the contracts are deployable.