### PR TITLE
contracts-stylus, scripts: bump stylus SDK & CLI usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366c3323b03fc99c7d0124cec4eee10e37a226a14b08829a416feec9f2ebb641"
+checksum = "9f274700c5c74abfcc9068f96564615173d8fed72ea44afd1e4404bb04478c00"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5522,15 +5522,14 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74778bf11048b0155b937ee6d52440709d864aa488843238b62272e6c9bdbc1a"
+checksum = "f4424e5f067b1b0922a4294efc01acaa1e36bfc7b31e6b0aed33d7221680f974"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "cfg-if 1.0.0",
  "derivative",
- "fnv",
  "hex",
  "keccak-const",
  "lazy_static",

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -772,8 +772,6 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
 #[cfg(test)]
 mod tests {
-    use core::result::Result;
-
     use alloc::vec;
     use arbitrum_client::conversion::to_contract_link_proof;
     use ark_bn254::Bn254;

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-stylus-sdk = { version = "0.4.2", default-features = false }
+stylus-sdk = "0.5"
 mini-alloc = "0.4.2"
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
@@ -19,7 +19,7 @@ serde = { workspace = true }
 darkpool = []
 darkpool-test-contract = []
 darkpool-core = []
-merkle = ["stylus-sdk/storage-cache"]
+merkle = []
 merkle-test-contract = []
 verifier = []
 vkeys = []

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -376,8 +376,7 @@ pub async fn deploy_stylus_contract(
     deploy_cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     deploy_cmd.arg(STYLUS_COMMAND);
     deploy_cmd.arg(DEPLOY_COMMAND);
-    deploy_cmd.arg("--nightly");
-    deploy_cmd.arg("--wasm-file-path");
+    deploy_cmd.arg("--wasm-file");
     deploy_cmd.arg(&wasm_file_path);
     deploy_cmd.arg("-e");
     deploy_cmd.arg(rpc_url);


### PR DESCRIPTION
This PR bumps the `stylus-sdk` version and the usage of the Stylus CLI to match what is expected in the Sepolia Stylus deployment.