### PR TITLE
docs: post-fees docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,37 +95,12 @@ _Note: It may take some time for the devnet to finish its setup if it's being in
 
 ### Deploying the contracts
 
-#### Using the `scripts` crate
-
 Next, you'll need to deploy our contracts to it. This can be done by running the scripts defined in our `scripts` crate.
 
-It's worth getting an overview of the `scripts` CLI functionality by running:
+You can get an overview of the `scripts` CLI functionality by running:
 
 ```shell
 cargo run -p scripts -- -h
-```
-
-Which will show:
-
-```shell
-Scripts for deploying & upgrading the Renegade Stylus contracts
-
-Usage: scripts --priv-key <PRIV_KEY> --rpc-url <RPC_URL> --deployments-path <DEPLOYMENTS_PATH> <COMMAND>
-
-Commands:
-  deploy-test-contracts  Deploy all the testing contracts (includes generating testing verification keys)
-  deploy-proxy           Deploy the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts
-  deploy-stylus          Deploy a Stylus contract
-  upgrade                Upgrade the darkpool implementation
-  gen-srs                Generate a structured reference string
-  gen-vkeys              Generate verification keys for the protocol circuits
-  help                   Print this message or the help of the given subcommand(s)
-
-Options:
-  -p, --priv-key <PRIV_KEY>                  Private key of the deployer
-  -r, --rpc-url <RPC_URL>                    Network RPC URL
-  -d, --deployments-path <DEPLOYMENTS_PATH>  Path to a `deployments.json` file
-  -h, --help
 ```
 
 For interacting with the devnet, you can define the following shell variables:
@@ -142,38 +117,24 @@ RPC_URL=http://localhost:8547
 DEPLOYMENTS_PATH=deployments.devnet.json
 ```
 
-#### Generating a testing SRS
-
-You'll need a structured reference string (SRS) for Plonk verification.
-
-You can define the following shell variable for consistency:
+Then, you can deploy all of the contracts used in the integration tests by running:
 
 ```shell
-# This can be any path, but `srs` is conveniently git-ignored
-SRS_PATH=srs
+cargo run -p scripts -- \
+  -p $PRIV_KEY \
+  -r $RPC_URL \
+  -d $DEPLOYMENTS_PATH \
+  deploy-test-contracts \
+  -o 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E \
+  -v contracts-stylus/vkeys/test
 ```
 
-which can be generated (note: **insecurely**, and only for testing) by running:
-
-```shell
-cargo run -p scripts -- -p $PRIV_KEY -r $RPC_URL -d $DEPLOYMENTS_PATH gen-srs -s $SRS_PATH -d <DEGREE>
-```
-
-A degree of `4096` is sufficient for `<DEGREE>`.
-
-#### Deploying the contracts themselves
-
-All of the contracts used in integration testing can be deployed by running the following command:
-```shell
-cargo run -p scripts -- -p $PRIV_KEY -r $RPC_URL -d $DEPLOYMENTS_PATH deploy-test-contracts -o 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E -f <FEE> -s $SRS_PATH -v contracts-stylus/vkeys/test
-```
 _Note: The address `0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E` is the address associated with the predeployed dev account, whose private key we've been using._
 
 _Be sure to use `contracts-stylus/vkeys/test` as the argument for the `-v` flag, indicating where the verification keys should be stored, as the verification keys contract expects to find them at this path._
 
-_The `<FEE>` parameter is the initial protocol fee to set in the darkpool contract, and is largely irrelevant for testing, so you can set it to anything (other than 0)._
 
-### Running tests
+### Running the tests
 
 You can get an overview of the integration testing suite by running:
 
@@ -181,34 +142,8 @@ You can get an overview of the integration testing suite by running:
 cargo run -p integration -- -h
 ```
 
-Which will show:
+You can run the entire integration testing suite using:
 
 ```shell
-CLI tool for running integration tests against a running devnet node
-
-Usage: integration [OPTIONS] --test <TEST> --deployments-file <DEPLOYMENTS_FILE> --srs-file <SRS_FILE>
-
-Options:
-  -t, --test <TEST>
-          Test to run [possible values: all, ec-add, ec-mul, ec-pairing, ec-recover, nullifier-set, merkle, verifier, upgradeable, impl-setters, initializable, ownable, pausable, external-transfer, new-wallet, update-wallet, process-match-settle]
-  -d, --deployments-file <DEPLOYMENTS_FILE>
-          Path to file containing contract deployment info
-  -s, --srs-file <SRS_FILE>
-          Path to file containing SRS
-  -p, --priv-key <PRIV_KEY>
-          Devnet private key, defaults to default Nitro devnet private key [default: 0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659]
-  -r, --rpc-url <RPC_URL>
-          Devnet RPC URL, defaults to default Nitro devnet private key [default: http://localhost:8547]
-  -h, --help
-          Print help (see more with '--help')
-```
-
-As you can see, `<PRIV_KEY>` and `<RPC_URL>` have their defaults set to the expected devnet values, so the `-p` and `-r` flags can be omitted.
-
-You should use the same `$SRS_PATH` and `$DEPLOYMENTS_PATH` that you used when deploying the contracts.
-
-From there, you can run the entire integration testing suite using:
-
-```shell
-cargo run -p integration -- -t all -s $SRS_PATH -d $DEPLOYMENTS_PATH
+cargo run -p integration -- -t all -d $DEPLOYMENTS_PATH
 ```

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -7,37 +7,41 @@ They are as follows:
 1. `TransparentUpgradeableProxy`
 2. `ProxyAdmin`
 3. `DarkpoolContract`
-4. `MerkleContract`
-5. `VerifierContract`
-6. `VkeysContract`
+4. `DarkpoolCoreContract`
+5. `MerkleContract`
+6. `VerifierContract`
+7. `VkeysContract`
+8. `TransferExecutorContract`
 
-1 & 2 are not implemented by Renegade, rather we directly deployed `v5.0` of OpenZeppelin's `TransparentUpgradeableProxy` contract, which itself deploys a `ProxyAdmin`. Details about these contracts and the transparent upgradeable proxy pattern can be found [here](https://docs.openzeppelin.com/contracts/5.x/api/proxy#transparent_proxy).
+1 & 2 are not implemented by Renegade, rather we directly deployed `v5.0` of OpenZeppelin's `TransparentUpgradeableProxy` contract, which itself deploys a `ProxyAdmin`. Details about these contracts and the transparent upgradeable proxy pattern can be found [here](https://docs.openzeppelin.com/contracts/5.x/api/proxy#transparent_proxy). Additionally, the protocol assumes the existence of a deployed `Permit2` contract. Details about `Permit2` can be found [here](https://docs.uniswap.org/contracts/permit2/overview).
 
-The remaining contracts are interacted with only by the `DarkpoolContract`, which serves as the sole user-facing entrypoint to the protocol.
+The remaining contracts are interacted with only by the `DarkpoolContract`, which serves as the sole user-facing entrypoint to the protocol. The reason we have this many contracts, then, is due to constraints on the binary size of a deployed contract (24kb, Brotli-compressed).
 
 ## Basic Contract Functionality
 
 The following is brief overview of the functioning of the on-chain portion of the Renegade protocol. This assumes familiarity with the broader Renegade protocol, for which we'd recommend reading the [whitepaper](https://www.renegade.fi/whitepaper.pdf) or the [docs](https://docs.renegade.fi/).
 
-The Renegade contracts manage deposits / withdrawals of users' funds into / from the darkpool, track commitments to current and nullified user wallets, and handle the settlement of trades. 
+The Renegade contracts manage deposits / withdrawals of users' funds into / from the darkpool, track commitments to current and nullified user wallets, and handle the settlement of trades and fee payments.
 
-Users submit changes to their wallet (e.g., creating a new wallet, creating / cancelling orders, settling matched trades) to the `DarkpoolContract`.
+The `DarkpoolContract` is responsible for managing access controls and system parameters, and serving externally-facing getter methods. Otherwise, it `delegatecall`s the `DarkpoolCoreContract` to handle all wallet-mutating methods (e.g., creating a new wallet, creating / cancelling orders, settling matched trades).
 
-These changes are encapsulated in a [Plonk](https://eprint.iacr.org/2019/953.pdf) zero-knowledge proof(s), which the `DarkpoolContract` verifies by `staticcall`ing the `VerifierContract` (during this process, the `DarkpoolContract` also `staticcall`s the `VkeysContract` for preprocessed public information about the statement being proven).
+These changes are encapsulated in [Plonk](https://eprint.iacr.org/2019/953.pdf) zero-knowledge proofs, which the `DarkpoolCoreContract` verifies by `staticcall`ing the `VerifierContract` (during this process, the `DarkpoolContract` also `staticcall`s the `VkeysContract` for preprocessed public information about the statement being proven).
 
-If the change was the settlement of a matched trade, then the `DarkpoolContract` also verifies "proof linking" between the Plonk proofs involved - this is a cryptographic statement attesting that the Plonk proofs use the same public inputs where appropriate. This, too is, done via a `staticcall` to the `VerifierContract` (and also fetches preprocessed information from the `VkeysContract`).
+If the change was the settlement of a matched trade, then the `DarkpoolCoreContract` also verifies "proof linking" between the Plonk proofs involved - this is a cryptographic statement attesting that the Plonk proofs use the same public inputs where appropriate. This, too is, done via a `staticcall` to the `VerifierContract` (and also fetches preprocessed information from the `VkeysContract`).
 
-The updated wallet is committed to as a leaf in a global Merkle tree via a `delegatecall` to the `MerkleContract` from the `DarkpoolContract`. We also add the newly-computed root to a set of historic roots.
+The updated wallet is committed to as a leaf in a global Merkle tree via a `delegatecall` to the `MerkleContract` from the `DarkpoolCoreContract`. We also add the newly-computed root to a set of historic roots.
 
-If the change was an update to an existing wallet by the user (this excludes the settlement of a matched trade, which can be done by a relayer), we also verify an ECDSA signature by the user over the commitment to the updated wallet to be inserted into the Merkle tree.
+In some cases of wallet changes, namely when the wallet is not constrained in-circuit to be properly reblinded, the wallet owner must also sign a commitment to the updated wallet. This is a secp256k1 ECDSA signature made using the user's `sk_root` that we verify before committing the wallet to the Merkle tree.
 
-The old wallet is then "nullified" in the `DarkpoolContract`, preventing it from being considered valid (we call such a wallet "spent"). This is done by having the user reveal the old wallet's "nullifier", an initially private value associated with a given state of a wallet.
+The old wallet is then "nullified" in the `DarkpoolCoreContract`, preventing it from being considered valid (we call such a wallet "spent"). This is done by having the user reveal the old wallet's "nullifier", an initially private value associated with a given state of a wallet.
 
-If the change was a deposit / withdrawal of a certain asset to / from a user's wallet, the `DarkpoolContract` also executes an ERC-20 transfer of the asset between itself and the user, in the appropriate direction. 
+If the change was a deposit / withdrawal of a certain asset to / from a user's wallet, the `DarkpoolCoreContract` also executes an ERC-20 transfer of the asset between itself and the user, in the appropriate direction. This is done by `delegatecall`ing the `TransferExecutorContract`, which executes deposits through the `Permit2` contract, and checks a user signature over the transfer metadata in the case of withdrawals.
+
+A more in-depth explanation of the contracts' functionality can be found in doc comments throughout the [contract definitions](../contracts-stylus/src/contracts).
 
 ## Contract State
 
-All of the state in the on-chain portion of the Renegade protocol is held in one contract, the `TransparentUpgradeableProxy`, since this contract proxies all calls to the `DarkpoolContract` via `delegatecall`, and the `DarkpoolContract` also calls the other contracts using only `delegatecall` or `staticcall`.
+All of the state in the on-chain portion of the Renegade protocol is held in one contract, the `TransparentUpgradeableProxy`, since this contract proxies all calls to the `DarkpoolContract` via `delegatecall`, and the `DarkpoolContract` also calls the other contracts using only `delegatecall` or `staticcall` (excluding, of course, the `call`s made to `Permit2` / ERC-20 contracts for deposits and withdrawals).
 
 For all intents and purposes though, one can think of the `DarkpoolContract` as managing all of the state.
 
@@ -50,105 +54,34 @@ The high-level state elements are the following:
     - The set of all spent wallet nullifiers
 - Verification keys
     - Preprocessed information for the Plonk circuits & proof linking statements being proven[^2]
-- Contract addresses
-    - The `DarkpoolContract` must know the addresses for the `MerkleContract`, `VerifierContract`, and aforementioned `VkeysContract` so that it can `delegatecall` / `staticcall` them appropriately
 - Protocol fee
-    - A global parameter indicating the fee taken by the protocol. This is a fixed percentage of each trade's volume represented as a fixed-point number
+    - A global parameter indicating the fee taken by the protocol. This is a fixed percentage of each trade's volume represented as a fixed-point number with a 32-bit fractional portion
+- Protocol public encryption key
+    - The EC-ElGamal public encryption key, over the BabyJubJub curve, to which fee notes owed to the protocol are encrypted
+- Contract addresses
+    - The `DarkpoolContract` must know the following contract addresses in order to `delegatecall` / `staticcall` them appropriately:
+        - `DarkpoolCoreContract`
+        - `VerifierContract`
+        - `VkeysContract`
+        - `MerkleContract`
+        - `TransferExecutorContract`
 
 ## Access Controls
 
 The on-chain protocol has the following access controls securing it:
+- Initialization
+    - The `DarkpoolContract` can only be initialized to a given version number once, ensuring that initialization logic is only ever executed during deployment or an upgrade. This follows from OpenZeppelin's `Initializable` [pattern](https://docs.openzeppelin.com/contracts/5.x/api/proxy#Initializable).
 - Upgradeability
     - We use OpenZeppelin's transparent upgradeable proxy pattern, as mentioned above. As such, the `DarkpoolContract` has all calls proxied to it through the `TransparentUpgradeableProxy` via a `delegatecall`, and can be upgraded via the `ProxyAdmin`.
-        - In using the OpenZeppelin contract implementations, we also adopt their access controls for the `TransparentUpgradeableProxy` and `ProxyAdmin`. Namely, the `ProxyAdmin` has a dedicated owner that can call its upgrade method, and the `TransparentUpgradeableProxy` only accepts upgrade calls from the `ProxyAdmin`
-    - Separately from the high-level transparent upgradeable proxy pattern being used for managing the version of the `DarkpoolContract`, we have individual, access-controlled methods for upgrading the implementations of the `VerifierContract`, `VkeysContract`, and `MerkleContract`, defined on the `DarkpoolContract`
-        - This allows us to scope individual upgrades to these components, without requiring upgrades to the entire `DarkpoolContract`
+        - In using the OpenZeppelin contract implementations, we also adopt their access controls for the `TransparentUpgradeableProxy` and `ProxyAdmin`. Namely, the `ProxyAdmin` has a dedicated owner that can call its upgrade method, and the `TransparentUpgradeableProxy` only accepts upgrade calls from the `ProxyAdmin`.
+    - Separately from the high-level transparent upgradeable proxy pattern being used for managing the version of the `DarkpoolContract`, we have individual, access-controlled methods defined on the `DarkpoolContract` for upgrading the implementations of the `DarkpoolCoreContract`, `VerifierContract`, `VkeysContract`, `MerkleContract`, and `TransferExecutorContract`.
+        - This allows us to scope individual upgrades to these components, without requiring upgrades to the entire `DarkpoolContract`. However, an upgrade to the `DarkpoolCoreContract` will likely have to be coupled with an upgrade to the `DarkpoolContract`, and vice versa, since they must mirror one another's storage layout perfectly. For more information, see the `DarkpoolCoreContract` [module](../contracts-stylus/src/contracts/darkpool_core.rs).
 - Ownership
-    - The `DarkpoolContract` also has a dedicated owner, potentially separate from the owner of the `ProxyAdmin`. This owner can be set during initialization, or ownership can be transferred from the current owner to another.
-    - Only the `DarkpoolContract` owner can call certain protected setter methods, such as setting the protocol fee, pausing the contract, or upgrading implementations of the `VerifierContract`, `VkeysContract`, and `MerkleContract`
+    - The `DarkpoolContract` has a dedicated owner, potentially separate from the owner of the `ProxyAdmin`. This owner can be set during initialization, or ownership can be transferred from the current owner to another.
+    - Only the `DarkpoolContract` owner can call certain protected setter methods, such as setting the protocol fee, pausing the contract, or upgrading implementations of the other contracts.
 - Pausing
-    - The `DarkpoolContract` can be paused, meaning that any user-accessible, state mutating methods (i.e., those that are not scoped to just the owner, such as settling matched orders) will revert.
+    - The `DarkpoolContract` can be paused, meaning that any user-accessible, state mutating methods (i.e., those that are not scoped to just the contract owner) will revert.
     - This is meant as an emergency measure, to give us time to upgrade any faulty or compromised implementations in the case of an attack or other unintended contract functionality.
-
-
-## Contract Interfaces
-
-Let's take a closer, detailed look at the contract functionality. The following is an overview of each of the contracts' external interfaces:
-
-`DarkpoolContract`:
-- `initialize`
-    - Initializes the smart contract system, storing the contract addresses needed by the `DarkpoolContract` (described above), and instantiating an empty Merkle tree by `delegatecall`ing the `MerkleContract`. This also sets the caller to be the `DarkpoolContract` owner. Intended to be called by the `ProxyAdmin` as a nested call of the `upgradeToAndCall` method.
-- `owner`
-    - Returns the `DarkpoolContract` owner
-- `transfer_ownership`
-    - Transfers ownership of the `DarkpoolContract` to the passed-in address. May only be called by the owner.
-- `paused`
-    - Returns whether or not the `DarkpoolContract` is paused
-- `pause`
-    - Pauses the `DarkpoolContract`, causing all calls to user-accesible, mutating functions to revert. May only be called by the owner and when the contract is unpaused.
-- `unpause`
-    - Unpauses the `DarkpoolContract`, making all user-accessible, mutating functions available to be called. May only be called by the owner and when the contract is paused.
-- `is_nullifier_spent`
-    - Checks whether the passed-in nullifier is present in the set maintained by the contract (i.e., if the wallet associated with this nullifier is spent).
-- `get_root`
-    - Returns the current root of the Merkle tree by `delegatecall`ing the `MerkleContract`.
-- `root_in_history`
-    - Checks whether or not the passed-in candidate Merkle root is a valid historical root by `delegatecall`ing the `MerkleContract`.
-- `get_fee`
-    - Returns the current protocol fee
-- `set_fee`
-    - Sets the protocol fee to the passed-in value. Can only be called by the owner.
-- `set_verifier_address`
-    - Sets the address of the `VerifierContract`. Can only be called by the owner.
-- `set_vkeys_address`
-    - Sets the address of the `VkeysContract`. Can only be called by the owner.
-- `set_merkle_address`
-    - Sets the address of the `MerkleContract`. Can only be called by the owner.
-- `new_wallet`
-    - Adds a new wallet to the protocol state. This includes:
-        1. Fetching the verification key for the `VALID WALLET CREATE` statement by `staticcall`ing the `VkeysContract`
-        2. Verifying a Plonk proof of the `VALID WALLET CREATE` statement by `staticcall`ing the `VerifierContract`
-        3. Inserting the commitment to the new wallet's state into the Merkle tree by `delegatecall`ing the `MerkleContract`
-        4. Emitting a `WalletUpdated` event with a public identifier of the new wallet
-    - May only be called when the contract is unpaused
-- `update_wallet`
-    - Updates an existing wallet, e.g. depositing / withdrawing funds to / from the wallet, or creating / cancelling an order. This includes:
-        1. Asserting that the Merkle root included in the passed-in Plonk proof of `VALID WALLET UPDATE` is a valid historical root
-        2. Fetching the verification key for the `VALID WALLET UPDATE` statement by `staticcall`ing the `VkeysContract`
-        3. Verifying a Plonk proof of the `VALID WALLET UPDATE` statement by `staticcall`ing the `VerifierContract`
-        4. Verifying an ECDSA signature over the commitment to the wallet's state
-        5. Inserting a commitment to the wallet's state into the Merkle tree by `delegatecall`ing the `MerkleContract`
-        6. Marking the old wallet's nullifier as spent
-        7. If the update was a deposit / withdrawal of an ERC20 asset, executing an ERC20 transfer for the asset between the user & contract in the appropriate direction
-        8. Emitting a `WalletUpdated` event with a public identifier of the wallet
-    - May only be called when the contract is unpaused
-- `process_match_settle`
-    - Settles a matched trade between two wallets. This includes:
-        1. Asserting that the Merkle roots inlcuded in the passed-in Plonk proofs of `VALID REBLIND` for each party are valid historical roots
-        2. Fetching the verification keys for `VALID REBLIND`, `VALID COMMITMENTS`, & `VALID MATCH SETTLE`, alongside the proof-linking verirication keys for the `VALID REBLIND <-> VALID COMMITMENTS`, `PARTY 0 VALID COMMITMENTS <-> VALID MATCH SETTLE`, & `PARTY 1 VALID COMMITMENTS <-> VALID MATCH SETTLE` links by `staticcall`ing the `VkeysContract`
-        3. Batch-verifying Plonk proofs of the `VALID REBLIND` & `VALID COMMITMENTS` statements for both parties, and a proof of `VALID MATCH SETTLE`, by `staticcall`ing the `VerifierContract`
-        4. Batch-verifying linking proofs of the `VALID REBLIND <-> VALID COMMITMENTS`, `PARTY 0 VALID COMMITMENTS <-> VALID MATCH SETTLE`, & `PARTY 1 VALID COMMITMENTS <-> VALID MATCH SETTLE` links by `staticcall`ing the `VerifierContract`
-        5. Inserting commitments to each party's post-trade wallets into the Merkle tree by `delegatecall`ing the `MerkleContract`
-        6. Marking each party's old wallet's nullifier as spent
-    - May only be called when the contract is unpaused
-
-`MerkleContract`
-- `init`
-    - Initializes an empty Merkle tree
-- `root`
-    - Returns the current Merkle root
-- `root_in_history`
-    - Checks whether the passed-in candidate Merkle root is a valid historical root
-- `insert_shares_commitment`
-    - Computes a commitment to the passed-in wallet and inserts it as a leaf into the Merkle tree
-- `verify_state_sig_and_insert`
-    - Computes a commitment to the passed-in wallet, verifies a user-generated ECDSA signature over it (this includes a `staticcall` to the [`ecRecover` precompile](https://www.evm.codes/precompiled#0x01?fork=shanghai)), and inserts it into the Merkle tree
-
-`VerifierContract`
-- `verify`
-    - Verifies the passed-in Plonk proof. This incurs many `staticcall`s to the [`ecAdd`](https://www.evm.codes/precompiled#0x06?fork=shanghai) and [`ecMul` precompiles](https://www.evm.codes/precompiled#0x07?fork=shanghai), and a single `staticcall` to the [`ecPairing` precompile](https://www.evm.codes/precompiled#0x08?fork=shanghai)
-- `verify_match`
-    - Batch-verifies the passed-in Plonk & linking proofs together. This is only intended to be called by the `DarkpoolContract`'s `process_match_settle` method, in that it expects the same proofs as that method does. This, too, incurs many `staticcall`s to the `ecAdd` and `ecMul` precompiles, and a single `staticcall` to `ecPairing`
 
 ## Assumptions
 
@@ -158,6 +91,7 @@ We make the following assumptions about interaction with the protocol:
 - The `initialize` method of the `DarkpoolContract` is called in the deployment of the `TransparentUpgradeableProxy`
 - Management of a wallet is only delegated to a single cluster
 - Calldata is generally available for wallet indexing & recovery
+- A `Permit2` contract is deployed
 
 ## Protocol Invariants
 


### PR DESCRIPTION
This PR updates the README and specification to be up-to-date after the fees changes. This is largely straightforward, though it's worth noting that I removed the "Contract Interfaces" section of the specification, since this is effectively a regurgitation of the doc comments throughout the codebase (but is much more cumbersome to maintain).