### PR TITLE
contracts-stylus: darkpool: Add protocol external fee address

### DIFF
--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -106,6 +106,9 @@ pub struct CoreSettlementContract {
     protocol_public_encryption_key: StorageArray<StorageU256, 2>,
 
     // --- Updated Fields for Atomic Settlement --- //
+    /// The address of the protocol external fee collection wallet
+    protocol_external_fee_collection_address: StorageAddress,
+
     /// The address of the core settlement contract
     ///
     /// Added at the bottom of the storage layout to
@@ -319,6 +322,8 @@ impl CoreSettlementContract {
 
 impl CoreSettlementContract {
     /// Batch-verifies all of the `process_match_settle` proofs
+    ///
+    /// TODO: Optimize the (re)serialization of the match statements if need be
     #[allow(clippy::too_many_arguments)]
     pub fn batch_verify_process_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -356,6 +361,8 @@ impl CoreSettlementContract {
     }
 
     /// Batch-verifies all of the `process_atomic_match_settle` proofs
+    ///
+    /// TODO: Optimize the (re)serialization of the match statements if need be
     pub fn batch_verify_process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
         internal_party_match_payload: &MatchPayload,

--- a/contracts-stylus/src/contracts/core/core_wallet_ops.rs
+++ b/contracts-stylus/src/contracts/core/core_wallet_ops.rs
@@ -110,6 +110,9 @@ pub struct CoreWalletOpsContract {
     protocol_public_encryption_key: StorageArray<StorageU256, 2>,
 
     // --- Updated Fields for Atomic Settlement --- //
+    /// The address of the protocol external fee collection wallet
+    _protocol_external_fee_collection_address: StorageAddress,
+
     /// The address of the core settlement contract
     ///
     /// Added at the bottom of the storage layout to

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -24,10 +24,10 @@ use crate::{
             init_0Call as initMerkleCall, init_1Call as initTransferExecutorCall, newWalletCall,
             processAtomicMatchSettleCall, processMatchSettleCall, redeemFeeCall, rootCall,
             rootInHistoryCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall, updateWalletCall,
-            CoreSettlementAddressChanged, CoreWalletOpsAddressChanged, FeeChanged,
-            MerkleAddressChanged, OwnershipTransferred, Paused, PubkeyRotated,
-            TransferExecutorAddressChanged, Unpaused, VerifierCoreAddressChanged,
-            VerifierSettlementAddressChanged, VkeysAddressChanged,
+            CoreSettlementAddressChanged, CoreWalletOpsAddressChanged,
+            ExternalFeeCollectionAddressChanged, FeeChanged, MerkleAddressChanged,
+            OwnershipTransferred, Paused, PubkeyRotated, TransferExecutorAddressChanged, Unpaused,
+            VerifierCoreAddressChanged, VerifierSettlementAddressChanged, VkeysAddressChanged,
         },
     },
 };
@@ -87,6 +87,11 @@ pub struct DarkpoolContract {
     pub(crate) protocol_public_encryption_key: StorageArray<StorageU256, 2>,
 
     // --- Updated Fields for Atomic Settlement --- //
+    /// The address of the protocol external fee collection wallet
+    ///
+    /// This is the address at which the protocol collects fees from external parties
+    pub(crate) protocol_external_fee_collection_address: StorageAddress,
+
     /// The address of the core settlement contract
     ///
     /// Added at the bottom of the storage layout to
@@ -120,6 +125,7 @@ impl DarkpoolContract {
         permit2_address: Address,
         protocol_fee: U256,
         protocol_public_encryption_key: [U256; 2],
+        protocol_external_fee_collection_address: Address,
     ) -> Result<(), Vec<u8>> {
         // Initialize the Merkle tree
         delegate_call_helper::<initMerkleCall>(storage, merkle_address, ())?;
@@ -146,6 +152,12 @@ impl DarkpoolContract {
 
         // Set the protocol public encryption key
         DarkpoolContract::set_public_encryption_key(storage, protocol_public_encryption_key)?;
+
+        // Set the protocol external fee collection address
+        DarkpoolContract::set_protocol_external_fee_collection_address(
+            storage,
+            protocol_external_fee_collection_address,
+        )?;
 
         // Mark the darkpool as initialized
         DarkpoolContract::_initialize(storage, 1)?;
@@ -298,6 +310,24 @@ impl DarkpoolContract {
             new_pubkey_y: new_public_encryption_key[1],
         });
 
+        Ok(())
+    }
+
+    /// Sets the protocol external fee collection address
+    pub fn set_protocol_external_fee_collection_address<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        new_protocol_external_fee_collection_address: Address,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_owner(storage)?;
+        DarkpoolContract::check_address_not_zero(new_protocol_external_fee_collection_address)?;
+        storage
+            .borrow_mut()
+            .protocol_external_fee_collection_address
+            .set(new_protocol_external_fee_collection_address);
+
+        evm::log(ExternalFeeCollectionAddressChanged {
+            new_address: new_protocol_external_fee_collection_address,
+        });
         Ok(())
     }
 

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -71,6 +71,7 @@ sol! {
     // Darkpool controls events
     event FeeChanged(uint256 indexed new_fee);
     event PubkeyRotated(uint256 indexed new_pubkey_x, uint256 indexed new_pubkey_y);
+    event ExternalFeeCollectionAddressChanged(address indexed new_address);
     event OwnershipTransferred(address indexed new_owner);
     event Paused();
     event Unpaused();

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -128,6 +128,10 @@ pub struct DeployProxyArgs {
     /// If not provided, a random key will be generated.
     #[arg(short, long)]
     pub protocol_public_encryption_key: Option<String>,
+
+    /// The address of the protocol external fee collection wallet
+    #[arg(short, long)]
+    pub protocol_external_fee_collection_address: Option<String>,
 }
 
 /// Deploy a Stylus contract

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -52,8 +52,9 @@ use crate::{
     types::{RenegadeVerificationKeys, StylusContract},
     utils::{
         build_stylus_contract, darkpool_initialize_calldata, deploy_stylus_contract,
-        get_contract_key, get_public_encryption_key, parse_addr_from_deployments_file,
-        setup_client, write_deployed_address, write_vkey_file, LocalWalletHttpClient,
+        get_contract_key, get_protocol_external_fee_collection_address, get_public_encryption_key,
+        parse_addr_from_deployments_file, setup_client, write_deployed_address, write_vkey_file,
+        LocalWalletHttpClient,
     },
 };
 
@@ -215,6 +216,7 @@ pub async fn deploy_test_contracts(
         owner: args.owner,
         fee: thread_rng().gen(),
         protocol_public_encryption_key: None,
+        protocol_external_fee_collection_address: None,
     };
     deploy_proxy(deploy_proxy_args, client, deployments_path).await?;
 
@@ -283,6 +285,10 @@ pub async fn deploy_proxy(
     let protocol_public_encryption_key =
         get_public_encryption_key(args.protocol_public_encryption_key)?;
 
+    let protocol_external_fee_collection_address = get_protocol_external_fee_collection_address(
+        args.protocol_external_fee_collection_address,
+    )?;
+
     let darkpool_calldata = Bytes::from(darkpool_initialize_calldata(
         core_wallet_ops_address,
         core_settlement_address,
@@ -294,6 +300,7 @@ pub async fn deploy_proxy(
         permit2_address,
         protocol_fee,
         protocol_public_encryption_key,
+        protocol_external_fee_collection_address,
     )?);
 
     // Deploy proxy contract

--- a/scripts/src/solidity.rs
+++ b/scripts/src/solidity.rs
@@ -4,7 +4,7 @@ use alloy_sol_types::sol;
 use ethers::contract::abigen;
 
 sol! {
-    function initialize(address memory core_wallet_ops_address, address memory core_settlement_address, address memory verifier_core_address, address memory verifier_settlement_address, address memory vkeys_address, address memory merkle_address, address memory transfer_executor_address, address memory permit2_address, uint256 memory protocol_fee, uint256[2] memory protocol_public_encryption_key) external;
+    function initialize(address memory core_wallet_ops_address, address memory core_settlement_address, address memory verifier_core_address, address memory verifier_settlement_address, address memory vkeys_address, address memory merkle_address, address memory transfer_executor_address, address memory permit2_address, uint256 memory protocol_fee, uint256[2] memory protocol_public_encryption_key, address memory protocol_external_fee_collection_address) external;
 }
 
 abigen!(

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -174,6 +174,19 @@ pub fn get_public_encryption_key(
     })
 }
 
+/// Gets the protocol external fee collection address from the given argument,
+/// or generates a random one if None is supplied   
+pub fn get_protocol_external_fee_collection_address(
+    arg: Option<String>,
+) -> Result<Address, ScriptError> {
+    if let Some(addr_str) = arg {
+        Address::from_str(&addr_str).map_err(|e| ScriptError::PubkeyParsing(e.to_string()))
+    } else {
+        let mut rng = thread_rng();
+        Ok(Address::random_using(&mut rng))
+    }
+}
+
 /// Prepare calldata for the Darkpool contract's `initialize` method
 #[allow(clippy::too_many_arguments)]
 pub fn darkpool_initialize_calldata(
@@ -187,6 +200,7 @@ pub fn darkpool_initialize_calldata(
     permit2_address: Address,
     protocol_fee: U256,
     protocol_public_encryption_key: PublicEncryptionKey,
+    protocol_external_fee_collection_address: Address,
 ) -> Result<Vec<u8>, ScriptError> {
     let core_wallet_ops_address = AlloyAddress::from_slice(core_wallet_ops_address.as_bytes());
     let core_settlement_address = AlloyAddress::from_slice(core_settlement_address.as_bytes());
@@ -201,6 +215,8 @@ pub fn darkpool_initialize_calldata(
         scalar_to_u256(protocol_public_encryption_key.x),
         scalar_to_u256(protocol_public_encryption_key.y),
     ];
+    let protocol_external_fee_collection_address =
+        AlloyAddress::from_slice(protocol_external_fee_collection_address.as_bytes());
 
     Ok(initializeCall::new((
         core_wallet_ops_address,
@@ -213,6 +229,7 @@ pub fn darkpool_initialize_calldata(
         permit2_address,
         protocol_fee,
         protocol_public_encryption_key,
+        protocol_external_fee_collection_address,
     ))
     .abi_encode())
 }


### PR DESCRIPTION
### Purpose
This PR adds an external fee address to the darkpool. This is the address at which the protocol may collect fees from external parties; i.e. in an atomic match settlement.

### Testing
Deferred until atomic match transfers are implemented