### PR TITLE
contracts-stylus: darkpool-core: add NotePosted event

### DIFF
--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -375,7 +375,7 @@ impl DarkpoolContract {
         storage: &mut S,
         proof: Bytes,
         valid_wallet_update_statement_bytes: Bytes,
-        shares_commitment_signature: Bytes,
+        wallet_commitment_signature: Bytes,
         transfer_aux_data_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
@@ -387,7 +387,7 @@ impl DarkpoolContract {
             (
                 proof.into(),
                 valid_wallet_update_statement_bytes.into(),
-                shares_commitment_signature.into(),
+                wallet_commitment_signature.into(),
                 transfer_aux_data_bytes.into(),
             ),
         )
@@ -431,7 +431,7 @@ impl DarkpoolContract {
         storage: &mut S,
         proof: Bytes,
         valid_relayer_fee_settlement_statement: Bytes,
-        relayer_shares_commitment_signature: Bytes,
+        relayer_wallet_commitment_signature: Bytes,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
@@ -442,7 +442,7 @@ impl DarkpoolContract {
             (
                 proof.into(),
                 valid_relayer_fee_settlement_statement.into(),
-                relayer_shares_commitment_signature.into(),
+                relayer_wallet_commitment_signature.into(),
             ),
         )
         .map(|_| ())
@@ -471,7 +471,7 @@ impl DarkpoolContract {
         storage: &mut S,
         proof: Bytes,
         valid_fee_redemption_statement: Bytes,
-        recipient_shares_commitment_signature: Bytes,
+        recipient_wallet_commitment_signature: Bytes,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
@@ -482,7 +482,7 @@ impl DarkpoolContract {
             (
                 proof.into(),
                 valid_fee_redemption_statement.into(),
-                recipient_shares_commitment_signature.into(),
+                recipient_wallet_commitment_signature.into(),
             ),
         )
         .map(|_| ())

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -11,11 +11,11 @@ sol! {
 
     // Core functions
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
-    function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory transfer_aux_data) external;
+    function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_shares_commitment_signature) external;
+    function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
-    function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_shares_commitment_signature) external;
+    function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
 
     // Merkle functions
     function init() external;
@@ -59,6 +59,7 @@ sol! {
     event NullifierSpent(uint256 indexed nullifier);
     event WalletUpdated(uint256 indexed wallet_blinder_share);
     event ExternalTransfer(address indexed account, address indexed mint, bool indexed is_withdrawal, uint256 amount);
+    event NotePosted(uint256 indexed note_commitment);
 
     // Darkpool controls events
     event FeeChanged(uint256 indexed new_fee);

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -28,11 +28,11 @@ abigen!(
         function getPubkey() external view returns (uint256[2])
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature, bytes memory transfer_aux_data) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_shares_commitment_signature) external
+        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
-        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_shares_commitment_signature) external
+        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
 
         function markNullifierSpent(uint256 memory nullifier) external
         function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool)


### PR DESCRIPTION
This PR adds a `NotePosted` event that is issued each time a note is committed to the Merkle tree, containing the note commitment. This will be useful for the relayers to scan for any notes that may have been addressed to them.

The `settle_offline_fee` integration tests pass, and I have asserted that logs pertaining the `NotePosted(uint256 indexed note_commitment)` signatures are emitted.