### PR TITLE
contracts-stylus: merkle: Call recurive helper instead of main helper

### DIFF
--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -277,7 +277,7 @@ where
         };
         let next_value = compute_poseidon_hash(&inputs);
 
-        self.insert_helper(next_value, height - 1, next_index, new_subtree_filled)?;
+        self.insert_recursive(next_value, height - 1, next_index, new_subtree_filled)?;
 
         // Emit the sibling coordinates and value
         let sibling_idx = if is_left {


### PR DESCRIPTION
### Purpose
This PR calls the `insert_recursive` helper in the merkle contract, rather than the `insert_helper`. The `insert_helper` adds a `MerkleInsertion` event, so we were previously adding one event per node in the tree; rather than a single event for the leaf.

### Testing
- Tested on a deployed version 