### PR TITLE
scripts: generate random protocol key if none is supplied

### DIFF
--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -121,9 +121,10 @@ pub struct DeployProxyArgs {
     pub fee: u64,
 
     /// The public EC-ElGamal encryption key for the protocol,
-    /// hex-encoded in compressed form
+    /// hex-encoded in compressed form.
+    /// If not provided, a random key will be generated.
     #[arg(short, long)]
-    pub protocol_public_encryption_key: String,
+    pub protocol_public_encryption_key: Option<String>,
 }
 
 /// Deploy a Stylus contract


### PR DESCRIPTION
This PR tweaks the interface of the `deploy-proxy` script to only optionally accept a protocol pubkey, and if none is supplied, generate one randomly. Semantically, this is already what we were doing in the `deploy-test-contracts` script, but lifting this to the interface significantly simplifies the deployment of the contracts in the relayer integration testing stack.

All contracts successfully deploy, and all integration tests pass.