### PR TITLE
contracts-stylus: darkpool: VALID FEE REDEMPTION contract method

### DIFF
--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -13,9 +13,9 @@ use crate::{
     types::{
         BabyJubJubPoint, ExternalTransfer, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256,
         NoteCiphertext, OrderSettlementIndices, PublicInputs, PublicSigningKey, ScalarField,
-        ValidCommitmentsStatement, ValidMatchSettleStatement, ValidOfflineFeeSettlementStatement,
-        ValidReblindStatement, ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement,
-        ValidWalletUpdateStatement,
+        ValidCommitmentsStatement, ValidFeeRedemptionStatement, ValidMatchSettleStatement,
+        ValidOfflineFeeSettlementStatement, ValidReblindStatement,
+        ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
     },
 };
 
@@ -280,7 +280,8 @@ impl ScalarSerializable for ValidMatchSettleStatement {
 impl ScalarSerializable for ValidRelayerFeeSettlementStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
         let mut scalars: Vec<ScalarField> = vec![
-            self.merkle_root,
+            self.merkle_root1,
+            self.merkle_root2,
             self.sender_nullifier,
             self.recipient_nullifier,
             self.sender_wallet_commitment,
@@ -305,6 +306,21 @@ impl ScalarSerializable for ValidOfflineFeeSettlementStatement {
         scalars.push(self.note_commitment);
         scalars.extend(baby_jubjub_point_to_scalars(&self.protocol_key));
         scalars.push(self.is_protocol_fee.into());
+        Ok(scalars)
+    }
+}
+
+impl ScalarSerializable for ValidFeeRedemptionStatement {
+    fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
+        let mut scalars: Vec<ScalarField> = vec![
+            self.merkle_root1,
+            self.merkle_root2,
+            self.nullifier,
+            self.note_nullifier,
+            self.new_wallet_commitment,
+        ];
+        scalars.extend(&self.new_wallet_public_shares);
+        scalars.extend(&pk_to_scalars(&self.old_pk_root));
         Ok(scalars)
     }
 }

--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -280,8 +280,8 @@ impl ScalarSerializable for ValidMatchSettleStatement {
 impl ScalarSerializable for ValidRelayerFeeSettlementStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
         let mut scalars: Vec<ScalarField> = vec![
-            self.merkle_root1,
-            self.merkle_root2,
+            self.sender_root,
+            self.recipient_root,
             self.sender_nullifier,
             self.recipient_nullifier,
             self.sender_wallet_commitment,
@@ -313,8 +313,8 @@ impl ScalarSerializable for ValidOfflineFeeSettlementStatement {
 impl ScalarSerializable for ValidFeeRedemptionStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
         let mut scalars: Vec<ScalarField> = vec![
-            self.merkle_root1,
-            self.merkle_root2,
+            self.wallet_root,
+            self.note_root,
             self.nullifier,
             self.note_nullifier,
             self.new_wallet_commitment,

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -369,9 +369,13 @@ pub struct MatchPayload {
 #[derive(Serialize, Deserialize)]
 pub struct ValidRelayerFeeSettlementStatement {
     /// A historic merkle root for which we prove inclusion of
-    /// the commitment to both wallets' private secret shares
+    /// the commitment to the sender's wallet's private secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub merkle_root: ScalarField,
+    pub merkle_root1: ScalarField,
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the recipient's wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root2: ScalarField,
     /// The nullifier of the sender's secret shares
     #[serde_as(as = "ScalarFieldDef")]
     pub sender_nullifier: ScalarField,
@@ -430,6 +434,34 @@ pub struct ValidOfflineFeeSettlementStatement {
     pub protocol_key: PublicEncryptionKey,
     /// Whether the fee is a protocol fee or a relayer fee
     pub is_protocol_fee: bool,
+}
+
+/// Statement for the `VALID FEE REDEMPTION` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidFeeRedemptionStatement {
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the old wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root1: ScalarField,
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to note
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root2: ScalarField,
+    /// The nullifier of the old wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub nullifier: ScalarField,
+    /// The nullifier of the note
+    #[serde_as(as = "ScalarFieldDef")]
+    pub note_nullifier: ScalarField,
+    /// A commitment to the new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub new_wallet_commitment: ScalarField,
+    /// The blinded public secret shares of the new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub new_wallet_public_shares: Vec<ScalarField>,
+    /// The public root key of the old wallet, rotated out after this update
+    pub old_pk_root: PublicSigningKey,
 }
 
 /// Represents the public inputs to a Plonk proof

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -371,11 +371,11 @@ pub struct ValidRelayerFeeSettlementStatement {
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to the sender's wallet's private secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub merkle_root1: ScalarField,
+    pub sender_root: ScalarField,
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to the recipient's wallet's private secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub merkle_root2: ScalarField,
+    pub recipient_root: ScalarField,
     /// The nullifier of the sender's secret shares
     #[serde_as(as = "ScalarFieldDef")]
     pub sender_nullifier: ScalarField,
@@ -443,11 +443,11 @@ pub struct ValidFeeRedemptionStatement {
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to the old wallet's private secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub merkle_root1: ScalarField,
+    pub wallet_root: ScalarField,
     /// A historic merkle root for which we prove inclusion of
     /// the commitment to note
     #[serde_as(as = "ScalarFieldDef")]
-    pub merkle_root2: ScalarField,
+    pub note_root: ScalarField,
     /// The nullifier of the old wallet's secret shares
     #[serde_as(as = "ScalarFieldDef")]
     pub nullifier: ScalarField,

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -543,7 +543,7 @@ impl DarkpoolContract {
         DarkpoolContract::rotate_wallet(
             storage,
             valid_relayer_fee_settlement_statement.sender_nullifier,
-            valid_relayer_fee_settlement_statement.merkle_root,
+            valid_relayer_fee_settlement_statement.merkle_root1,
             valid_relayer_fee_settlement_statement.sender_wallet_commitment,
             &valid_relayer_fee_settlement_statement.sender_updated_public_shares,
         )?;
@@ -551,7 +551,7 @@ impl DarkpoolContract {
         DarkpoolContract::rotate_wallet_with_signature(
             storage,
             valid_relayer_fee_settlement_statement.recipient_nullifier,
-            valid_relayer_fee_settlement_statement.merkle_root,
+            valid_relayer_fee_settlement_statement.merkle_root2,
             valid_relayer_fee_settlement_statement.recipient_wallet_commitment,
             &valid_relayer_fee_settlement_statement.recipient_updated_public_shares,
             relayer_shares_commitment_signature.into(),


### PR DESCRIPTION
This PR adds the `redeem_fee` method to the darkpool contract, representing the on-chain logic encapsulated in the redemption of a fee note via the `VALID FEE REDEMPTION` circuit.

I make reasonable assumptions on the structure and order of the fields in the `ValidFeeRedemptionStatement`.

Additionally, this PR amends the `ValidRelayerFeeSettlementStatement` to also accept 2 Merkle roots, as in `VALID FEE REDEMPTION`.

As before, deployment/testing is deferred.