### PR TITLE
contracts-core: verifier: Add match settle atomic verification method

### DIFF
--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -20,6 +20,9 @@ pub const NUM_SELECTORS: usize = 13;
 /// The number of linking proofs in a match bundle
 pub const NUM_MATCH_LINKING_PROOFS: usize = 4;
 
+/// The number of linking proofs in an atomic match bundle
+pub const NUM_ATOMIC_MATCH_LINKING_PROOFS: usize = 2;
+
 /// The transcript has a 64 byte state size to accommodate two hash digests.
 pub const TRANSCRIPT_STATE_SIZE: usize = 64;
 

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -178,6 +178,19 @@ pub struct LinkingProof {
     pub linking_poly_opening: G1Affine,
 }
 
+/// A proof-linking verification instance
+#[derive(Clone)]
+pub struct LinkingInstance {
+    /// The verification key for the linking proof
+    pub vkey: LinkingVerificationKey,
+    /// The proof to be verified
+    pub proof: LinkingProof,
+    /// The wire polynomial commitment of the first proof
+    pub wire_comm_0: G1Affine,
+    /// The wire polynomial commitment of the second proof
+    pub wire_comm_1: G1Affine,
+}
+
 /// The linking proofs used to ensure input consistency
 /// between the `MatchProofs`
 #[derive(Serialize, Deserialize, Clone, Copy)]
@@ -194,6 +207,29 @@ pub struct MatchLinkingProofs {
     /// The proof of linked inputs between
     /// `PARTY 1 VALID COMMITMENTS` <-> `VALID MATCH SETTLE`
     pub valid_commitments_match_settle_1: LinkingProof,
+}
+
+/// The proofs representing the matching and settlement of an atomic match
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct MatchAtomicProofs {
+    /// The internal party's proof of `VALID COMMITMENTS`
+    pub valid_commitments: Proof,
+    /// The internal party's proof of `VALID REBLIND`
+    pub valid_reblind: Proof,
+    /// The proof of `VALID MATCH SETTLE ATOMIC`
+    pub valid_match_settle_atomic: Proof,
+}
+
+/// The linking proofs used to ensure input consistency
+/// between the `MatchAtomicProofs`
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct MatchAtomicLinkingProofs {
+    /// The proof of linked inputs between the internal party's
+    /// `VALID REBLIND` <-> `VALID COMMITMENTS`
+    pub valid_reblind_commitments: LinkingProof,
+    /// The proof of linked inputs between the internal party's
+    /// `VALID COMMITMENTS` <-> `VALID MATCH SETTLE ATOMIC`
+    pub valid_commitments_match_settle_atomic: LinkingProof,
 }
 
 /// The public coin challenges used throughout the Plonk protocol, obtained via a Fiat-Shamir transformation.
@@ -592,13 +628,32 @@ pub struct MatchLinkingWirePolyComms {
 
 /// The public inputs for the `MatchAtomicProofs`
 #[derive(Serialize, Deserialize)]
-pub struct AtomicMatchSettlePublicInputs {
+pub struct AtomicMatchPublicInputs {
     /// The public inputs to the internal party's `VALID COMMITMENTS` proof
     pub valid_commitments: PublicInputs,
     /// The public inputs to the internal party's `VALID REBLIND` proof
     pub valid_reblind: PublicInputs,
     /// The public inputs to the `VALID MATCH SETTLE` proof
     pub valid_match_settle_atomic: PublicInputs,
+}
+
+/// The commitments to the first wiring polynomials in each of the
+/// Plonk proofs being linked during the matching of a trade
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct AtomicMatchLinkingWirePolyComms {
+    /// The commitment to the first wiring polynomial in the internal party's
+    /// `VALID REBLIND` proof
+    #[serde_as(as = "G1AffineDef")]
+    pub valid_reblind: G1Affine,
+    /// The commitment to the first wiring polynomial in the internal party's
+    /// `VALID COMMITMENTS` proof
+    #[serde_as(as = "G1AffineDef")]
+    pub valid_commitments: G1Affine,
+    /// The commitment to the first wiring polynomial in the
+    /// `VALID MATCH SETTLE ATOMIC` proof
+    #[serde_as(as = "G1AffineDef")]
+    pub valid_match_settle_atomic: G1Affine,
 }
 
 /// The elements to be used in a KZG batch opening pairing check

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -9,10 +9,12 @@ use alloc::{vec, vec::Vec};
 use ark_ff::{batch_inversion, FftField, Field, One, Zero};
 use contracts_common::{
     backends::{G1ArithmeticBackend, HashBackend},
-    constants::{NUM_MATCH_LINKING_PROOFS, NUM_WIRE_TYPES},
+    constants::{NUM_ATOMIC_MATCH_LINKING_PROOFS, NUM_MATCH_LINKING_PROOFS, NUM_WIRE_TYPES},
     custom_serde::SerdeError,
     types::{
-        Challenges, G1Affine, G2Affine, LinkingProof, LinkingVerificationKey, MatchLinkingProofs,
+        AtomicMatchLinkingWirePolyComms, AtomicMatchPublicInputs, Challenges, G1Affine, G2Affine,
+        LinkingInstance, LinkingProof, LinkingVerificationKey, MatchAtomicLinkingProofs,
+        MatchAtomicLinkingVkeys, MatchAtomicProofs, MatchAtomicVkeys, MatchLinkingProofs,
         MatchLinkingVkeys, MatchLinkingWirePolyComms, MatchProofs, MatchPublicInputs, MatchVkeys,
         OpeningElems, Proof, PublicInputs, ScalarField, VerificationKey,
     },
@@ -144,6 +146,82 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         Self::batch_opening(&final_opening_elems, x_h, h)
     }
 
+    /// Batch-verifies:
+    /// - internal party's `VALID COMMITMENTS`
+    /// - internal party's `VALID REBLIND`
+    /// - `VALID MATCH SETTLE ATOMIC`
+    ///
+    /// And verifies proof linking between:
+    /// - `VALID REBLIND` <-> `VALID COMMITMENTS`
+    /// - `VALID COMMITMENTS` <-> `VALID MATCH SETTLE ATOMIC`
+    ///
+    /// Applies batch verification as implemented in Jellyfish: https://github.com/renegade-fi/mpc-jellyfish/blob/main/plonk/src/proof_system/verifier.rs#L199
+    ///
+    /// This assumes that all the verification keys were generated using the same SRS.
+    pub fn verify_atomic_match(
+        match_vkeys: MatchAtomicVkeys,
+        match_linking_vkeys: MatchAtomicLinkingVkeys,
+        match_proofs: MatchAtomicProofs,
+        match_public_inputs: AtomicMatchPublicInputs,
+        match_linking_proofs: MatchAtomicLinkingProofs,
+    ) -> Result<bool, VerifierError> {
+        let x_h = match_vkeys.valid_commitments_vkey.x_h;
+        let h = match_vkeys.valid_commitments_vkey.h;
+
+        // Prepare linking proofs for batch verification
+        let match_linking_wire_poly_comms = AtomicMatchLinkingWirePolyComms {
+            valid_reblind: match_proofs.valid_reblind.wire_comms[0],
+            valid_commitments: match_proofs.valid_commitments.wire_comms[0],
+            valid_match_settle_atomic: match_proofs.valid_match_settle_atomic.wire_comms[0],
+        };
+
+        let OpeningElems {
+            g1_lhs_elems: linking_g1_lhs_elems,
+            g1_rhs_elems: linking_g1_rhs_elems,
+            transcript_elements: linking_transcript_elements,
+        } = Self::prep_atomic_match_linking_proofs_opening(
+            match_linking_vkeys,
+            match_linking_proofs,
+            match_linking_wire_poly_comms,
+        )?;
+
+        let vkey_batch = [
+            match_vkeys.valid_commitments_vkey,
+            match_vkeys.valid_reblind_vkey,
+            match_vkeys.valid_match_settle_atomic_vkey,
+        ];
+        let proof_batch = [
+            match_proofs.valid_commitments,
+            match_proofs.valid_reblind,
+            match_proofs.valid_match_settle_atomic,
+        ];
+        let public_inputs_batch = [
+            match_public_inputs.valid_commitments,
+            match_public_inputs.valid_reblind,
+            match_public_inputs.valid_match_settle_atomic,
+        ];
+
+        // Prepare Plonk proofs for batch verification
+        let OpeningElems {
+            g1_lhs_elems: plonk_g1_lhs_elems,
+            g1_rhs_elems: plonk_g1_rhs_elems,
+            transcript_elements: plonk_transcript_elements,
+        } = Self::prep_batch_plonk_proofs_opening(&vkey_batch, &proof_batch, &public_inputs_batch)?;
+
+        let g1_lhs_elems = [linking_g1_lhs_elems, plonk_g1_lhs_elems].concat();
+        let g1_rhs_elems = [linking_g1_rhs_elems, plonk_g1_rhs_elems].concat();
+        let transcript_elements = [linking_transcript_elements, plonk_transcript_elements].concat();
+
+        let final_opening_elems = OpeningElems {
+            g1_lhs_elems,
+            g1_rhs_elems,
+            transcript_elements,
+        };
+
+        // Batch-open all of the linking & Plonk proofs together
+        Self::batch_opening(&final_opening_elems, x_h, h)
+    }
+
     /// Computes the elements used in the final KZG batch opening pairing check
     /// for a batch of Plonk proofs
     fn prep_batch_plonk_proofs_opening(
@@ -252,66 +330,85 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         match_linking_proofs: MatchLinkingProofs,
         match_linking_wire_poly_comms: MatchLinkingWirePolyComms,
     ) -> Result<OpeningElems, VerifierError> {
-        let mut g1_lhs_elems = [G1Affine::default(); NUM_MATCH_LINKING_PROOFS];
-        let mut g1_rhs_elems = [G1Affine::default(); NUM_MATCH_LINKING_PROOFS];
-        let mut transcript_elements = [ScalarField::zero(); NUM_MATCH_LINKING_PROOFS];
+        // Setup the linking instances
+        let mut linking_instances = Vec::with_capacity(NUM_MATCH_LINKING_PROOFS);
+        linking_instances.push(LinkingInstance {
+            vkey: match_linking_vkeys.valid_commitments_match_settle_0,
+            proof: match_linking_proofs.valid_commitments_match_settle_0,
+            wire_comm_0: match_linking_wire_poly_comms.valid_commitments_0,
+            wire_comm_1: match_linking_wire_poly_comms.valid_match_settle,
+        });
+        linking_instances.push(LinkingInstance {
+            vkey: match_linking_vkeys.valid_reblind_commitments,
+            proof: match_linking_proofs.valid_reblind_commitments_0,
+            wire_comm_0: match_linking_wire_poly_comms.valid_reblind_0,
+            wire_comm_1: match_linking_wire_poly_comms.valid_commitments_0,
+        });
+        linking_instances.push(LinkingInstance {
+            vkey: match_linking_vkeys.valid_commitments_match_settle_1,
+            proof: match_linking_proofs.valid_commitments_match_settle_1,
+            wire_comm_0: match_linking_wire_poly_comms.valid_commitments_1,
+            wire_comm_1: match_linking_wire_poly_comms.valid_match_settle,
+        });
+        linking_instances.push(LinkingInstance {
+            vkey: match_linking_vkeys.valid_reblind_commitments,
+            proof: match_linking_proofs.valid_reblind_commitments_1,
+            wire_comm_0: match_linking_wire_poly_comms.valid_reblind_1,
+            wire_comm_1: match_linking_wire_poly_comms.valid_commitments_1,
+        });
 
-        // Prep the PARTY 0 VALID COMMITMENTS <-> VALID MATCH SETTLE linking proof opening elements
-        let (g1_lhs_0, g1_rhs_0, eta_0) = Self::prep_linking_proof_opening_elems(
-            match_linking_vkeys.valid_commitments_match_settle_0,
-            match_linking_proofs.valid_commitments_match_settle_0,
-            (
-                match_linking_wire_poly_comms.valid_commitments_0,
-                match_linking_wire_poly_comms.valid_match_settle,
-            ),
-        )?;
-        g1_lhs_elems[0] = g1_lhs_0;
-        g1_rhs_elems[0] = g1_rhs_0;
-        transcript_elements[0] = eta_0;
+        Self::prep_linking_instances(linking_instances)
+    }
 
-        // Prep the PARTY 0 VALID REBLIND <-> PARTY 0 VALID COMMITMENTS linking proof opening elements
-        let (g1_lhs_1, g1_rhs_1, eta_1) = Self::prep_linking_proof_opening_elems(
-            match_linking_vkeys.valid_reblind_commitments,
-            match_linking_proofs.valid_reblind_commitments_0,
-            (
-                match_linking_wire_poly_comms.valid_reblind_0,
-                match_linking_wire_poly_comms.valid_commitments_0,
-            ),
-        )?;
-        g1_lhs_elems[1] = g1_lhs_1;
-        g1_rhs_elems[1] = g1_rhs_1;
-        transcript_elements[1] = eta_1;
+    /// Computes the elements used in the final KZG batch opening pairing check
+    /// for the linking proofs involved in the matching and settlement of an atomic match.
+    fn prep_atomic_match_linking_proofs_opening(
+        match_linking_vkeys: MatchAtomicLinkingVkeys,
+        match_linking_proofs: MatchAtomicLinkingProofs,
+        match_linking_wire_poly_comms: AtomicMatchLinkingWirePolyComms,
+    ) -> Result<OpeningElems, VerifierError> {
+        // Setup the linking instances
+        let mut linking_instances = Vec::with_capacity(NUM_ATOMIC_MATCH_LINKING_PROOFS);
+        linking_instances.push(LinkingInstance {
+            vkey: match_linking_vkeys.valid_reblind_commitments,
+            proof: match_linking_proofs.valid_reblind_commitments,
+            wire_comm_0: match_linking_wire_poly_comms.valid_reblind,
+            wire_comm_1: match_linking_wire_poly_comms.valid_commitments,
+        });
+        linking_instances.push(LinkingInstance {
+            vkey: match_linking_vkeys.valid_commitments_match_settle_atomic,
+            proof: match_linking_proofs.valid_commitments_match_settle_atomic,
+            wire_comm_0: match_linking_wire_poly_comms.valid_commitments,
+            wire_comm_1: match_linking_wire_poly_comms.valid_match_settle_atomic,
+        });
 
-        // Prep the PARTY 1 VALID COMMITMENTS <-> VALID MATCH SETTLE linking proof opening elements
-        let (g1_lhs_2, g1_rhs_2, eta_2) = Self::prep_linking_proof_opening_elems(
-            match_linking_vkeys.valid_commitments_match_settle_1,
-            match_linking_proofs.valid_commitments_match_settle_1,
-            (
-                match_linking_wire_poly_comms.valid_commitments_1,
-                match_linking_wire_poly_comms.valid_match_settle,
-            ),
-        )?;
-        g1_lhs_elems[2] = g1_lhs_2;
-        g1_rhs_elems[2] = g1_rhs_2;
-        transcript_elements[2] = eta_2;
+        Self::prep_linking_instances(linking_instances)
+    }
 
-        // Prep the PARTY 1 VALID REBLIND <-> PARTY 1 VALID COMMITMENTS linking proof opening elements
-        let (g1_lhs_3, g1_rhs_3, eta_3) = Self::prep_linking_proof_opening_elems(
-            match_linking_vkeys.valid_reblind_commitments,
-            match_linking_proofs.valid_reblind_commitments_1,
-            (
-                match_linking_wire_poly_comms.valid_reblind_1,
-                match_linking_wire_poly_comms.valid_commitments_1,
-            ),
-        )?;
-        g1_lhs_elems[3] = g1_lhs_3;
-        g1_rhs_elems[3] = g1_rhs_3;
-        transcript_elements[3] = eta_3;
+    /// Prepares the pairing product values for a set of link-proof verification instances
+    fn prep_linking_instances(
+        linking_instances: Vec<LinkingInstance>,
+    ) -> Result<OpeningElems, VerifierError> {
+        let mut g1_lhs_elems = Vec::with_capacity(linking_instances.len());
+        let mut g1_rhs_elems = Vec::with_capacity(linking_instances.len());
+        let mut transcript_elements = Vec::with_capacity(linking_instances.len());
+
+        for link in linking_instances {
+            let (g1_lhs, g1_rhs, eta) = Self::prep_linking_proof_opening_elems(
+                link.vkey,
+                link.proof,
+                (link.wire_comm_0, link.wire_comm_1),
+            )?;
+
+            g1_lhs_elems.push(g1_lhs);
+            g1_rhs_elems.push(g1_rhs);
+            transcript_elements.push(eta);
+        }
 
         Ok(OpeningElems {
-            g1_lhs_elems: g1_lhs_elems.to_vec(),
-            g1_rhs_elems: g1_rhs_elems.to_vec(),
-            transcript_elements: transcript_elements.to_vec(),
+            g1_lhs_elems,
+            g1_rhs_elems,
+            transcript_elements,
         })
     }
 

--- a/contracts-stylus/src/contracts/darkpool_core.rs
+++ b/contracts-stylus/src/contracts/darkpool_core.rs
@@ -27,8 +27,8 @@ use crate::{
             processAtomicMatchSettleVkeysCall, processMatchSettleVkeysCall, rootInHistoryCall,
             validFeeRedemptionVkeyCall, validOfflineFeeSettlementVkeyCall,
             validRelayerFeeSettlementVkeyCall, validWalletCreateVkeyCall,
-            validWalletUpdateVkeyCall, verifyCall, verifyMatchCall, verifyStateSigAndInsertCall,
-            NotePosted, NullifierSpent, WalletUpdated,
+            validWalletUpdateVkeyCall, verifyAtomicMatchCall, verifyCall, verifyMatchCall,
+            verifyStateSigAndInsertCall, NotePosted, NullifierSpent, WalletUpdated,
         },
     },
 };
@@ -774,7 +774,7 @@ impl DarkpoolCoreContract {
         ]
         .concat();
 
-        let result = DarkpoolCoreContract::call_verifier::<_, verifyMatchCall>(
+        let result = DarkpoolCoreContract::call_verifier::<_, verifyAtomicMatchCall>(
             storage,
             (batch_verification_bundle_ser.into(),),
         )?;

--- a/contracts-stylus/src/contracts/verifier.rs
+++ b/contracts-stylus/src/contracts/verifier.rs
@@ -43,4 +43,24 @@ impl VerifierContract {
         )
         .map_err(Into::into)
     }
+
+    /// Batch-verify the proofs involved in settling an atomic match
+    pub fn verify_atomic_match(&self, atomic_match_bundle: Bytes) -> Result<bool, Vec<u8>> {
+        let (
+            match_vkeys,
+            match_linking_vkeys,
+            match_proofs,
+            match_public_inputs,
+            match_linking_proofs,
+        ) = deserialize_from_calldata(&atomic_match_bundle)?;
+
+        Verifier::<PrecompileG1ArithmeticBackend, StylusHasher>::verify_atomic_match(
+            match_vkeys,
+            match_linking_vkeys,
+            match_proofs,
+            match_public_inputs,
+            match_linking_proofs,
+        )
+        .map_err(Into::into)
+    }
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -7,7 +7,7 @@ use contracts_common::{
     constants::{NUM_BYTES_U256, SCALAR_CONVERSION_ERROR_MESSAGE},
     custom_serde::{bigint_from_le_bytes, statement_to_public_inputs, ScalarSerializable},
     types::{
-        AtomicMatchSettlePublicInputs, MatchPublicInputs, PublicSigningKey, ScalarField,
+        AtomicMatchPublicInputs, MatchPublicInputs, PublicSigningKey, ScalarField,
         ValidCommitmentsStatement, ValidMatchSettleAtomicStatement, ValidMatchSettleStatement,
         ValidReblindStatement,
     },
@@ -99,7 +99,7 @@ pub fn serialize_atomic_match_statements_for_verification(
     valid_reblind: &ValidReblindStatement,
     valid_match_settle_atomic: &ValidMatchSettleAtomicStatement,
 ) -> Result<Vec<u8>, Vec<u8>> {
-    let atomic_match_public_inputs = AtomicMatchSettlePublicInputs {
+    let atomic_match_public_inputs = AtomicMatchPublicInputs {
         valid_commitments: statement_to_public_inputs(valid_commitments)
             .map_err(map_calldata_ser_error)?,
         valid_reblind: statement_to_public_inputs(valid_reblind).map_err(map_calldata_ser_error)?,

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -38,6 +38,7 @@ sol! {
     // Verifier functions
     function verify(bytes memory verification_bundle) external view returns (bool);
     function verifyMatch(bytes memory match_bundle) external view returns (bool);
+    function verifyAtomicMatch(bytes memory atomic_match_bundle) external view returns (bool);
 
     // Transfer executor functions
     function init(address memory permit2_address) external;

--- a/contracts-utils/src/proof_system/mod.rs
+++ b/contracts-utils/src/proof_system/mod.rs
@@ -136,7 +136,7 @@ pub fn gen_match_atomic_linking_vkeys<C: SingleProverCircuit>(
 // | ERROR TYPE |
 // --------------
 
-/// An error that occurred when interacting with the proof system
+/// An error that occured when interacting with the proof system
 #[derive(Debug)]
 pub enum ProofSystemError {
     /// An error that occurred when converting between prover and contract types


### PR DESCRIPTION
### Purpose
This PR adds a verifier method for verifying the atomic match settlement bundle. This closely follows the standard match path, but requires fewer proof-linking groups.

### Testing
Deferred to a follow up