### PR TITLE
contracts-stylus: darkpool: Call core contracts separately

### DIFF
--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -84,25 +84,29 @@ pub const EMPTY_LEAF_VALUE: ScalarField = Fp(
     PhantomData,
 );
 
-/// The selector for the darkpool core address in the
+/// The selector for the core wallet ops address in the
 /// `is_implementation_upgraded` method on the Darkpool test contract
-pub const DARKPOOL_CORE_ADDRESS_SELECTOR: u8 = 0;
+pub const CORE_WALLET_OPS_ADDRESS_SELECTOR: u8 = 0;
+
+/// The selector for the core settlement address in the
+/// `is_implementation_upgraded` method on the Darkpool test contract
+pub const CORE_SETTLEMENT_ADDRESS_SELECTOR: u8 = 1;
 
 /// The selector for the verifier address in the `is_implementation_upgraded`
 /// method on the Darkpool test contract
-pub const VERIFIER_ADDRESS_SELECTOR: u8 = 1;
+pub const VERIFIER_ADDRESS_SELECTOR: u8 = 2;
 
 /// The selector for the vkeys address in the `is_implementation_upgraded`
 /// method on the Darkpool test contract
-pub const VKEYS_ADDRESS_SELECTOR: u8 = 2;
+pub const VKEYS_ADDRESS_SELECTOR: u8 = 3;
 
 /// The selector for the merkle address in the `is_implementation_upgraded`
 /// method on the Darkpool test contract
-pub const MERKLE_ADDRESS_SELECTOR: u8 = 3;
+pub const MERKLE_ADDRESS_SELECTOR: u8 = 4;
 
 /// The selector for the transfer executor address in the
 /// `is_implementation_upgraded` method on the Darkpool test contract
-pub const TRANSFER_EXECUTOR_ADDRESS_SELECTOR: u8 = 4;
+pub const TRANSFER_EXECUTOR_ADDRESS_SELECTOR: u8 = 5;
 
 /// The revert message when failing to convert a
 /// u256 to a scalar

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -24,9 +24,9 @@ use crate::{
             init_0Call as initMerkleCall, init_1Call as initTransferExecutorCall, newWalletCall,
             processAtomicMatchSettleCall, processMatchSettleCall, redeemFeeCall, rootCall,
             rootInHistoryCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall, updateWalletCall,
-            DarkpoolCoreAddressChanged, FeeChanged, MerkleAddressChanged, OwnershipTransferred,
-            Paused, PubkeyRotated, TransferExecutorAddressChanged, Unpaused,
-            VerifierAddressChanged, VkeysAddressChanged,
+            CoreSettlementAddressChanged, CoreWalletOpsAddressChanged, FeeChanged,
+            MerkleAddressChanged, OwnershipTransferred, Paused, PubkeyRotated,
+            TransferExecutorAddressChanged, Unpaused, VerifierAddressChanged, VkeysAddressChanged,
         },
     },
 };
@@ -51,7 +51,7 @@ pub struct DarkpoolContract {
     paused: StorageBool,
 
     /// The address of the darkpool core contract
-    pub(crate) darkpool_core_address: StorageAddress,
+    pub(crate) core_wallet_ops_address: StorageAddress,
 
     /// The address of the verifier contract
     pub(crate) verifier_address: StorageAddress,
@@ -84,6 +84,11 @@ pub struct DarkpoolContract {
 
     /// The BabyJubJub EC-ElGamal public encryption key for the protocol
     pub(crate) protocol_public_encryption_key: StorageArray<StorageU256, 2>,
+
+    // --- Updated Fields for Atomic Settlement --- //
+    /// The address of the core settlement contract, added at the bottom of the storage layout to
+    /// prevent collisions with existing fields when this field was added
+    pub(crate) core_settlement_address: StorageAddress,
 }
 
 #[external]
@@ -96,7 +101,8 @@ impl DarkpoolContract {
     #[allow(clippy::too_many_arguments)]
     pub fn initialize<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
-        darkpool_core_address: Address,
+        core_wallet_ops_address: Address,
+        core_settlement_address: Address,
         verifier_address: Address,
         vkeys_address: Address,
         merkle_address: Address,
@@ -117,7 +123,8 @@ impl DarkpoolContract {
 
         // Set the stored addresses
         DarkpoolContract::_transfer_ownership(storage, msg::sender());
-        DarkpoolContract::set_darkpool_core_address(storage, darkpool_core_address)?;
+        DarkpoolContract::set_core_wallet_ops_address(storage, core_wallet_ops_address)?;
+        DarkpoolContract::set_core_settlement_address(storage, core_settlement_address)?;
         DarkpoolContract::set_verifier_address(storage, verifier_address)?;
         DarkpoolContract::set_vkeys_address(storage, vkeys_address)?;
         DarkpoolContract::set_merkle_address(storage, merkle_address)?;
@@ -284,22 +291,39 @@ impl DarkpoolContract {
     }
 
     /// Sets the darkpool core address
-    pub fn set_darkpool_core_address<S: TopLevelStorage + BorrowMut<Self>>(
+    pub fn set_core_wallet_ops_address<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
-        darkpool_core_address: Address,
+        core_wallet_ops_address: Address,
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage)?;
-
-        DarkpoolContract::check_address_not_zero(darkpool_core_address)?;
+        DarkpoolContract::check_address_not_zero(core_wallet_ops_address)?;
         storage
             .borrow_mut()
-            .darkpool_core_address
-            .set(darkpool_core_address);
+            .core_wallet_ops_address
+            .set(core_wallet_ops_address);
 
-        evm::log(DarkpoolCoreAddressChanged {
-            new_address: darkpool_core_address,
+        evm::log(CoreWalletOpsAddressChanged {
+            new_address: core_wallet_ops_address,
         });
 
+        Ok(())
+    }
+
+    /// Sets the core settlement address
+    pub fn set_core_settlement_address<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        core_settlement_address: Address,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_owner(storage)?;
+        DarkpoolContract::check_address_not_zero(core_settlement_address)?;
+        storage
+            .borrow_mut()
+            .core_settlement_address
+            .set(core_settlement_address);
+
+        evm::log(CoreSettlementAddressChanged {
+            new_address: core_settlement_address,
+        });
         Ok(())
     }
 
@@ -376,10 +400,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
         delegate_call_helper::<newWalletCall>(
             storage,
-            darkpool_core_address,
+            core_wallet_ops_address,
             (
                 proof.to_vec().into(),
                 valid_wallet_create_statement_bytes.to_vec().into(),
@@ -398,10 +422,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
         delegate_call_helper::<updateWalletCall>(
             storage,
-            darkpool_core_address,
+            core_wallet_ops_address,
             (
                 proof.to_vec().into(),
                 valid_wallet_update_statement_bytes.to_vec().into(),
@@ -428,10 +452,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
         delegate_call_helper::<processMatchSettleCall>(
             storage,
-            darkpool_core_address,
+            core_settlement_address,
             (
                 party_0_match_payload.to_vec().into(),
                 party_1_match_payload.to_vec().into(),
@@ -460,10 +484,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
         delegate_call_helper::<processAtomicMatchSettleCall>(
             storage,
-            darkpool_core_address,
+            core_settlement_address,
             (
                 internal_party_match_payload.to_vec().into(),
                 valid_match_settle_atomic_statement.to_vec().into(),
@@ -484,10 +508,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
         delegate_call_helper::<settleOnlineRelayerFeeCall>(
             storage,
-            darkpool_core_address,
+            core_wallet_ops_address,
             (
                 proof.to_vec().into(),
                 valid_relayer_fee_settlement_statement.to_vec().into(),
@@ -506,10 +530,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
         delegate_call_helper::<settleOfflineFeeCall>(
             storage,
-            darkpool_core_address,
+            core_wallet_ops_address,
             (
                 proof.to_vec().into(),
                 valid_offline_fee_settlement_statement.to_vec().into(),
@@ -527,10 +551,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let darkpool_core_address = storage.borrow_mut().darkpool_core_address.get();
+        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
         delegate_call_helper::<redeemFeeCall>(
             storage,
-            darkpool_core_address,
+            core_wallet_ops_address,
             (
                 proof.to_vec().into(),
                 valid_fee_redemption_statement.to_vec().into(),
@@ -606,6 +630,16 @@ impl DarkpoolContract {
     /// Checks that the given address is not the zero address
     pub fn check_address_not_zero(address: Address) -> Result<(), Vec<u8>> {
         assert_result!(address != Address::ZERO, ZERO_ADDRESS_ERROR_MESSAGE)
+    }
+
+    /// Get the core wallet ops address
+    pub fn get_core_wallet_ops_address(&self) -> Address {
+        self.core_wallet_ops_address.get()
+    }
+
+    /// Get the core settlement address
+    pub fn get_core_settlement_address(&self) -> Address {
+        self.core_settlement_address.get()
     }
 
     /// Gets the affine coordinates of the protocol public encryption key

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -4,8 +4,8 @@ use core::borrow::{Borrow, BorrowMut};
 
 use alloc::vec::Vec;
 use contracts_common::constants::{
-    DARKPOOL_CORE_ADDRESS_SELECTOR, MERKLE_ADDRESS_SELECTOR, TRANSFER_EXECUTOR_ADDRESS_SELECTOR,
-    VERIFIER_ADDRESS_SELECTOR, VKEYS_ADDRESS_SELECTOR,
+    CORE_SETTLEMENT_ADDRESS_SELECTOR, CORE_WALLET_OPS_ADDRESS_SELECTOR, MERKLE_ADDRESS_SELECTOR,
+    TRANSFER_EXECUTOR_ADDRESS_SELECTOR, VERIFIER_ADDRESS_SELECTOR, VKEYS_ADDRESS_SELECTOR,
 };
 use stylus_sdk::{
     alloy_primitives::{Address, U256},
@@ -121,7 +121,8 @@ impl DarkpoolTestContract {
     pub fn is_implementation_upgraded(&mut self, address_selector: u8) -> Result<bool, Vec<u8>> {
         let this = BorrowMut::<DarkpoolContract>::borrow_mut(self);
         let implementation_address = match address_selector {
-            DARKPOOL_CORE_ADDRESS_SELECTOR => this.darkpool_core_address.get(),
+            CORE_WALLET_OPS_ADDRESS_SELECTOR => this.get_core_wallet_ops_address(),
+            CORE_SETTLEMENT_ADDRESS_SELECTOR => this.get_core_settlement_address(),
             VERIFIER_ADDRESS_SELECTOR => this.verifier_address.get(),
             VKEYS_ADDRESS_SELECTOR => this.vkeys_address.get(),
             MERKLE_ADDRESS_SELECTOR => this.merkle_address.get(),

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -9,14 +9,16 @@ sol! {
     // | FUNCTIONS |
     // -------------
 
-    // Core functions
+    // Core wallet ops functions
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
-    function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
     function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
+
+    // Core settlement functions
+    function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
 
     // Merkle functions
     function init() external;
@@ -71,7 +73,8 @@ sol! {
     event OwnershipTransferred(address indexed new_owner);
     event Paused();
     event Unpaused();
-    event DarkpoolCoreAddressChanged(address indexed new_address);
+    event CoreWalletOpsAddressChanged(address indexed new_address);
+    event CoreSettlementAddressChanged(address indexed new_address);
     event VerifierAddressChanged(address indexed new_address);
     event VkeysAddressChanged(address indexed new_address);
     event MerkleAddressChanged(address indexed new_address);


### PR DESCRIPTION
### Purpose
This PR switches the `darkpool` contract to call the core settlement and wallet ops contracts separately. To do so, we add a new storage slot to the end of the existing storage to prevent conflict. We re-use the `darkpool_core_address` storage slot for the `core_wallet_ops_address` and place the `core_settlement_address` in the new slot.

### Testing
- Core contracts and darkpool contracts build under the size limit
- Deferred until all contracts build