### PR TITLE
contracts-stylus: core-settlement: Prevent overflow in fee computation

### DIFF
--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -407,7 +407,9 @@ pub struct FeeTake {
 impl FeeTake {
     /// Get the total fee taken
     pub fn total(&self) -> U256 {
-        self.relayer_fee + self.protocol_fee
+        self.relayer_fee
+            .checked_add(self.protocol_fee)
+            .expect("fees overflow") // unwrap here for interface simplicity
     }
 }
 

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -12,8 +12,8 @@ use crate::{
     utils::{
         constants::{
             INVALID_ORDER_SETTLEMENT_INDICES_ERROR_MESSAGE, INVALID_PROTOCOL_FEE_ERROR_MESSAGE,
-            MERKLE_STORAGE_GAP_SIZE, TRANSFER_EXECUTOR_STORAGE_GAP_SIZE,
-            VERIFICATION_FAILED_ERROR_MESSAGE,
+            MERKLE_STORAGE_GAP_SIZE, TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE,
+            TRANSFER_EXECUTOR_STORAGE_GAP_SIZE, VERIFICATION_FAILED_ERROR_MESSAGE,
         },
         helpers::{
             delegate_call_helper, deserialize_from_calldata, postcard_serialize,
@@ -443,7 +443,9 @@ impl CoreSettlementContract {
         ));
 
         // The amount received by the external party after deducting the fees
-        let trader_take = receive_amount - fees.total();
+        let trader_take = receive_amount
+            .checked_sub(fees.total())
+            .ok_or(TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE)?;
         transfers_batch.push(SimpleErc20Transfer::new_withdraw(
             tx_sender,
             receive_mint,

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -61,6 +61,10 @@ pub const PUBLIC_BLINDER_USED_ERROR_MESSAGE: &[u8] = b"public blinder already us
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
 pub const ROOT_NOT_IN_HISTORY_ERROR_MESSAGE: &[u8] = b"root not in history";
 
+/// The revert message when a transfer arithmetic operation overflows
+#[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
+pub const TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE: &[u8] = b"transfer arithmetic overflow";
+
 /// The revert message when order settlement indices are different
 /// between a VALID COMMITMENTS & VALID MATCH SETTLE statement
 #[cfg(feature = "core-settlement")]

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -130,7 +130,7 @@ pub struct DeployProxyArgs {
     pub protocol_public_encryption_key: Option<String>,
 
     /// The address of the protocol external fee collection wallet
-    #[arg(short, long)]
+    #[arg(long)]
     pub protocol_external_fee_collection_address: Option<String>,
 }
 


### PR DESCRIPTION
### Purpose
This PR fixes an overflow bug in the computation of the trader's take net fees. We use a `checked_sub` in place of the direct arithmetic operator. I also replaced a direct addition on the `FeeTake::total` method. While this doesn't fix a bug, it future proofs that interface.

### Testing
- Tests pass