### PR TITLE
chore: pin serde to 1.0.197

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5143,9 +5143,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -5161,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ark-crypto-primitives = { version = "0.4", default-features = false, features = 
 ] }
 alloy-primitives = { version = "0.3.1", default-features = false }
 alloy-sol-types = { version = "0.3.1", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "=1.0.197", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.4", default-features = false, features = [
     "macros",


### PR DESCRIPTION
This PR pins the version of `serde` to 1.0.197, ensuring consistency with the relayer. Most of the currently deployed contracts in the staging environment use this version, but the new Merkle contract is deployed with version 1.0.198. The Merkle contract has been redeployed and upgraded on staging already.