### PR TITLE
contracts-stylus: merkle: Add leaf insertion event

### DIFF
--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -29,7 +29,7 @@ use crate::{
     utils::{
         constants::{TREE_FULL_ERROR_MESSAGE, ZEROS},
         helpers::{assert_valid_signature, u256_to_scalar},
-        solidity::MerkleOpeningNode,
+        solidity::{MerkleInsertion, MerkleOpeningNode},
     },
 };
 
@@ -207,10 +207,27 @@ where
         Ok(compute_poseidon_hash(&shares))
     }
 
+    /// A helper to insert a value into the tree
+    fn insert_helper(
+        &mut self,
+        value: ScalarField,
+        height: u8,
+        insert_index: u128,
+        subtree_filled: bool,
+    ) -> Result<(), Vec<u8>> {
+        self.insert_recursive(value, height, insert_index, subtree_filled)?;
+        evm::log(MerkleInsertion {
+            index: insert_index,
+            value: scalar_to_u256(value),
+        });
+
+        Ok(())
+    }
+
     /// Recursive helper for inserting a value into the Merkle tree,
     /// updating the sibling pathway along the way, and returning
     /// the updated internal nodes
-    fn insert_helper(
+    fn insert_recursive(
         &mut self,
         value: ScalarField,
         height: u8,

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -54,6 +54,7 @@ sol! {
 
     // Merkle events; we emit the opening path of the inserted node
     event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value);
+    event MerkleInsertion(uint128 indexed index, uint256 indexed value);
 
     // Darkpool user interaction events
     event NullifierSpent(uint256 indexed nullifier);


### PR DESCRIPTION
### Purpose
This PR adds a leaf node insertion event. Now that we have changed the `MerkleOpeningNode` event to be the siblings in the path, we need an index of the insertions themselves to find commitments in the tree. The `MerkleInsertion` event fills this need.

### Testing
- Deployed to a local sequencer, able to reconstruct Merkle paths with updated client logic