### PR TITLE
integration: add redeem_fee test

### DIFF
--- a/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
+++ b/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
@@ -254,7 +254,7 @@ impl SingleProverCircuit for DummyValidOfflineFeeSettlement {
 /// The dummy version of the `VALID FEE REDEMPTION` circuit
 pub struct DummyValidFeeRedemption;
 
-type SizedValidFeeRedemptionStatement = ValidFeeRedemptionStatement<MAX_BALANCES, MAX_ORDERS>;
+pub type SizedValidFeeRedemptionStatement = ValidFeeRedemptionStatement<MAX_BALANCES, MAX_ORDERS>;
 
 impl SingleProverCircuit for DummyValidFeeRedemption {
     type Statement = SizedValidFeeRedemptionStatement;


### PR DESCRIPTION
This PR adds an integration test asserting the basic functionality of the `redeem_fee` method on the darkpool. The new test passes.

I've left a TODO comment indicating some other test cases we should write, but am for now moving on to more urgent tasks.

Note: I've merged #228 into this so you can just review the changes from first commit on this branch