### PR TITLE
contracts-stylus: transfer_executor: include `pk_root` as witness data for Permit2

### DIFF
--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -113,7 +113,7 @@ pub const INVALID_INPUTS_ERROR_MESSAGE: &[u8] = b"invalid inputs";
 /// operation fails
 pub const ARITHMETIC_BACKEND_ERROR_MESSAGE: &[u8] = b"arithmetic backend error";
 
-/// The witness type string used for deposits via `permitWitnessTransferFrom`.
+/// The EIP-712 type string used for deposit witness data via `permitWitnessTransferFrom`.
 ///
 /// For more details see: https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permitwitnesstransferfrom
 pub const DEPOSIT_WITNESS_TYPE_STRING: &str = "DepositWitness witness)DepositWitness(uint256[4] pkRoot)TokenPermissions(address token,uint256 amount)";

--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -112,3 +112,8 @@ pub const INVALID_INPUTS_ERROR_MESSAGE: &[u8] = b"invalid inputs";
 /// The revert message when an EC arithmetic backend
 /// operation fails
 pub const ARITHMETIC_BACKEND_ERROR_MESSAGE: &[u8] = b"arithmetic backend error";
+
+/// The witness type string used for deposits via `permitWitnessTransferFrom`.
+///
+/// For more details see: https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permitwitnesstransferfrom
+pub const DEPOSIT_WITNESS_TYPE_STRING: &str = "DepositWitness witness)DepositWitness(uint256[4] pkRoot)TokenPermissions(address token,uint256 amount)";

--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -429,6 +429,17 @@ pub fn scalar_to_u256(scalar: ScalarField) -> U256 {
     U256::from_be_slice(&scalar.serialize_to_bytes())
 }
 
+/// Converts a [`PublicSigningKey`] into the [`U256`] array representing its scalar serialization
+pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], SerdeError> {
+    let scalars = pk_to_scalars(pk);
+    scalars
+        .into_iter()
+        .map(scalar_to_u256)
+        .collect::<Vec<_>>()
+        .try_into()
+        .map_err(|_| SerdeError::InvalidLength)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/contracts-common/src/solidity.rs
+++ b/contracts-common/src/solidity.rs
@@ -15,13 +15,23 @@ sol! {
         uint256 amount;
     }
 
+    /// The Permit2 witness type used in a deposit
+    struct DepositWitness {
+        /// The root public key of the wallet receiving the deposit
+        uint256[4] pkRoot;
+    }
+
     /// The signed permit message for a single token transfer
     ///
     /// NOTE: This differs from the `PermitTransferFrom` struct in the `ISignatureTransfer` interface
-    /// in that it includes the `spender` field. This field is signed and thus must be included in the
-    /// EIP-712 hash, but is not included in the Solidity definition of the  `PermitTransferFrom` struct
-    /// (as this field is injected by the Permit2 contract).
-    struct PermitTransferFrom {
+    /// in the following ways:
+    /// - It is named `PermitWitnessTransferFrom`, which is indicated to be the proper EIP-712 type name
+    ///   by the [_PERMIT_TRANSFER_FROM_WITNESS_TYPEHASH_STUB](https://github.com/Uniswap/permit2/blob/main/src/libraries/PermitHash.sol#L31)
+    ///   in the Permit2 contract source code.
+    /// - It includes the `spender` and `witness` fields, which are signed and thus must be included in the
+    ///   EIP-712 hash, but are not included in the Solidity definition of the  `PermitTransferFrom` struct
+    ///   (as these fields are injected by the Permit2 contract).
+    struct PermitWitnessTransferFrom {
         /// The token permissions for the transfer
         TokenPermissions permitted;
         /// The address to which the transfer is made
@@ -30,15 +40,17 @@ sol! {
         uint256 nonce;
         /// deadline on the permit signature
         uint256 deadline;
+        /// The witness for the transfer
+        DepositWitness witness;
     }
 
     /// The permit message for a single token transfer
     ///
     /// This exactly matches the `PermitTransferFrom` struct in the `ISignatureTransfer` interface,
-    /// and is what's expected as an argument to the `permitTransferFrom` method. It must be named
+    /// and is what's expected as an argument to the `permitWitnessTransferFrom` method. It must be named
     /// differently so that the `PermitTransferFrom` name can be used in the EIP712 type hash of the
     /// struct above.
-    struct CalldataPermitTransferFrom {
+    struct CalldataPermitWitnessTransferFrom {
         /// The token permissions for the transfer
         TokenPermissions permitted;
         /// a unique value for every token owner's signature to prevent signature replays
@@ -58,15 +70,21 @@ sol! {
     }
 
     /// Transfers a token using a signed permit message
+    /// Includes extra data provided by the caller to verify signature over
+    /// The witness type string must follow EIP712 ordering of nested structs and must include the TokenPermissions type definition
     /// Reverts if the requested amount is greater than the permitted signed amount
     /// permit The permit data signed over by the owner
     /// owner The owner of the tokens to transfer
     /// transferDetails The spender's requested transfer details for the permitted token
+    /// witness Extra data to include when checking the user signature
+    /// witnessTypeString The EIP-712 type definition for remaining string stub of the typehash
     /// signature The signature to verify
-    function permitTransferFrom(
-        CalldataPermitTransferFrom memory permit,
+    function permitWitnessTransferFrom(
+        CalldataPermitWitnessTransferFrom memory permit,
         SignatureTransferDetails calldata transferDetails,
         address owner,
+        bytes32 witness,
+        string calldata witnessTypeString,
         bytes calldata signature
     ) external;
 }

--- a/contracts-stylus/src/contracts/darkpool_core.rs
+++ b/contracts-stylus/src/contracts/darkpool_core.rs
@@ -9,16 +9,15 @@ use crate::{
     assert_result, if_verifying,
     utils::{
         constants::{
-            INVALID_ARR_LEN_ERROR_MESSAGE, INVALID_ORDER_SETTLEMENT_INDICES_ERROR_MESSAGE,
-            INVALID_PROTOCOL_FEE_ERROR_MESSAGE, INVALID_PROTOCOL_PUBKEY_ERROR_MESSAGE,
-            MERKLE_STORAGE_GAP_SIZE, NULLIFIER_SPENT_ERROR_MESSAGE,
-            ROOT_NOT_IN_HISTORY_ERROR_MESSAGE, TRANSFER_EXECUTOR_STORAGE_GAP_SIZE,
-            VERIFICATION_FAILED_ERROR_MESSAGE,
+            CALL_RETDATA_DECODING_ERROR_MESSAGE, INVALID_ARR_LEN_ERROR_MESSAGE,
+            INVALID_ORDER_SETTLEMENT_INDICES_ERROR_MESSAGE, INVALID_PROTOCOL_FEE_ERROR_MESSAGE,
+            INVALID_PROTOCOL_PUBKEY_ERROR_MESSAGE, MERKLE_STORAGE_GAP_SIZE,
+            NULLIFIER_SPENT_ERROR_MESSAGE, ROOT_NOT_IN_HISTORY_ERROR_MESSAGE,
+            TRANSFER_EXECUTOR_STORAGE_GAP_SIZE, VERIFICATION_FAILED_ERROR_MESSAGE,
+            VERIFICATION_RESULT_LAST_BYTE_INDEX,
         },
         helpers::{
-            delegate_call_helper, deserialize_from_calldata, postcard_serialize,
-            serialize_match_statements_for_verification, serialize_statement_for_verification,
-            static_call_helper, u256_to_scalar,
+            delegate_call_helper, deserialize_from_calldata, map_call_error, postcard_serialize, serialize_match_statements_for_verification, serialize_statement_for_verification, u256_to_scalar
         },
         solidity::{
             executeExternalTransferCall, insertNoteCommitmentCall, insertSharesCommitmentCall,

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -105,11 +105,6 @@ pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata"
 #[cfg(feature = "transfer-executor")]
 pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
 
-/// The revert message when failing to extract a `pk_root`
-/// for an external transfer
-#[cfg(feature = "transfer-executor")]
-pub const MISSING_PK_ROOT_ERROR_MESSAGE: &[u8] = b"missing pk_root for transfer";
-
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use ark_ff::PrimeField;
 use contracts_common::{
-    constants::SCALAR_CONVERSION_ERROR_MESSAGE,
+    constants::{SCALAR_CONVERSION_ERROR_MESSAGE, NUM_BYTES_U256},
     custom_serde::{bigint_from_le_bytes, statement_to_public_inputs, ScalarSerializable},
     types::{
         MatchPublicInputs, PublicSigningKey, ScalarField, ValidCommitmentsStatement,

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -4,11 +4,8 @@ use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use ark_ff::PrimeField;
 use contracts_common::{
-    constants::{NUM_BYTES_U256, NUM_SCALARS_PK, SCALAR_CONVERSION_ERROR_MESSAGE},
-    custom_serde::{
-        bigint_from_le_bytes, pk_to_scalars, scalar_to_u256, statement_to_public_inputs,
-        ScalarSerializable,
-    },
+    constants::SCALAR_CONVERSION_ERROR_MESSAGE,
+    custom_serde::{bigint_from_le_bytes, statement_to_public_inputs, ScalarSerializable},
     types::{
         MatchPublicInputs, PublicSigningKey, ScalarField, ValidCommitmentsStatement,
         ValidMatchSettleStatement, ValidReblindStatement,
@@ -159,18 +156,6 @@ pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, Vec<u8>> {
     let bigint = bigint_from_le_bytes(&u256.to_le_bytes::<NUM_BYTES_U256>())
         .map_err(|_| SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())?;
     ScalarField::from_bigint(bigint).ok_or(SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())
-}
-
-/// Converts a [`PublicSigningKey`] into the [`U256`] array representing its scalar serialization
-#[cfg_attr(not(feature = "darkpool-core"), allow(dead_code))]
-pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], Vec<u8>> {
-    let scalars = pk_to_scalars(pk);
-    scalars
-        .into_iter()
-        .map(scalar_to_u256)
-        .collect::<Vec<_>>()
-        .try_into()
-        .map_err(|_| INVALID_ARR_LEN_ERROR_MESSAGE.to_vec())
 }
 
 /// Asserts the validity of the given signature using the given public signing key,

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -789,9 +789,9 @@ async fn test_external_transfer(test_args: TestArgs) -> Result<()> {
 }
 integration_test_async!(test_external_transfer);
 
-/// Test that a malformed deposit is rejected
+/// Test that a deposit specified from a different ETH address is rejected
 #[allow(non_snake_case)]
-async fn test_external_transfer__malicious_deposit(test_args: TestArgs) -> Result<()> {
+async fn test_external_transfer__wrong_eth_addr(test_args: TestArgs) -> Result<()> {
     let transfer_executor_contract = TransferExecutorContract::new(
         test_args.transfer_executor_address,
         test_args.client.clone(),
@@ -840,7 +840,7 @@ async fn test_external_transfer__malicious_deposit(test_args: TestArgs) -> Resul
 
     Ok(())
 }
-integration_test_async!(test_external_transfer__malicious_deposit);
+integration_test_async!(test_external_transfer__wrong_eth_addr);
 
 /// Test that a malformed withdrawal is rejected
 #[allow(non_snake_case)]
@@ -880,6 +880,7 @@ async fn test_external_transfer__malicious_withdrawal(test_args: TestArgs) -> Re
     let mut withdrawal = dummy_erc20_withdrawal(account_address, mint);
     let transfer_aux_data = gen_transfer_aux_data(
         &signing_key,
+        pk_root,
         &withdrawal,
         test_args.permit2_address,
         &transfer_executor_contract,
@@ -894,7 +895,7 @@ async fn test_external_transfer__malicious_withdrawal(test_args: TestArgs) -> Re
     assert!(
         transfer_executor_contract
             .execute_external_transfer(
-                serialize_to_calldata(&Some(pk_root))?,
+                serialize_to_calldata(&pk_root)?,
                 serialize_to_calldata(&withdrawal)?,
                 serialize_to_calldata(&transfer_aux_data)?,
             )


### PR DESCRIPTION
This PR addresses the vulnerability disclosed in our audit concerning the ability to "frontrun" a deposit by using a properly signed `permitTransferFrom` payload but generating a proof wherein the deposit is directed to the attacker's wallet within the Renegade protocol.

We mitigate this by including the intended recipient wallet's `pk_root` as additional witness data to be signed, validated by the Permit2 contract by leveraging its [`permitWitnessTransferFrom`](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permitwitnesstransferfrom) method.

I have added an integration test covering this specific case. All `test_external_transfer*` tests pass.