### PR TITLE
integration: tests for `settle_offline_fee`

### DIFF
--- a/contracts-utils/src/conversion.rs
+++ b/contracts-utils/src/conversion.rs
@@ -2,13 +2,18 @@
 
 use arbitrum_client::{conversion::to_contract_public_signing_key, errors::ConversionError};
 use circuit_types::{
+    elgamal::{ElGamalCiphertext, EncryptionKey},
     keychain::{NonNativeScalar, PublicSigningKey as CircuitPublicSigningKey},
+    note::NOTE_CIPHERTEXT_SIZE,
     traits::BaseType,
     PolynomialCommitment,
 };
 use constants::{Scalar, SystemCurve};
 use contracts_common::types::{
-    G1Affine, LinkingVerificationKey, PublicSigningKey as ContractPublicSigningKey,
+    BabyJubJubPoint, G1Affine, LinkingVerificationKey, NoteCiphertext as ContractNoteCiphertext,
+    PublicEncryptionKey as ContractPublicEncryptionKey,
+    PublicSigningKey as ContractPublicSigningKey,
+    ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
     ValidRelayerFeeSettlementStatement as ContractValidRelayerFeeSettlementStatement,
     VerificationKey,
 };
@@ -16,7 +21,9 @@ use eyre::{eyre, Result};
 use mpc_plonk::proof_system::structs::VerifyingKey;
 use mpc_relation::proof_linking::GroupLayout;
 
-use crate::proof_system::dummy_renegade_circuits::SizedValidRelayerFeeSettlementStatement;
+use crate::proof_system::dummy_renegade_circuits::{
+    SizedValidOfflineFeeSettlementStatement, SizedValidRelayerFeeSettlementStatement,
+};
 
 /// Converts a [`GroupLayout`] (from prover-side code) to a [`LinkingVerificationKey`]
 pub fn to_linking_vkey(group_layout: &GroupLayout) -> LinkingVerificationKey {
@@ -84,7 +91,7 @@ pub fn to_circuit_pubkey(contract_pubkey: ContractPublicSigningKey) -> CircuitPu
     CircuitPublicSigningKey { x, y }
 }
 
-/// Converts a [`CircuitPublicSigningKey`] (from prover-side code) to a [`ContractPublicSigningKey`]
+/// Converts a [`SizedValidRelayerFeeSettlementStatement`] (from prover-side code) to a [`ContractValidRelayerFeeSettlementStatement`]
 // TODO: Remove this function once the `arbitrum-client` crate is updated
 pub fn to_contract_valid_relayer_fee_settlement_statement(
     statement: &SizedValidRelayerFeeSettlementStatement,
@@ -110,5 +117,54 @@ pub fn to_contract_valid_relayer_fee_settlement_statement(
             .collect(),
         recipient_pk_root: to_contract_public_signing_key(&statement.recipient_pk_root)
             .map_err(|e| eyre!(e))?,
+    })
+}
+
+/// Converts a [`ElGamalCiphertext`] (from prover-side code) to a [`ContractNoteCiphertext`]
+// TODO: Remove this function once the `arbitrum-client` crate is updated
+pub fn to_contract_note_ciphertext(
+    note_ciphertext: &ElGamalCiphertext<NOTE_CIPHERTEXT_SIZE>,
+) -> ContractNoteCiphertext {
+    ContractNoteCiphertext(
+        BabyJubJubPoint {
+            x: note_ciphertext.ephemeral_key.x.inner(),
+            y: note_ciphertext.ephemeral_key.y.inner(),
+        },
+        note_ciphertext.ciphertext[0].inner(),
+        note_ciphertext.ciphertext[1].inner(),
+        note_ciphertext.ciphertext[2].inner(),
+    )
+}
+
+/// Converts an [`EncryptionKey`] (from prover-side code) to a [`ContractPublicEncryptionKey`]
+// TODO: Remove this function once the `arbitrum-client` crate is updated
+pub fn to_contract_public_encryption_key(
+    public_encryption_key: &EncryptionKey,
+) -> ContractPublicEncryptionKey {
+    ContractPublicEncryptionKey {
+        x: public_encryption_key.x.inner(),
+        y: public_encryption_key.y.inner(),
+    }
+}
+
+/// Converts a [`SizedValidOfflineFeeSettlementStatement`] (from prover-side code) to a [`ContractValidOfflineFeeSettlementStatement`]
+// TODO: Remove this function once the `arbitrum-client` crate is updated
+pub fn to_contract_valid_offline_fee_settlement_statement(
+    statement: &SizedValidOfflineFeeSettlementStatement,
+) -> Result<ContractValidOfflineFeeSettlementStatement> {
+    Ok(ContractValidOfflineFeeSettlementStatement {
+        merkle_root: statement.merkle_root.inner(),
+        nullifier: statement.nullifier.inner(),
+        updated_wallet_commitment: statement.updated_wallet_commitment.inner(),
+        updated_wallet_public_shares: statement
+            .updated_wallet_public_shares
+            .to_scalars()
+            .iter()
+            .map(|s| s.inner())
+            .collect(),
+        note_ciphertext: to_contract_note_ciphertext(&statement.note_ciphertext),
+        note_commitment: statement.note_commitment.inner(),
+        protocol_key: to_contract_public_encryption_key(&statement.protocol_key),
+        is_protocol_fee: statement.is_protocol_fee,
     })
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -25,6 +25,7 @@ abigen!(
 
         function getRoot() external view returns (uint256)
         function getFee() external view returns (uint256)
+        function getPubkey() external view returns (uint256[2])
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory transfer_aux_data) external

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -9,6 +9,8 @@ use alloy_sol_types::{
     Eip712Domain, SolStruct, SolType,
 };
 use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
+use circuit_types::elgamal::EncryptionKey;
+use constants::Scalar;
 use contracts_common::{
     constants::NUM_BYTES_FELT,
     custom_serde::{BytesDeserializable, BytesSerializable},
@@ -366,4 +368,15 @@ fn permit_signing_hash(permit: &PermitTransferFrom, domain: &Eip712Domain) -> B2
     digest_input[2..34].copy_from_slice(&domain_separator[..]);
     digest_input[34..66].copy_from_slice(&struct_hash[..]);
     keccak256(digest_input)
+}
+
+/// Fetches the protocol public encryption key from the darkpool contract
+pub async fn get_protocol_pubkey(
+    darkpool_contract: &DarkpoolTestContract<LocalWalletHttpClient>,
+) -> Result<EncryptionKey> {
+    let [x, y] = darkpool_contract.get_pubkey().call().await?;
+    Ok(EncryptionKey {
+        x: Scalar::new(u256_to_scalar(x)?),
+        y: Scalar::new(u256_to_scalar(y)?),
+    })
 }


### PR DESCRIPTION
This PR adds 2 tests to assert the basic functionality of `settle_offline_fee`, one ensuring the state was updated appropriately when calling the method with valid inputs, the other ensuring that the call reverts when calling the method with the incorrect protocol pubkey is used.

Both of these new tests pass.