### PR TITLE
contracts-stylus: contract: darkpool: Add atomic match settle method

### DIFF
--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -11,9 +11,10 @@ use ark_serialize::Flags;
 use crate::{
     constants::{NUM_BYTES_ADDRESS, NUM_BYTES_FELT, NUM_BYTES_U64, NUM_SCALARS_PK, NUM_U64S_FELT},
     types::{
-        BabyJubJubPoint, ExternalTransfer, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256,
-        NoteCiphertext, OrderSettlementIndices, PublicInputs, PublicSigningKey, ScalarField,
-        ValidCommitmentsStatement, ValidFeeRedemptionStatement, ValidMatchSettleStatement,
+        BabyJubJubPoint, ExternalMatchResult, ExternalTransfer, FeeTake, G1Affine, G1BaseField,
+        G2Affine, G2BaseField, MontFp256, NoteCiphertext, OrderSettlementIndices, PublicInputs,
+        PublicSigningKey, ScalarField, ValidCommitmentsStatement, ValidFeeRedemptionStatement,
+        ValidMatchSettleAtomicStatement, ValidMatchSettleStatement,
         ValidOfflineFeeSettlementStatement, ValidReblindStatement,
         ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
     },
@@ -277,6 +278,18 @@ impl ScalarSerializable for ValidMatchSettleStatement {
     }
 }
 
+impl ScalarSerializable for ValidMatchSettleAtomicStatement {
+    fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
+        let mut scalars: Vec<ScalarField> = Vec::new();
+        scalars.extend(external_match_result_to_scalars(&self.match_result)?);
+        scalars.extend(fee_take_to_scalars(&self.external_party_fees)?);
+        scalars.extend(&self.internal_party_modified_shares);
+        scalars.extend(&self.internal_party_indices.serialize_to_scalars()?);
+        scalars.push(self.protocol_fee);
+        scalars.push(self.relayer_fee_address);
+        Ok(scalars)
+    }
+}
 impl ScalarSerializable for ValidRelayerFeeSettlementStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
         let mut scalars: Vec<ScalarField> = vec![
@@ -392,6 +405,27 @@ fn external_transfer_to_scalars(
         address_to_scalar(external_transfer.mint)?,
         amount_to_scalar(external_transfer.amount)?,
         external_transfer.is_withdrawal.into(),
+    ])
+}
+
+/// Converts an [`ExternalMatchResult`] into a vector of [`ScalarField`]s
+fn external_match_result_to_scalars(
+    external_match_result: &ExternalMatchResult,
+) -> Result<Vec<ScalarField>, SerdeError> {
+    Ok(vec![
+        address_to_scalar(external_match_result.quote_mint)?,
+        address_to_scalar(external_match_result.base_mint)?,
+        amount_to_scalar(external_match_result.quote_amount)?,
+        amount_to_scalar(external_match_result.base_amount)?,
+        external_match_result.direction.into(),
+    ])
+}
+
+/// Converts a [`FeeTake`] into a vector of [`ScalarField`]s
+fn fee_take_to_scalars(fee_take: &FeeTake) -> Result<Vec<ScalarField>, SerdeError> {
+    Ok(vec![
+        amount_to_scalar(fee_take.relayer_fee)?,
+        amount_to_scalar(fee_take.protocol_fee)?,
     ])
 }
 

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -255,6 +255,41 @@ pub struct TransferAuxData {
     pub transfer_signature: Option<Vec<u8>>,
 }
 
+/// A fee take from a match
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct FeeTake {
+    /// The fee the relayer takes
+    #[serde_as(as = "U256Def")]
+    pub relayer_fee: U256,
+    /// The fee the protocol takes
+    #[serde_as(as = "U256Def")]
+    pub protocol_fee: U256,
+}
+
+/// The result of an atomic match
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ExternalMatchResult {
+    /// The mint (erc20 address) of the quote token
+    #[serde_as(as = "AddressDef")]
+    pub quote_mint: Address,
+    /// The mint (erc20 address) of the base token
+    #[serde_as(as = "AddressDef")]
+    pub base_mint: Address,
+    /// The amount of the quote token
+    #[serde_as(as = "U256Def")]
+    pub quote_amount: U256,
+    /// The amount of the base token
+    #[serde_as(as = "U256Def")]
+    pub base_amount: U256,
+    /// The direction of the trade
+    ///
+    /// `false` (0) corresponds to the internal party buying the base
+    /// `true` (1) corresponds to the internal party selling the base
+    pub direction: bool,
+}
+
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.
 /// Since the secp256k1 base field order is larger than that of Bn254's scalar field,
 /// it takes 2 Bn254 scalar field elements to represent each coordinate.
@@ -384,6 +419,28 @@ pub struct MatchPayload {
     pub valid_commitments_statement: ValidCommitmentsStatement,
     /// The statement for the party's `VALID_REBLIND` proof
     pub valid_reblind_statement: ValidReblindStatement,
+}
+
+/// The statement type for `VALID MATCH SETTLE ATOMIC`
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidMatchSettleAtomicStatement {
+    /// The result of the match
+    pub match_result: ExternalMatchResult,
+    /// The external party's fee obligations as a result of the match
+    pub external_party_fees: FeeTake,
+    /// The modified public shares of the internal party
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub internal_party_modified_shares: Vec<ScalarField>,
+    /// The indices that settlement should modify in the internal party's wallet
+    pub internal_party_indices: OrderSettlementIndices,
+    /// The protocol fee used in the match
+    #[serde_as(as = "ScalarFieldDef")]
+    pub protocol_fee: ScalarField,
+    /// The address at which the relayer wishes to receive their fee due from
+    /// the external party
+    #[serde_as(as = "ScalarFieldDef")]
+    pub relayer_fee_address: ScalarField,
 }
 
 /// Statement for the `VALID RELAYER FEE SETTLEMENT` circuit
@@ -531,6 +588,17 @@ pub struct MatchLinkingWirePolyComms {
     /// `VALID MATCH SETTLE`
     #[serde_as(as = "G1AffineDef")]
     pub valid_match_settle: G1Affine,
+}
+
+/// The public inputs for the `MatchAtomicProofs`
+#[derive(Serialize, Deserialize)]
+pub struct AtomicMatchSettlePublicInputs {
+    /// The public inputs to the internal party's `VALID COMMITMENTS` proof
+    pub valid_commitments: PublicInputs,
+    /// The public inputs to the internal party's `VALID REBLIND` proof
+    pub valid_reblind: PublicInputs,
+    /// The public inputs to the `VALID MATCH SETTLE` proof
+    pub valid_match_settle_atomic: PublicInputs,
 }
 
 /// The elements to be used in a KZG batch opening pairing check

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -22,8 +22,8 @@ use crate::{
         helpers::delegate_call_helper,
         solidity::{
             init_0Call as initMerkleCall, init_1Call as initTransferExecutorCall, newWalletCall,
-            processMatchSettleCall, redeemFeeCall, rootCall, rootInHistoryCall,
-            settleOfflineFeeCall, settleOnlineRelayerFeeCall, updateWalletCall,
+            processAtomicMatchSettleCall, processMatchSettleCall, redeemFeeCall, rootCall,
+            rootInHistoryCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall, updateWalletCall,
             DarkpoolCoreAddressChanged, FeeChanged, MerkleAddressChanged, OwnershipTransferred,
             Paused, PubkeyRotated, TransferExecutorAddressChanged, Unpaused,
             VerifierAddressChanged, VkeysAddressChanged,
@@ -436,6 +436,37 @@ impl DarkpoolContract {
                 party_0_match_payload.to_vec().into(),
                 party_1_match_payload.to_vec().into(),
                 valid_match_settle_statement.to_vec().into(),
+                match_proofs.to_vec().into(),
+                match_linking_proofs.to_vec().into(),
+            ),
+        )
+        .map(|_| ())
+    }
+
+    /// Processes an atomic match settlement between two parties; one internal and one external
+    ///
+    /// An internal party is one with state committed into the darkpool, while an external party provides liquidity to the pool
+    /// during the transaction in which this method is called
+    ///
+    /// The `match_proofs` argument is the serialization of the [`contracts_common::types::ExternalMatchProofs`]
+    /// struct, and the `match_linking_proofs` argument is the serialization of the
+    /// [`contracts_common::types::ExternalMatchLinkingProofs`] struct
+    pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        internal_party_match_payload: Bytes,
+        valid_match_settle_atomic_statement: Bytes,
+        match_proofs: Bytes,
+        match_linking_proofs: Bytes,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_not_paused(storage)?;
+
+        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        delegate_call_helper::<processAtomicMatchSettleCall>(
+            storage,
+            darkpool_core_address,
+            (
+                internal_party_match_payload.to_vec().into(),
+                valid_match_settle_atomic_statement.to_vec().into(),
                 match_proofs.to_vec().into(),
                 match_linking_proofs.to_vec().into(),
             ),

--- a/contracts-stylus/src/contracts/darkpool_core.rs
+++ b/contracts-stylus/src/contracts/darkpool_core.rs
@@ -18,15 +18,17 @@ use crate::{
         },
         helpers::{
             delegate_call_helper, deserialize_from_calldata, get_public_blinder_from_shares,
-            map_call_error, postcard_serialize, serialize_match_statements_for_verification,
-            serialize_statement_for_verification, static_call_helper, u256_to_scalar,
+            map_call_error, postcard_serialize, serialize_atomic_match_statements_for_verification,
+            serialize_match_statements_for_verification, serialize_statement_for_verification,
+            static_call_helper, u256_to_scalar,
         },
         solidity::{
             executeExternalTransferCall, insertNoteCommitmentCall, insertSharesCommitmentCall,
-            processMatchSettleVkeysCall, rootInHistoryCall, validFeeRedemptionVkeyCall,
-            validOfflineFeeSettlementVkeyCall, validRelayerFeeSettlementVkeyCall,
-            validWalletCreateVkeyCall, validWalletUpdateVkeyCall, verifyCall, verifyMatchCall,
-            verifyStateSigAndInsertCall, NotePosted, NullifierSpent, WalletUpdated,
+            processAtomicMatchSettleVkeysCall, processMatchSettleVkeysCall, rootInHistoryCall,
+            validFeeRedemptionVkeyCall, validOfflineFeeSettlementVkeyCall,
+            validRelayerFeeSettlementVkeyCall, validWalletCreateVkeyCall,
+            validWalletUpdateVkeyCall, verifyCall, verifyMatchCall, verifyStateSigAndInsertCall,
+            NotePosted, NullifierSpent, WalletUpdated,
         },
     },
 };
@@ -36,8 +38,9 @@ use contracts_common::{
     custom_serde::{pk_to_u256s, scalar_to_u256},
     types::{
         ExternalTransfer, MatchPayload, PublicEncryptionKey, PublicSigningKey, ScalarField,
-        ValidFeeRedemptionStatement, ValidMatchSettleStatement, ValidOfflineFeeSettlementStatement,
-        ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
+        ValidFeeRedemptionStatement, ValidMatchSettleAtomicStatement, ValidMatchSettleStatement,
+        ValidOfflineFeeSettlementStatement, ValidRelayerFeeSettlementStatement,
+        ValidWalletCreateStatement, ValidWalletUpdateStatement,
     },
 };
 use stylus_sdk::{
@@ -277,6 +280,71 @@ impl DarkpoolCoreContract {
                 .valid_reblind_statement
                 .reblinded_private_shares_commitment,
             &valid_match_settle_statement.party1_modified_shares,
+        )?;
+
+        Ok(())
+    }
+
+    /// Processes an atomic match settlement between two parties; one internal and one external
+    ///
+    /// An internal party is one with state committed into the darkpool, while an external party provides liquidity to the pool
+    /// during the transaction in which this method is called
+    ///
+    /// The `match_proofs` argument is the serialization of the [`contracts_common::types::ExternalMatchProofs`]
+    /// struct, and the `match_linking_proofs` argument is the serialization of the
+    /// [`contracts_common::types::ExternalMatchLinkingProofs`] struct
+    pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        internal_party_match_payload: Bytes,
+        valid_match_settle_statement: Bytes,
+        match_proofs: Bytes,
+        match_linking_proofs: Bytes,
+    ) -> Result<(), Vec<u8>> {
+        let internal_party_match_payload: MatchPayload =
+            deserialize_from_calldata(&internal_party_match_payload)?;
+
+        let valid_match_settle_atomic_statement: ValidMatchSettleAtomicStatement =
+            deserialize_from_calldata(&valid_match_settle_statement)?;
+
+        if_verifying!({
+            let commitments_indices = &internal_party_match_payload
+                .valid_commitments_statement
+                .indices;
+            let settlement_indices = &valid_match_settle_atomic_statement.internal_party_indices;
+            let same_indices = commitments_indices == settlement_indices;
+
+            assert_result!(same_indices, INVALID_ORDER_SETTLEMENT_INDICES_ERROR_MESSAGE)?;
+
+            // We convert the protocol fee directly to a scalar as it is already kept
+            // in storage as fixed-point number, no manipulation is needed to coerce it
+            // to the form expected in the statement / circuit.
+            let protocol_fee = u256_to_scalar(storage.borrow_mut().protocol_fee.get())?;
+            assert_result!(
+                valid_match_settle_atomic_statement.protocol_fee == protocol_fee,
+                INVALID_PROTOCOL_FEE_ERROR_MESSAGE
+            )?;
+
+            DarkpoolCoreContract::batch_verify_process_atomic_match_settle(
+                storage,
+                &internal_party_match_payload,
+                &valid_match_settle_atomic_statement,
+                match_proofs,
+                match_linking_proofs,
+            )?;
+        });
+
+        DarkpoolCoreContract::rotate_wallet(
+            storage,
+            internal_party_match_payload
+                .valid_reblind_statement
+                .original_shares_nullifier,
+            internal_party_match_payload
+                .valid_reblind_statement
+                .merkle_root,
+            internal_party_match_payload
+                .valid_reblind_statement
+                .reblinded_private_shares_commitment,
+            &valid_match_settle_atomic_statement.internal_party_modified_shares,
         )?;
 
         Ok(())
@@ -666,6 +734,42 @@ impl DarkpoolCoreContract {
             process_match_settle_vkeys,
             match_proofs.0,
             match_public_inputs,
+            match_linking_proofs.0,
+        ]
+        .concat();
+
+        let result = DarkpoolCoreContract::call_verifier::<_, verifyMatchCall>(
+            storage,
+            (batch_verification_bundle_ser.into(),),
+        )?;
+
+        assert_result!(result._0, VERIFICATION_FAILED_ERROR_MESSAGE)
+    }
+
+    /// Batch-verifies all of the `process_atomic_match_settle` proofs
+    pub fn batch_verify_process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        internal_party_match_payload: &MatchPayload,
+        valid_match_settle_atomic_statement: &ValidMatchSettleAtomicStatement,
+        match_proofs: Bytes,
+        match_linking_proofs: Bytes,
+    ) -> Result<(), Vec<u8>> {
+        // Fetch the Plonk & linking verification keys used in verifying the matching of a trade
+        let process_atomic_match_settle_vkeys = DarkpoolCoreContract::fetch_vkeys(
+            storage,
+            &processAtomicMatchSettleVkeysCall::SELECTOR,
+        )?;
+
+        let atomic_match_public_inputs = serialize_atomic_match_statements_for_verification(
+            &internal_party_match_payload.valid_commitments_statement,
+            &internal_party_match_payload.valid_reblind_statement,
+            valid_match_settle_atomic_statement,
+        )?;
+
+        let batch_verification_bundle_ser = [
+            process_atomic_match_settle_vkeys,
+            match_proofs.0,
+            atomic_match_public_inputs,
             match_linking_proofs.0,
         ]
         .concat();

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -7,8 +7,9 @@ use contracts_common::{
     constants::{NUM_BYTES_U256, SCALAR_CONVERSION_ERROR_MESSAGE},
     custom_serde::{bigint_from_le_bytes, statement_to_public_inputs, ScalarSerializable},
     types::{
-        MatchPublicInputs, PublicSigningKey, ScalarField, ValidCommitmentsStatement,
-        ValidMatchSettleStatement, ValidReblindStatement,
+        AtomicMatchSettlePublicInputs, MatchPublicInputs, PublicSigningKey, ScalarField,
+        ValidCommitmentsStatement, ValidMatchSettleAtomicStatement, ValidMatchSettleStatement,
+        ValidReblindStatement,
     },
 };
 use contracts_core::crypto::ecdsa::ecdsa_verify;
@@ -88,6 +89,24 @@ pub fn serialize_match_statements_for_verification(
             .map_err(map_calldata_ser_error)?,
     };
     postcard_serialize(&match_public_inputs)
+}
+
+/// Serializes the statements used in verifying the settlement of an atomic
+/// matched trade into scalars, builds the [`AtomicMatchSettlePublicInputs`] struct,
+/// and then serializes it into bytes, as expected by the verifier contract.
+pub fn serialize_atomic_match_statements_for_verification(
+    valid_commitments: &ValidCommitmentsStatement,
+    valid_reblind: &ValidReblindStatement,
+    valid_match_settle_atomic: &ValidMatchSettleAtomicStatement,
+) -> Result<Vec<u8>, Vec<u8>> {
+    let atomic_match_public_inputs = AtomicMatchSettlePublicInputs {
+        valid_commitments: statement_to_public_inputs(valid_commitments)
+            .map_err(map_calldata_ser_error)?,
+        valid_reblind: statement_to_public_inputs(valid_reblind).map_err(map_calldata_ser_error)?,
+        valid_match_settle_atomic: statement_to_public_inputs(valid_match_settle_atomic)
+            .map_err(map_calldata_ser_error)?,
+    };
+    postcard_serialize(&atomic_match_public_inputs)
 }
 
 /// Fetch the public blinder from a set of public shares

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -13,6 +13,7 @@ sol! {
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
     function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
@@ -29,6 +30,7 @@ sol! {
     function validWalletCreateVkey() external view returns (bytes);
     function validWalletUpdateVkey() external view returns (bytes);
     function processMatchSettleVkeys() external view returns (bytes);
+    function processAtomicMatchSettleVkeys() external view returns (bytes);
     function validRelayerFeeSettlementVkey() external view returns (bytes);
     function validOfflineFeeSettlementVkey() external view returns (bytes);
     function validFeeRedemptionVkey() external view returns (bytes);

--- a/contracts-utils/src/proof_system/mod.rs
+++ b/contracts-utils/src/proof_system/mod.rs
@@ -136,7 +136,7 @@ pub fn gen_match_atomic_linking_vkeys<C: SingleProverCircuit>(
 // | ERROR TYPE |
 // --------------
 
-/// An error that occured when interacting with the proof system
+/// An error that occurred when interacting with the proof system
 #[derive(Debug)]
 pub enum ProofSystemError {
     /// An error that occurred when converting between prover and contract types


### PR DESCRIPTION
### Purpose
This PR adds a method to verify an atomic match settlement. This follows mostly the same flow as the standard match settlement, except that only _one_ party has a `VALID COMMITMENTS` and `VALID REBLIND` bundle.

Note that, in this state, the `darkpool-core` contract is too large, so a follow-up will optimize this below the binary size limit.

### Testing
- Deferred until complete