### PR TITLE
contracts-utils, integration: test settle_online_relayer_fee

### DIFF
--- a/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
+++ b/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
@@ -208,7 +208,7 @@ impl SingleProverCircuit for DummyValidMatchSettle {
 /// The dummy version of the `VALID RELAYER FEE SETTLEMENT` circuit
 pub struct DummyValidRelayerFeeSettlement;
 
-type SizedValidRelayerFeeSettlementStatement =
+pub type SizedValidRelayerFeeSettlementStatement =
     ValidRelayerFeeSettlementStatement<MAX_BALANCES, MAX_ORDERS>;
 
 impl SingleProverCircuit for DummyValidRelayerFeeSettlement {
@@ -231,7 +231,7 @@ impl SingleProverCircuit for DummyValidRelayerFeeSettlement {
 /// The dummy version of the `VALID OFFLINE FEE SETTLEMENT` circuit
 pub struct DummyValidOfflineFeeSettlement;
 
-type SizedValidOfflineFeeSettlementStatement =
+pub type SizedValidOfflineFeeSettlementStatement =
     ValidOfflineFeeSettlementStatement<MAX_BALANCES, MAX_ORDERS>;
 
 impl SingleProverCircuit for DummyValidOfflineFeeSettlement {

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -29,6 +29,9 @@ abigen!(
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_shares_commitment_signature) external
+        function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
+        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_shares_commitment_signature) external
 
         function markNullifierSpent(uint256 memory nullifier) external
         function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool)

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -73,4 +73,6 @@ pub(crate) enum Tests {
     /// Test the `process_match_settle` method on the darkpool
     /// with an inconsistent protocol fee
     InconsistentProtocolFee,
+    /// Test the `settle_online_relayer_fee` method on the darkpool
+    SettleOnlineRelayerFee,
 }

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -13,12 +13,7 @@ use scripts::{
     utils::{parse_addr_from_deployments_file, setup_client},
 };
 use tests::{
-    test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer,
-    test_external_transfer__malicious_deposit, test_external_transfer__malicious_withdrawal,
-    test_implementation_address_setters, test_initializable, test_merkle, test_new_wallet,
-    test_nullifier_set, test_ownable, test_pausable, test_process_match_settle,
-    test_process_match_settle__inconsistent_fee, test_process_match_settle__inconsistent_indices,
-    test_update_wallet, test_upgradeable, test_verifier,
+    test_ec_add, test_ec_mul, test_ec_pairing, test_ec_recover, test_external_transfer, test_external_transfer__malicious_deposit, test_external_transfer__malicious_withdrawal, test_implementation_address_setters, test_initializable, test_merkle, test_new_wallet, test_nullifier_set, test_ownable, test_pausable, test_process_match_settle, test_process_match_settle__inconsistent_fee, test_process_match_settle__inconsistent_indices, test_settle_online_relayer_fee, test_update_wallet, test_upgradeable, test_verifier
 };
 
 mod abis;
@@ -127,7 +122,8 @@ async fn main() -> Result<()> {
             test_process_match_settle(darkpool_proxy_address, client.clone()).await?;
             test_process_match_settle__inconsistent_indices(darkpool_proxy_address, client.clone())
                 .await?;
-            test_process_match_settle__inconsistent_fee(darkpool_proxy_address, client).await
+            test_process_match_settle__inconsistent_fee(darkpool_proxy_address, client.clone()).await?;
+            test_settle_online_relayer_fee(darkpool_proxy_address, client).await
         }
         Tests::EcAdd => test_ec_add(precompiles_contract_address, client).await,
         Tests::EcMul => test_ec_mul(precompiles_contract_address, client).await,
@@ -209,5 +205,6 @@ async fn main() -> Result<()> {
         Tests::InconsistentProtocolFee => {
             test_process_match_settle__inconsistent_fee(darkpool_proxy_address, client).await
         }
+        Tests::SettleOnlineRelayerFee => test_settle_online_relayer_fee(darkpool_proxy_address, client).await
     }
 }

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -644,10 +644,16 @@ pub(crate) async fn test_pausable(
 
     let (new_wallet_proof, new_wallet_statement) = gen_new_wallet_data(&mut rng)?;
 
-    let (update_wallet_proof, update_wallet_statement, public_inputs_signature) =
+    let (update_wallet_proof, update_wallet_statement, update_wallet_commitment_signature) =
         gen_update_wallet_data(&mut rng, contract_root)?;
 
     let data = gen_process_match_settle_data(&mut rng, contract_root, protocol_fee)?;
+
+    let (
+        valid_relayer_fee_settlement_proof,
+        valid_relayer_fee_settlement_statement,
+        online_relayer_wallet_commitment_signature,
+    ) = gen_settle_online_relayer_fee_data(&mut rng, contract_root)?;
 
     assert_all_revert(vec![
         contract
@@ -660,7 +666,7 @@ pub(crate) async fn test_pausable(
             .update_wallet(
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
-                public_inputs_signature.clone(),
+                update_wallet_commitment_signature.clone(),
                 Bytes::new(), /* transfer_aux_data */
             )
             .send(),
@@ -671,6 +677,13 @@ pub(crate) async fn test_pausable(
                 serialize_to_calldata(&data.valid_match_settle_statement)?,
                 serialize_to_calldata(&data.match_proofs)?,
                 serialize_to_calldata(&data.match_linking_proofs)?,
+            )
+            .send(),
+        contract
+            .settle_online_relayer_fee(
+                serialize_to_calldata(&valid_relayer_fee_settlement_proof)?,
+                serialize_to_calldata(&valid_relayer_fee_settlement_statement)?,
+                online_relayer_wallet_commitment_signature.clone(),
             )
             .send(),
         contract.pause().send(),
@@ -692,7 +705,7 @@ pub(crate) async fn test_pausable(
             .update_wallet(
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
-                public_inputs_signature,
+                update_wallet_commitment_signature,
                 Bytes::new(), /* transfer_aux_data */
             )
             .send(),
@@ -703,6 +716,13 @@ pub(crate) async fn test_pausable(
                 serialize_to_calldata(&data.valid_match_settle_statement)?,
                 serialize_to_calldata(&data.match_proofs)?,
                 serialize_to_calldata(&data.match_linking_proofs)?,
+            )
+            .send(),
+        contract
+            .settle_online_relayer_fee(
+                serialize_to_calldata(&valid_relayer_fee_settlement_proof)?,
+                serialize_to_calldata(&valid_relayer_fee_settlement_statement)?,
+                online_relayer_wallet_commitment_signature.clone(),
             )
             .send(),
     ])


### PR DESCRIPTION
This PR adds the helpers for & implementation of a test ensuring `settle_online_relayer_fee` functions as expected. Additionally, it updates the pausable test to ensure that this method is not callable when the contract is paused.

Both of these tests pass.