### PR TITLE
contracts-stylus: test_contracts: dummy_erc20, scripts: settable params in dummy ERC-20s

### DIFF
--- a/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
@@ -17,6 +17,7 @@ use stylus_sdk::{
 
 sol_storage! {
     /// Erc20 implements all ERC-20 methods.
+    #[entrypoint]
     pub struct Erc20 {
         /// The name of the token
         string name;

--- a/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
@@ -8,31 +8,29 @@
 #![allow(clippy::missing_docs_in_private_items)]
 
 use alloc::{string::String, vec::Vec};
-use core::marker::PhantomData;
 use stylus_sdk::{
-    alloy_primitives::{Address, U256},
+    alloy_primitives::{Address, Uint, U256},
     alloy_sol_types::{sol, SolError},
     evm, msg,
     prelude::*,
 };
 
-pub trait Erc20Params {
-    const NAME: &'static str;
-    const SYMBOL: &'static str;
-    const DECIMALS: u8;
-}
-
 sol_storage! {
     /// Erc20 implements all ERC-20 methods.
-    pub struct Erc20<T> {
+    pub struct Erc20 {
+        /// The name of the token
+        string name;
+        /// The symbol of the token
+        string symbol;
+        /// The number of decimals the token uses
+        uint8 decimals;
+
         /// Maps users to balances
         mapping(address => uint256) balances;
         /// Maps users to a mapping of each spender's allowance
         mapping(address => mapping(address => uint256)) allowances;
         /// The total supply of the token
         uint256 total_supply;
-        /// Used to allow [`Erc20Params`]
-        PhantomData<T> phantom;
     }
 }
 
@@ -61,7 +59,7 @@ impl From<Erc20Error> for Vec<u8> {
 
 // These methods aren't exposed to other contracts
 // Note: modifying storage will become much prettier soon
-impl<T: Erc20Params> Erc20<T> {
+impl Erc20 {
     pub fn transfer_impl(
         &mut self,
         from: Address,
@@ -83,6 +81,38 @@ impl<T: Erc20Params> Erc20<T> {
         to_balance.set(new_to_balance);
         evm::log(Transfer { from, to, value });
         Ok(())
+    }
+}
+
+// These methods are external to other contracts
+// Note: modifying storage will become much prettier soon
+#[external]
+impl Erc20 {
+    pub fn set_name(&mut self, name: String) -> Result<(), Erc20Error> {
+        self.name.set_str(name);
+        Ok(())
+    }
+
+    pub fn set_symbol(&mut self, symbol: String) -> Result<(), Erc20Error> {
+        self.symbol.set_str(symbol);
+        Ok(())
+    }
+
+    pub fn set_decimals(&mut self, decimals: u8) -> Result<(), Erc20Error> {
+        self.decimals.set(Uint::from(decimals));
+        Ok(())
+    }
+
+    pub fn name(&self) -> Result<String, Erc20Error> {
+        Ok(self.name.get_string())
+    }
+
+    pub fn symbol(&self) -> Result<String, Erc20Error> {
+        Ok(self.symbol.get_string())
+    }
+
+    pub fn decimals(&self) -> Result<u8, Erc20Error> {
+        Ok(self.decimals.get().try_into().unwrap())
     }
 
     pub fn mint(&mut self, address: Address, value: U256) {
@@ -115,23 +145,6 @@ impl<T: Erc20Params> Erc20<T> {
             value,
         });
         Ok(())
-    }
-}
-
-// These methods are external to other contracts
-// Note: modifying storage will become much prettier soon
-#[external]
-impl<T: Erc20Params> Erc20<T> {
-    pub fn name() -> Result<String, Erc20Error> {
-        Ok(T::NAME.into())
-    }
-
-    pub fn symbol() -> Result<String, Erc20Error> {
-        Ok(T::SYMBOL.into())
-    }
-
-    pub fn decimals() -> Result<u8, Erc20Error> {
-        Ok(T::DECIMALS)
     }
 
     pub fn balance_of(&self, address: Address) -> Result<U256, Erc20Error> {
@@ -177,37 +190,5 @@ impl<T: Erc20Params> Erc20<T> {
 
     pub fn allowance(&self, owner: Address, spender: Address) -> Result<U256, Erc20Error> {
         Ok(self.allowances.getter(owner).get(spender))
-    }
-}
-
-struct DummyErc20Params;
-
-/// Immutable definitions
-impl Erc20Params for DummyErc20Params {
-    const NAME: &'static str = concat!("Dummy ", env!("DUMMY_ERC20_SYMBOL"));
-    const SYMBOL: &'static str = env!("DUMMY_ERC20_SYMBOL");
-    const DECIMALS: u8 = 18;
-}
-
-// The contract
-sol_storage! {
-    #[entrypoint] // Makes DummyErc20 the entrypoint
-    struct DummyErc20 {
-        #[borrow] // Allows erc20 to access DummyErc20's storage and make calls
-        Erc20<DummyErc20Params> erc20;
-    }
-}
-
-#[external]
-#[inherit(Erc20<DummyErc20Params>)]
-impl DummyErc20 {
-    pub fn mint(&mut self, address: Address, amount: U256) -> Result<(), Vec<u8>> {
-        self.erc20.mint(address, amount);
-        Ok(())
-    }
-
-    pub fn burn(&mut self, address: Address, amount: U256) -> Result<(), Vec<u8>> {
-        self.erc20.burn(address, amount)?;
-        Ok(())
     }
 }

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -13,13 +13,14 @@ use ethers::abi::Address;
 use eyre::Result;
 use scripts::{
     constants::{
-        CORE_SETTLEMENT_CONTRACT_KEY, CORE_WALLET_OPS_CONTRACT_KEY, DARKPOOL_CONTRACT_KEY,
-        DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, MERKLE_CONTRACT_KEY,
-        PERMIT2_CONTRACT_KEY, PRECOMPILE_TEST_CONTRACT_KEY, TEST_ERC20_TICKER1, TEST_ERC20_TICKER2,
-        TEST_UPGRADE_TARGET_CONTRACT_KEY, TRANSFER_EXECUTOR_CONTRACT_KEY,
-        VERIFIER_CORE_CONTRACT_KEY, VERIFIER_SETTLEMENT_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
+        DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, PERMIT2_CONTRACT_KEY,
+        TEST_ERC20_TICKER1, TEST_ERC20_TICKER2,
     },
-    utils::{parse_addr_from_deployments_file, setup_client, LocalWalletHttpClient},
+    types::StylusContract,
+    utils::{
+        read_deployment_address, read_stylus_deployment_address, setup_client,
+        LocalWalletHttpClient,
+    },
 };
 use test_helpers::{integration_test_main, types::TestVerbosity};
 use utils::u256_to_alloy_u256;
@@ -97,67 +98,79 @@ impl From<Cli> for TestArgs {
             .unwrap();
 
         let darkpool_proxy_address =
-            parse_addr_from_deployments_file(&value.deployments_file, DARKPOOL_PROXY_CONTRACT_KEY)
+            read_deployment_address(&value.deployments_file, DARKPOOL_PROXY_CONTRACT_KEY).unwrap();
+
+        let proxy_admin_address =
+            read_deployment_address(&value.deployments_file, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY)
                 .unwrap();
 
-        let proxy_admin_address = parse_addr_from_deployments_file(
+        let darkpool_impl_address = read_stylus_deployment_address(
             &value.deployments_file,
-            DARKPOOL_PROXY_ADMIN_CONTRACT_KEY,
+            &StylusContract::DarkpoolTestContract,
         )
         .unwrap();
 
-        let darkpool_impl_address =
-            parse_addr_from_deployments_file(&value.deployments_file, DARKPOOL_CONTRACT_KEY)
-                .unwrap();
-
         let core_wallet_ops_address =
-            parse_addr_from_deployments_file(&value.deployments_file, CORE_WALLET_OPS_CONTRACT_KEY)
+            read_stylus_deployment_address(&value.deployments_file, &StylusContract::CoreWalletOps)
                 .unwrap();
 
-        let core_settlement_address =
-            parse_addr_from_deployments_file(&value.deployments_file, CORE_SETTLEMENT_CONTRACT_KEY)
-                .unwrap();
+        let core_settlement_address = read_stylus_deployment_address(
+            &value.deployments_file,
+            &StylusContract::CoreSettlement,
+        )
+        .unwrap();
 
-        let merkle_address =
-            parse_addr_from_deployments_file(&value.deployments_file, MERKLE_CONTRACT_KEY).unwrap();
+        let merkle_address = read_stylus_deployment_address(
+            &value.deployments_file,
+            &StylusContract::MerkleTestContract,
+        )
+        .unwrap();
 
         let verifier_core_address =
-            parse_addr_from_deployments_file(&value.deployments_file, VERIFIER_CORE_CONTRACT_KEY)
+            read_stylus_deployment_address(&value.deployments_file, &StylusContract::VerifierCore)
                 .unwrap();
 
-        let verifier_settlement_address = parse_addr_from_deployments_file(
+        let verifier_settlement_address = read_stylus_deployment_address(
             &value.deployments_file,
-            VERIFIER_SETTLEMENT_CONTRACT_KEY,
+            &StylusContract::VerifierSettlement,
         )
         .unwrap();
 
         let vkeys_address =
-            parse_addr_from_deployments_file(&value.deployments_file, VKEYS_CONTRACT_KEY).unwrap();
+            read_stylus_deployment_address(&value.deployments_file, &StylusContract::TestVkeys)
+                .unwrap();
 
         let permit2_address =
-            parse_addr_from_deployments_file(&value.deployments_file, PERMIT2_CONTRACT_KEY)
-                .unwrap();
+            read_deployment_address(&value.deployments_file, PERMIT2_CONTRACT_KEY).unwrap();
 
-        let transfer_executor_address = parse_addr_from_deployments_file(
+        let transfer_executor_address = read_stylus_deployment_address(
             &value.deployments_file,
-            TRANSFER_EXECUTOR_CONTRACT_KEY,
+            &StylusContract::TransferExecutor,
         )
         .unwrap();
 
-        let test_erc20_address1 =
-            parse_addr_from_deployments_file(&value.deployments_file, TEST_ERC20_TICKER1).unwrap();
-        let test_erc20_address2 =
-            parse_addr_from_deployments_file(&value.deployments_file, TEST_ERC20_TICKER2).unwrap();
-
-        let test_upgrade_target_address = parse_addr_from_deployments_file(
+        let test_erc20_address1 = read_stylus_deployment_address(
             &value.deployments_file,
-            TEST_UPGRADE_TARGET_CONTRACT_KEY,
+            &StylusContract::DummyErc20(TEST_ERC20_TICKER1.to_string()),
+        )
+        .unwrap();
+        let test_erc20_address2 = read_stylus_deployment_address(
+            &value.deployments_file,
+            &StylusContract::DummyErc20(TEST_ERC20_TICKER2.to_string()),
         )
         .unwrap();
 
-        let precompiles_contract_address =
-            parse_addr_from_deployments_file(&value.deployments_file, PRECOMPILE_TEST_CONTRACT_KEY)
-                .unwrap();
+        let test_upgrade_target_address = read_stylus_deployment_address(
+            &value.deployments_file,
+            &StylusContract::DummyUpgradeTarget,
+        )
+        .unwrap();
+
+        let precompiles_contract_address = read_stylus_deployment_address(
+            &value.deployments_file,
+            &StylusContract::PrecompileTestContract,
+        )
+        .unwrap();
 
         TestArgs {
             client,

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -46,8 +46,8 @@ pub enum Command {
     DeployPermit2,
     /// Deploy a Stylus contract
     DeployStylus(DeployStylusArgs),
-    /// Deploy dummy ERC20s
-    DeployErc20s(DeployErc20Args),
+    /// Deploy a dummy ERC20
+    DeployErc20(DeployErc20Args),
     /// Upgrade the darkpool implementation
     Upgrade(UpgradeArgs),
     /// Generate verification keys for the protocol circuits
@@ -72,8 +72,9 @@ impl Command {
             Command::DeployStylus(args) => {
                 build_and_deploy_stylus_contract(&args, rpc_url, priv_key, client, deployments_path)
                     .await
+                    .map(|_| ())
             }
-            Command::DeployErc20s(args) => {
+            Command::DeployErc20(args) => {
                 deploy_erc20(&args, rpc_url, priv_key, client, deployments_path).await
             }
             Command::Upgrade(args) => upgrade(&args, client, deployments_path).await,
@@ -132,10 +133,14 @@ pub struct DeployProxyArgs {
     /// The address of the protocol external fee collection wallet
     #[arg(long)]
     pub protocol_external_fee_collection_address: Option<String>,
+
+    /// Whether or not to use the test contracts
+    #[arg(short, long)]
+    pub test: bool,
 }
 
 /// Deploy a Stylus contract
-#[derive(Args, Clone, Copy)]
+#[derive(Args, Clone)]
 pub struct DeployStylusArgs {
     /// The Stylus contract to deploy
     #[arg(short, long)]

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Args, Parser, Subcommand};
 
 use crate::{
     commands::{
-        build_and_deploy_stylus_contract, deploy_erc20s, deploy_permit2, deploy_proxy,
+        build_and_deploy_stylus_contract, deploy_erc20, deploy_permit2, deploy_proxy,
         deploy_test_contracts, gen_vkeys, upgrade,
     },
     errors::ScriptError,
@@ -47,7 +47,7 @@ pub enum Command {
     /// Deploy a Stylus contract
     DeployStylus(DeployStylusArgs),
     /// Deploy dummy ERC20s
-    DeployErc20s(DeployErc20sArgs),
+    DeployErc20s(DeployErc20Args),
     /// Upgrade the darkpool implementation
     Upgrade(UpgradeArgs),
     /// Generate verification keys for the protocol circuits
@@ -65,19 +65,19 @@ impl Command {
     ) -> Result<(), ScriptError> {
         match self {
             Command::DeployTestContracts(args) => {
-                deploy_test_contracts(args, rpc_url, priv_key, client, deployments_path).await
+                deploy_test_contracts(&args, rpc_url, priv_key, client, deployments_path).await
             }
-            Command::DeployProxy(args) => deploy_proxy(args, client, deployments_path).await,
+            Command::DeployProxy(args) => deploy_proxy(&args, client, deployments_path).await,
             Command::DeployPermit2 => deploy_permit2(client, deployments_path).await,
             Command::DeployStylus(args) => {
-                build_and_deploy_stylus_contract(args, rpc_url, priv_key, client, deployments_path)
+                build_and_deploy_stylus_contract(&args, rpc_url, priv_key, client, deployments_path)
                     .await
             }
             Command::DeployErc20s(args) => {
-                deploy_erc20s(args, rpc_url, priv_key, client, deployments_path).await
+                deploy_erc20(&args, rpc_url, priv_key, client, deployments_path).await
             }
-            Command::Upgrade(args) => upgrade(args, client, deployments_path).await,
-            Command::GenVkeys(args) => gen_vkeys(args),
+            Command::Upgrade(args) => upgrade(&args, client, deployments_path).await,
+            Command::GenVkeys(args) => gen_vkeys(&args),
         }
     }
 }
@@ -147,20 +147,28 @@ pub struct DeployStylusArgs {
     pub no_verify: bool,
 }
 
-/// Deploy dummy ERC20s. Assumes the darkpool contract has already been deployed.
+/// Deploy a dummy ERC20. Assumes the darkpool contract has already been deployed.
 #[derive(Args)]
-pub struct DeployErc20sArgs {
-    /// The tickers for the ERC20s to deploy
-    #[arg(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
-    pub tickers: Vec<String>,
+pub struct DeployErc20Args {
+    /// The symbol for the ERC20 to deploy
+    #[arg(short, long)]
+    pub symbol: String,
+
+    /// The name for the ERC20 to deploy
+    #[arg(short, long)]
+    pub name: String,
+
+    /// The number of decimals for the ERC20 to deploy
+    #[arg(short, long)]
+    pub decimals: u8,
 
     /// The amount with which to fund each account
     #[arg(short, long)]
-    pub funding_amount: u128,
+    pub funding_amount: Option<u128>,
 
     /// A space-separated list of private keys corresponding to the accounts
-    /// which will be funded with the ERC20s and
-    /// for which the darkpool will be approved to transfer ERC20s
+    /// which will be funded with the ERC20 and for which the Permit2 contract
+    /// will be approved to transfer the ERC20
     #[arg(short, long, value_parser, num_args = 0.., value_delimiter = ' ')]
     pub account_skeys: Vec<String>,
 }

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -30,20 +30,20 @@ use ethers::{
     utils::hex::FromHex,
 };
 use rand::{thread_rng, Rng};
-use std::{env, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 use tracing::log::info;
 
 use crate::{
     cli::{
-        DeployErc20sArgs, DeployProxyArgs, DeployStylusArgs, DeployTestContractsArgs, GenVkeysArgs,
+        DeployErc20Args, DeployProxyArgs, DeployStylusArgs, DeployTestContractsArgs, GenVkeysArgs,
         UpgradeArgs,
     },
     constants::{
-        DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, DUMMY_ERC20_SYMBOL_ENV_VAR,
-        NUM_BYTES_ADDRESS, NUM_BYTES_STORAGE_SLOT, NUM_DEPLOY_CONFIRMATIONS, PERMIT2_ABI,
-        PERMIT2_BYTECODE, PERMIT2_CONTRACT_KEY, PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE,
+        DARKPOOL_PROXY_ADMIN_CONTRACT_KEY, DARKPOOL_PROXY_CONTRACT_KEY, NUM_BYTES_ADDRESS,
+        NUM_BYTES_STORAGE_SLOT, NUM_DEPLOY_CONFIRMATIONS, PERMIT2_ABI, PERMIT2_BYTECODE,
+        PERMIT2_CONTRACT_KEY, PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE,
         PROCESS_MATCH_SETTLE_VKEYS_FILE, PROXY_ABI, PROXY_ADMIN_STORAGE_SLOT, PROXY_BYTECODE,
-        TEST_ERC20_TICKER1, TEST_ERC20_TICKER2, TEST_FUNDING_AMOUNT,
+        TEST_ERC20_DECIMALS, TEST_ERC20_TICKER1, TEST_ERC20_TICKER2, TEST_FUNDING_AMOUNT,
         VALID_FEE_REDEMPTION_VKEY_FILE, VALID_OFFLINE_FEE_SETTLEMENT_VKEY_FILE,
         VALID_RELAYER_FEE_SETTLEMENT_VKEY_FILE, VALID_WALLET_CREATE_VKEY_FILE,
         VALID_WALLET_UPDATE_VKEY_FILE,
@@ -54,8 +54,8 @@ use crate::{
     utils::{
         build_stylus_contract, darkpool_initialize_calldata, deploy_stylus_contract,
         get_contract_key, get_protocol_external_fee_collection_address, get_public_encryption_key,
-        parse_addr_from_deployments_file, setup_client, write_deployed_address, write_vkey_file,
-        LocalWalletHttpClient,
+        parse_addr_from_deployments_file, send_contract_call, setup_client, write_deployed_address,
+        write_vkey_file, LocalWalletHttpClient,
     },
 };
 
@@ -63,7 +63,7 @@ use crate::{
 ///
 /// This includes generating fresh verification keys for testing.
 pub async fn deploy_test_contracts(
-    args: DeployTestContractsArgs,
+    args: &DeployTestContractsArgs,
     rpc_url: &str,
     priv_key: &str,
     client: Arc<LocalWalletHttpClient>,
@@ -74,7 +74,7 @@ pub async fn deploy_test_contracts(
         vkeys_dir: args.vkeys_dir.clone(),
         test: true,
     };
-    gen_vkeys(gen_vkeys_args)?;
+    gen_vkeys(&gen_vkeys_args)?;
 
     let mut deploy_stylus_args = DeployStylusArgs {
         contract: StylusContract::TestVkeys,
@@ -83,7 +83,7 @@ pub async fn deploy_test_contracts(
 
     info!("Deploying testing verification keys");
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -98,7 +98,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying dummy upgrade target contract");
     deploy_stylus_args.contract = StylusContract::DummyUpgradeTarget;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -109,7 +109,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying precompiles testing contract");
     deploy_stylus_args.contract = StylusContract::PrecompileTestContract;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -120,7 +120,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying Merkle testing contract");
     deploy_stylus_args.contract = StylusContract::MerkleTestContract;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -131,7 +131,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying transfer executor contract");
     deploy_stylus_args.contract = StylusContract::TransferExecutor;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -142,17 +142,27 @@ pub async fn deploy_test_contracts(
     info!("Deploying Permit2 contract");
     deploy_permit2(client.clone(), deployments_path).await?;
 
-    info!("Deploying test ERC-20 contract");
-    let deploy_erc20_args = DeployErc20sArgs {
-        tickers: vec![
-            TEST_ERC20_TICKER1.to_string(),
-            TEST_ERC20_TICKER2.to_string(),
-        ],
-        funding_amount: TEST_FUNDING_AMOUNT,
+    info!("Deploying test ERC-20 contracts");
+    let mut deploy_erc20_args = DeployErc20Args {
+        symbol: TEST_ERC20_TICKER1.to_string(),
+        name: TEST_ERC20_TICKER1.to_string(),
+        decimals: TEST_ERC20_DECIMALS,
+        funding_amount: Some(TEST_FUNDING_AMOUNT),
         account_skeys: vec![priv_key.to_string()],
     };
-    deploy_erc20s(
-        deploy_erc20_args,
+    deploy_erc20(
+        &deploy_erc20_args,
+        rpc_url,
+        priv_key,
+        client.clone(),
+        deployments_path,
+    )
+    .await?;
+
+    deploy_erc20_args.symbol = TEST_ERC20_TICKER2.to_string();
+    deploy_erc20_args.name = TEST_ERC20_TICKER2.to_string();
+    deploy_erc20(
+        &deploy_erc20_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -163,7 +173,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying verifier contract");
     deploy_stylus_args.contract = StylusContract::VerifierCore;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -174,7 +184,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying verifier settlement contract");
     deploy_stylus_args.contract = StylusContract::VerifierSettlement;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -185,7 +195,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying core wallet operations contract");
     deploy_stylus_args.contract = StylusContract::CoreWalletOps;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -196,7 +206,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying core settlement contract");
     deploy_stylus_args.contract = StylusContract::CoreSettlement;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -207,7 +217,7 @@ pub async fn deploy_test_contracts(
     info!("Deploying darkpool testing contract");
     deploy_stylus_args.contract = StylusContract::DarkpoolTestContract;
     build_and_deploy_stylus_contract(
-        deploy_stylus_args,
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
@@ -217,19 +227,19 @@ pub async fn deploy_test_contracts(
 
     info!("Deploying proxy contract");
     let deploy_proxy_args = DeployProxyArgs {
-        owner: args.owner,
+        owner: args.owner.clone(),
         fee: thread_rng().gen(),
         protocol_public_encryption_key: None,
         protocol_external_fee_collection_address: None,
     };
-    deploy_proxy(deploy_proxy_args, client, deployments_path).await?;
+    deploy_proxy(&deploy_proxy_args, client, deployments_path).await?;
 
     Ok(())
 }
 
 /// Deploys the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts
 pub async fn deploy_proxy(
-    args: DeployProxyArgs,
+    args: &DeployProxyArgs,
     client: Arc<LocalWalletHttpClient>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
@@ -287,10 +297,10 @@ pub async fn deploy_proxy(
     let protocol_fee = U256::from(args.fee);
 
     let protocol_public_encryption_key =
-        get_public_encryption_key(args.protocol_public_encryption_key)?;
+        get_public_encryption_key(args.protocol_public_encryption_key.clone())?;
 
     let protocol_external_fee_collection_address = get_protocol_external_fee_collection_address(
-        args.protocol_external_fee_collection_address,
+        args.protocol_external_fee_collection_address.clone(),
     )?;
 
     let darkpool_calldata = Bytes::from(darkpool_initialize_calldata(
@@ -385,90 +395,91 @@ pub async fn deploy_permit2(
     write_deployed_address(deployments_path, PERMIT2_CONTRACT_KEY, permit2_address)
 }
 
-/// Deploys the ERC-20 contracts & approves the darkpool
+/// Deploys the ERC-20 contract & approves the Permit2 contract
 /// to spend the maximum amount of tokens for the provided
 /// addresses.
-///
-/// Note: the provided tickers will not actually be used as the contract's
-/// name or symbol, but rather as a way to identify the contract in the deployments file.
-pub async fn deploy_erc20s(
-    args: DeployErc20sArgs,
+pub async fn deploy_erc20(
+    args: &DeployErc20Args,
     rpc_url: &str,
     priv_key: &str,
     client: Arc<LocalWalletHttpClient>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
-    let mut erc20_addresses = Vec::with_capacity(args.tickers.len());
-    for ticker in args.tickers {
-        env::set_var(DUMMY_ERC20_SYMBOL_ENV_VAR, &ticker);
-
-        let wasm_file_path =
-            build_stylus_contract(StylusContract::DummyErc20, false /* no_verify */)?;
-
-        erc20_addresses.push(
-            deploy_stylus_contract(
-                wasm_file_path.clone(),
-                rpc_url,
-                priv_key,
-                client.clone(),
-                StylusContract::DummyErc20,
-                deployments_path,
-                Some(&ticker),
-            )
-            .await?,
-        );
+    if !args.account_skeys.is_empty() && args.funding_amount.is_none() {
+        return Err(ScriptError::InvalidArguments(
+            "funding amount must be provided if account skeys are provided".to_string(),
+        ));
     }
+
+    let wasm_file_path =
+        build_stylus_contract(StylusContract::DummyErc20, false /* no_verify */)?;
+
+    let erc20_address = deploy_stylus_contract(
+        wasm_file_path.clone(),
+        rpc_url,
+        priv_key,
+        client.clone(),
+        StylusContract::DummyErc20,
+        deployments_path,
+        Some(&args.symbol),
+    )
+    .await?;
+
+    set_erc20_params(erc20_address, client, args).await?;
 
     let permit2_address = parse_addr_from_deployments_file(deployments_path, PERMIT2_CONTRACT_KEY)?;
 
-    for erc20_address in erc20_addresses {
-        for skey in &args.account_skeys {
-            let account_client = setup_client(skey, rpc_url).await?;
-            let account_address = account_client.default_sender().unwrap();
-            let erc20 = DummyErc20Contract::new(erc20_address, account_client);
-
-            mint_erc20(&erc20, account_address, args.funding_amount).await?;
-            approve_erc20_max(&erc20, permit2_address).await?;
-        }
+    for skey in &args.account_skeys {
+        fund_and_approve_erc20(
+            rpc_url,
+            erc20_address,
+            skey,
+            args.funding_amount.unwrap(),
+            permit2_address,
+        )
+        .await?;
     }
 
     Ok(())
 }
 
-/// Mints ERC20 tokens for the provided address
-async fn mint_erc20(
-    erc20: &DummyErc20Contract<impl Middleware + 'static>,
-    recipient_address: Address,
-    amount: u128,
+/// Sets the symbol, name, and decimals parameters for the ERC20 contract
+async fn set_erc20_params(
+    erc20_address: Address,
+    client: Arc<LocalWalletHttpClient>,
+    args: &DeployErc20Args,
 ) -> Result<(), ScriptError> {
-    erc20
-        .mint(recipient_address, EthersU256::from(amount))
-        .send()
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))
-        .map(|_| ())
+    let erc20 = DummyErc20Contract::new(erc20_address, client);
+
+    send_contract_call(erc20.set_symbol(args.symbol.clone())).await?;
+    send_contract_call(erc20.set_name(args.name.clone())).await?;
+    send_contract_call(erc20.set_decimals(args.decimals)).await?;
+
+    Ok(())
 }
 
-/// Approves the darkpool to spend the maximum amount of the given ERC20
-async fn approve_erc20_max(
-    erc20: &DummyErc20Contract<impl Middleware + 'static>,
-    spender_address: Address,
+/// Funds the provided account with the given amount of ERC20 tokens,
+/// and approves the Permit2 contract to spend the maximum amount of the ERC20
+async fn fund_and_approve_erc20(
+    rpc_url: &str,
+    erc20_address: Address,
+    recipient_skey: &str,
+    funding_amount: u128,
+    permit2_address: Address,
 ) -> Result<(), ScriptError> {
-    erc20
-        .approve(spender_address, EthersU256::MAX)
-        .send()
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))
-        .map(|_| ())
+    let account_client = setup_client(recipient_skey, rpc_url).await?;
+    let account_address = account_client.default_sender().unwrap();
+    let erc20 = DummyErc20Contract::new(erc20_address, account_client);
+
+    send_contract_call(erc20.mint(account_address, EthersU256::from(funding_amount))).await?;
+    send_contract_call(erc20.approve(permit2_address, EthersU256::MAX)).await?;
+
+    Ok(())
 }
 
 /// Builds and deploys a Stylus contract
 pub async fn build_and_deploy_stylus_contract(
-    args: DeployStylusArgs,
+    args: &DeployStylusArgs,
     rpc_url: &str,
     priv_key: &str,
     client: Arc<LocalWalletHttpClient>,
@@ -490,7 +501,7 @@ pub async fn build_and_deploy_stylus_contract(
 
 /// Upgrades the darkpool implementation
 pub async fn upgrade(
-    args: UpgradeArgs,
+    args: &UpgradeArgs,
     client: Arc<LocalWalletHttpClient>,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
@@ -506,19 +517,14 @@ pub async fn upgrade(
         get_contract_key(StylusContract::Darkpool),
     )?;
 
-    let data = if let Some(calldata) = args.calldata {
+    let data = if let Some(calldata) = args.calldata.clone() {
         Bytes::from_hex(calldata).map_err(|e| ScriptError::CalldataConstruction(e.to_string()))?
     } else {
         Bytes::new()
     };
 
-    proxy_admin
-        .upgrade_and_call(proxy_address, implementation_address, data)
-        .send()
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?;
+    send_contract_call(proxy_admin.upgrade_and_call(proxy_address, implementation_address, data))
+        .await?;
 
     Ok(())
 }
@@ -633,7 +639,7 @@ fn write_vkeys(vkeys_dir: &str, vkeys: &RenegadeVerificationKeys) -> Result<(), 
 
 /// Generates and writes either the testing or production protocol verification keys
 /// to the specified directory
-pub fn gen_vkeys(args: GenVkeysArgs) -> Result<(), ScriptError> {
+pub fn gen_vkeys(args: &GenVkeysArgs) -> Result<(), ScriptError> {
     let vkeys = if args.test {
         compute_vkeys::<
             DummyValidWalletCreate,

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -53,9 +53,10 @@ use crate::{
     types::{RenegadeVerificationKeys, StylusContract},
     utils::{
         build_stylus_contract, darkpool_initialize_calldata, deploy_stylus_contract,
-        get_contract_key, get_protocol_external_fee_collection_address, get_public_encryption_key,
-        parse_addr_from_deployments_file, send_contract_call, setup_client, write_deployed_address,
-        write_vkey_file, LocalWalletHttpClient,
+        get_protocol_external_fee_collection_address, get_public_encryption_key,
+        read_deployment_address, read_stylus_deployment_address, send_contract_call, setup_client,
+        write_deployment_address, write_stylus_contract_address, write_vkey_file,
+        LocalWalletHttpClient,
     },
 };
 
@@ -231,6 +232,7 @@ pub async fn deploy_test_contracts(
         fee: thread_rng().gen(),
         protocol_public_encryption_key: None,
         protocol_external_fee_collection_address: None,
+        test: true,
     };
     deploy_proxy(&deploy_proxy_args, client, deployments_path).await?;
 
@@ -254,42 +256,39 @@ pub async fn deploy_proxy(
 
     // Parse proxy contract constructor arguments
 
-    let darkpool_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::Darkpool),
-    )?;
-    let core_wallet_ops_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::CoreWalletOps),
-    )?;
-    let core_settlement_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::CoreSettlement),
-    )?;
-    let merkle_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::Merkle),
-    )?;
-    let verifier_core_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::VerifierCore),
-    )?;
-    let verifier_settlement_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::VerifierSettlement),
-    )?;
+    let darkpool_contract = if args.test {
+        StylusContract::DarkpoolTestContract
+    } else {
+        StylusContract::Darkpool
+    };
+    let merkle_contract = if args.test {
+        StylusContract::MerkleTestContract
+    } else {
+        StylusContract::Merkle
+    };
+    let vkeys_contract = if args.test {
+        StylusContract::TestVkeys
+    } else {
+        StylusContract::Vkeys
+    };
 
-    let vkeys_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::Vkeys),
-    )?;
+    let darkpool_address = read_stylus_deployment_address(deployments_path, &darkpool_contract)?;
+    let core_wallet_ops_address =
+        read_stylus_deployment_address(deployments_path, &StylusContract::CoreWalletOps)?;
+    let core_settlement_address =
+        read_stylus_deployment_address(deployments_path, &StylusContract::CoreSettlement)?;
+    let merkle_address = read_stylus_deployment_address(deployments_path, &merkle_contract)?;
+    let verifier_core_address =
+        read_stylus_deployment_address(deployments_path, &StylusContract::VerifierCore)?;
+    let verifier_settlement_address =
+        read_stylus_deployment_address(deployments_path, &StylusContract::VerifierSettlement)?;
 
-    let transfer_executor_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::TransferExecutor),
-    )?;
+    let vkeys_address = read_stylus_deployment_address(deployments_path, &vkeys_contract)?;
 
-    let permit2_address = parse_addr_from_deployments_file(deployments_path, PERMIT2_CONTRACT_KEY)?;
+    let transfer_executor_address =
+        read_stylus_deployment_address(deployments_path, &StylusContract::TransferExecutor)?;
+
+    let permit2_address = read_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY)?;
 
     let owner_address = Address::from_str(&args.owner)
         .map_err(|e| ScriptError::CalldataConstruction(e.to_string()))?;
@@ -355,8 +354,8 @@ pub async fn deploy_proxy(
     );
 
     // Write deployed addresses to deployments file
-    write_deployed_address(deployments_path, DARKPOOL_PROXY_CONTRACT_KEY, proxy_address)?;
-    write_deployed_address(
+    write_deployment_address(deployments_path, DARKPOOL_PROXY_CONTRACT_KEY, proxy_address)?;
+    write_deployment_address(
         deployments_path,
         DARKPOOL_PROXY_ADMIN_CONTRACT_KEY,
         proxy_admin_address,
@@ -392,7 +391,7 @@ pub async fn deploy_permit2(
         permit2_address
     );
 
-    write_deployed_address(deployments_path, PERMIT2_CONTRACT_KEY, permit2_address)
+    write_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY, permit2_address)
 }
 
 /// Deploys the ERC-20 contract & approves the Permit2 contract
@@ -411,33 +410,36 @@ pub async fn deploy_erc20(
         ));
     }
 
-    let wasm_file_path =
-        build_stylus_contract(StylusContract::DummyErc20, false /* no_verify */)?;
+    let contract = StylusContract::DummyErc20(args.symbol.clone());
 
-    let erc20_address = deploy_stylus_contract(
-        wasm_file_path.clone(),
+    let deploy_stylus_args = DeployStylusArgs {
+        contract,
+        no_verify: false,
+    };
+    let erc20_address = build_and_deploy_stylus_contract(
+        &deploy_stylus_args,
         rpc_url,
         priv_key,
         client.clone(),
-        StylusContract::DummyErc20,
         deployments_path,
-        Some(&args.symbol),
     )
     .await?;
 
     set_erc20_params(erc20_address, client, args).await?;
 
-    let permit2_address = parse_addr_from_deployments_file(deployments_path, PERMIT2_CONTRACT_KEY)?;
+    if !args.account_skeys.is_empty() {
+        let permit2_address = read_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY)?;
 
-    for skey in &args.account_skeys {
-        fund_and_approve_erc20(
-            rpc_url,
-            erc20_address,
-            skey,
-            args.funding_amount.unwrap(),
-            permit2_address,
-        )
-        .await?;
+        for recipient_skey in &args.account_skeys {
+            fund_and_approve_erc20(
+                args,
+                rpc_url,
+                erc20_address,
+                recipient_skey,
+                permit2_address,
+            )
+            .await?;
+        }
     }
 
     Ok(())
@@ -451,6 +453,8 @@ async fn set_erc20_params(
 ) -> Result<(), ScriptError> {
     let erc20 = DummyErc20Contract::new(erc20_address, client);
 
+    info!("Setting {} contract parameters", args.symbol);
+
     send_contract_call(erc20.set_symbol(args.symbol.clone())).await?;
     send_contract_call(erc20.set_name(args.name.clone())).await?;
     send_contract_call(erc20.set_decimals(args.decimals)).await?;
@@ -461,15 +465,23 @@ async fn set_erc20_params(
 /// Funds the provided account with the given amount of ERC20 tokens,
 /// and approves the Permit2 contract to spend the maximum amount of the ERC20
 async fn fund_and_approve_erc20(
+    args: &DeployErc20Args,
     rpc_url: &str,
     erc20_address: Address,
     recipient_skey: &str,
-    funding_amount: u128,
     permit2_address: Address,
 ) -> Result<(), ScriptError> {
     let account_client = setup_client(recipient_skey, rpc_url).await?;
     let account_address = account_client.default_sender().unwrap();
     let erc20 = DummyErc20Contract::new(erc20_address, account_client);
+
+    let funding_amount = args.funding_amount.unwrap();
+    let symbol = args.symbol.clone();
+
+    info!(
+        "Funding {:#x} with {} {} & approving Permit2",
+        account_address, funding_amount, symbol
+    );
 
     send_contract_call(erc20.mint(account_address, EthersU256::from(funding_amount))).await?;
     send_contract_call(erc20.approve(permit2_address, EthersU256::MAX)).await?;
@@ -477,26 +489,26 @@ async fn fund_and_approve_erc20(
     Ok(())
 }
 
-/// Builds and deploys a Stylus contract
+/// Builds and deploys a Stylus contract,
+/// saving the deployment address to the deployments file
 pub async fn build_and_deploy_stylus_contract(
     args: &DeployStylusArgs,
     rpc_url: &str,
     priv_key: &str,
     client: Arc<LocalWalletHttpClient>,
     deployments_path: &str,
-) -> Result<(), ScriptError> {
-    let wasm_file_path = build_stylus_contract(args.contract, args.no_verify)?;
-    deploy_stylus_contract(
-        wasm_file_path,
-        rpc_url,
-        priv_key,
-        client,
-        args.contract,
-        deployments_path,
-        None,
-    )
-    .await
-    .map(|_| ())
+) -> Result<Address, ScriptError> {
+    // Build the contract to WASM
+    let wasm_file_path = build_stylus_contract(&args.contract, args.no_verify)?;
+
+    // Deploy the contract
+    let deployed_address =
+        deploy_stylus_contract(wasm_file_path, rpc_url, priv_key, client, &args.contract).await?;
+
+    // Write deployed address to deployments file
+    write_stylus_contract_address(deployments_path, &args.contract, deployed_address)?;
+
+    Ok(deployed_address)
 }
 
 /// Upgrades the darkpool implementation
@@ -506,16 +518,13 @@ pub async fn upgrade(
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     let proxy_admin_address =
-        parse_addr_from_deployments_file(deployments_path, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY)?;
+        read_deployment_address(deployments_path, DARKPOOL_PROXY_ADMIN_CONTRACT_KEY)?;
     let proxy_admin = ProxyAdminContract::new(proxy_admin_address, client);
 
-    let proxy_address =
-        parse_addr_from_deployments_file(deployments_path, DARKPOOL_PROXY_CONTRACT_KEY)?;
+    let proxy_address = read_deployment_address(deployments_path, DARKPOOL_PROXY_CONTRACT_KEY)?;
 
-    let implementation_address = parse_addr_from_deployments_file(
-        deployments_path,
-        get_contract_key(StylusContract::Darkpool),
-    )?;
+    let implementation_address =
+        read_stylus_deployment_address(deployments_path, &StylusContract::Darkpool)?;
 
     let data = if let Some(calldata) = args.calldata.clone() {
         Bytes::from_hex(calldata).map_err(|e| ScriptError::CalldataConstruction(e.to_string()))?

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -111,14 +111,8 @@ pub const DEPLOY_COMMAND: &str = "deploy";
 /// The deployments key in the `deployments.json` file
 pub const DEPLOYMENTS_KEY: &str = "deployments";
 
-/// The darkpool contract key in the `deployments.json` file
-pub const DARKPOOL_CONTRACT_KEY: &str = "darkpool_contract";
-
-/// The core wallet operations contract key in the `deployments.json` file
-pub const CORE_WALLET_OPS_CONTRACT_KEY: &str = "core_wallet_ops_contract";
-
-/// The core settlement contract key in the `deployments.json` file
-pub const CORE_SETTLEMENT_CONTRACT_KEY: &str = "core_settlement_contract";
+/// The ERC-20s sub-key in the `deployments.json` file
+pub const ERC20S_KEY: &str = "erc20s";
 
 /// The darkpool proxy contract key in the `deployments.json` file
 pub const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";
@@ -128,21 +122,6 @@ pub const DARKPOOL_PROXY_ADMIN_CONTRACT_KEY: &str = "darkpool_proxy_admin_contra
 
 /// The permit2 contract key in the `deployments.json` file
 pub const PERMIT2_CONTRACT_KEY: &str = "permit2_contract";
-
-/// The merkle contract key in the `deployments.json` file
-pub const MERKLE_CONTRACT_KEY: &str = "merkle_contract";
-
-/// The verifier contract key in the `deployments.json` file
-pub const VERIFIER_CORE_CONTRACT_KEY: &str = "verifier_core_contract";
-
-/// The verifier settlement contract key in the `deployments.json` file
-pub const VERIFIER_SETTLEMENT_CONTRACT_KEY: &str = "verifier_settlement_contract";
-
-/// The vkeys contract key in the `deployments.json` file
-pub const VKEYS_CONTRACT_KEY: &str = "vkeys_contract";
-
-/// The transfer executor contract key in the `deployments.json` file
-pub const TRANSFER_EXECUTOR_CONTRACT_KEY: &str = "transfer_executor_contract";
 
 /// The ticker of the ERC20 contract deployed using `deploy_test_contracts`,
 /// which is also its contract key in the `deployments.json` file
@@ -158,12 +137,6 @@ pub const TEST_ERC20_DECIMALS: u8 = 18;
 /// The amount of dummy ERC20 tokens to fund the user with
 /// when deploying the testing contracts
 pub const TEST_FUNDING_AMOUNT: u128 = 1000;
-
-/// The test upgrade target contract key in the `deployments.json` file
-pub const TEST_UPGRADE_TARGET_CONTRACT_KEY: &str = "test_upgrade_target_contract";
-
-/// The precompile test contract key in the `deployments.json` file
-pub const PRECOMPILE_TEST_CONTRACT_KEY: &str = "precompile_test_contract";
 
 /// The file name for the VALID WALLET CREATE verification key
 pub const VALID_WALLET_CREATE_VKEY_FILE: &str = "valid_wallet_create";

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -152,8 +152,8 @@ pub const TEST_ERC20_TICKER1: &str = "TEST1";
 /// which is also its contract key in the `deployments.json` file
 pub const TEST_ERC20_TICKER2: &str = "TEST2";
 
-/// The environment variable denoting the symbol w/ which to deploy the dummy ERC20 contract
-pub const DUMMY_ERC20_SYMBOL_ENV_VAR: &str = "DUMMY_ERC20_SYMBOL";
+/// The number of decimals for the testing ERC20 contracts
+pub const TEST_ERC20_DECIMALS: u8 = 18;
 
 /// The amount of dummy ERC20 tokens to fund the user with
 /// when deploying the testing contracts

--- a/scripts/src/errors.rs
+++ b/scripts/src/errors.rs
@@ -8,6 +8,8 @@ use std::{
 /// Errors that can occur during the execution of the contract management scripts
 #[derive(Debug)]
 pub enum ScriptError {
+    /// Invalid arguments provided to a command
+    InvalidArguments(String),
     /// Error reading from the deployments file
     ReadFile(String),
     /// Error writing to the deployments file
@@ -39,6 +41,7 @@ pub enum ScriptError {
 impl Display for ScriptError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            ScriptError::InvalidArguments(s) => write!(f, "invalid arguments: {}", s),
             ScriptError::ReadFile(s) => write!(f, "error reading deployments: {}", s),
             ScriptError::WriteFile(s) => write!(f, "error writing deployments: {}", s),
             ScriptError::ArtifactParsing(s) => write!(f, "error parsing artifact: {}", s),

--- a/scripts/src/lib.rs
+++ b/scripts/src/lib.rs
@@ -10,5 +10,5 @@ mod commands;
 pub mod constants;
 pub mod errors;
 mod solidity;
-mod types;
+pub mod types;
 pub mod utils;

--- a/scripts/src/solidity.rs
+++ b/scripts/src/solidity.rs
@@ -18,6 +18,9 @@ abigen!(
     DummyErc20Contract,
     r#"[
         function totalSupply() external view returns (uint256)
+        function setName(string name) external
+        function setSymbol(string symbol) external
+        function setDecimals(uint8 decimals) external
         function balanceOf(address account) external view returns (uint256)
         function mint(address memory _address, uint256 memory value) external
         function transfer(address to, uint256 value) external returns (bool)

--- a/scripts/src/types.rs
+++ b/scripts/src/types.rs
@@ -8,7 +8,7 @@ use contracts_common::types::{
 };
 
 /// The possible Stylus contracts to deploy
-#[derive(ValueEnum, Copy, Clone)]
+#[derive(ValueEnum, Clone)]
 pub enum StylusContract {
     /// The darkpool contract
     Darkpool,
@@ -32,8 +32,12 @@ pub enum StylusContract {
     TestVkeys,
     /// The transfer executor contract
     TransferExecutor,
-    /// The dummy ERC20 contract
-    DummyErc20,
+    /// The dummy ERC20 contract, containing the
+    /// token symbol
+    // We skip this value in the CLI as we have
+    // a separate command for deploying ERC20s
+    #[value(skip)]
+    DummyErc20(String),
     /// The dummy upgrade target contract
     DummyUpgradeTarget,
     /// The precompile test contract
@@ -54,7 +58,7 @@ impl Display for StylusContract {
             StylusContract::Vkeys => write!(f, "vkeys"),
             StylusContract::TestVkeys => write!(f, "test-vkeys"),
             StylusContract::TransferExecutor => write!(f, "transfer-executor"),
-            StylusContract::DummyErc20 => write!(f, "dummy-erc20"),
+            StylusContract::DummyErc20(_) => write!(f, "dummy-erc20"),
             StylusContract::DummyUpgradeTarget => write!(f, "dummy-upgrade-target"),
             StylusContract::PrecompileTestContract => write!(f, "precompile-test-contract"),
         }

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -33,14 +33,11 @@ use util::hex::jubjub_from_hex_string;
 use crate::{
     constants::{
         AGGRESSIVE_OPTIMIZATION_FLAG, AGGRESSIVE_SIZE_OPTIMIZATION_FLAG, BUILD_COMMAND,
-        CARGO_COMMAND, CORE_SETTLEMENT_CONTRACT_KEY, CORE_WALLET_OPS_CONTRACT_KEY,
-        DARKPOOL_CONTRACT_KEY, DEFAULT_RUSTFLAGS, DEPLOYMENTS_KEY, DEPLOY_COMMAND,
-        INLINE_THRESHOLD_FLAG, MANIFEST_DIR_ENV_VAR, MERKLE_CONTRACT_KEY, NO_VERIFY_FEATURE,
-        OPT_LEVEL_3, OPT_LEVEL_FLAG, OPT_LEVEL_Z, PRECOMPILE_TEST_CONTRACT_KEY,
-        RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND, STYLUS_CONTRACTS_CRATE_NAME,
-        TARGET_PATH_SEGMENT, TEST_UPGRADE_TARGET_CONTRACT_KEY, TRANSFER_EXECUTOR_CONTRACT_KEY,
-        VERIFIER_CORE_CONTRACT_KEY, VERIFIER_SETTLEMENT_CONTRACT_KEY, VKEYS_CONTRACT_KEY,
-        WASM_EXTENSION, WASM_OPT_COMMAND, WASM_OPT_EXTENSION, WASM_TARGET_TRIPLE, Z_FLAGS,
+        CARGO_COMMAND, DEFAULT_RUSTFLAGS, DEPLOYMENTS_KEY, DEPLOY_COMMAND, ERC20S_KEY,
+        INLINE_THRESHOLD_FLAG, MANIFEST_DIR_ENV_VAR, NO_VERIFY_FEATURE, OPT_LEVEL_3,
+        OPT_LEVEL_FLAG, OPT_LEVEL_Z, RELEASE_PATH_SEGMENT, RUSTFLAGS_ENV_VAR, STYLUS_COMMAND,
+        STYLUS_CONTRACTS_CRATE_NAME, TARGET_PATH_SEGMENT, WASM_EXTENSION, WASM_OPT_COMMAND,
+        WASM_OPT_EXTENSION, WASM_TARGET_TRIPLE, Z_FLAGS,
     },
     errors::ScriptError,
     solidity::initializeCall,
@@ -100,29 +97,45 @@ pub fn get_json_from_file(file_path: &str) -> Result<JsonValue, ScriptError> {
 
 /// Parses a the given contract's deployment address from the
 /// deployments file at the given path
-pub fn parse_addr_from_deployments_file(
+pub fn read_stylus_deployment_address(
     file_path: &str,
-    contract_key: &str,
+    contract: &StylusContract,
 ) -> Result<Address, ScriptError> {
     let parsed_json = get_json_from_file(file_path)?;
 
-    Address::from_str(
-        parsed_json[DEPLOYMENTS_KEY][contract_key]
-            .as_str()
-            .ok_or_else(|| {
-                ScriptError::ReadFile(
-                    "Could not parse contract address from deployments file".to_string(),
-                )
-            })?,
-    )
-    .map_err(|e| ScriptError::ReadFile(e.to_string()))
+    let address_str = match contract {
+        StylusContract::DummyErc20(symbol) => {
+            parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol].as_str()
+        }
+        _ => parsed_json[DEPLOYMENTS_KEY][contract.to_string()].as_str(),
+    }
+    .ok_or_else(|| {
+        ScriptError::ReadFile("Could not parse contract address from deployments file".to_string())
+    })?;
+
+    Address::from_str(address_str).map_err(|e| ScriptError::ReadFile(e.to_string()))
 }
 
-/// Writes the given address for the deployed contract
-/// to the deployments file at the given path
-pub fn write_deployed_address(
+/// Reads the address under the given key from the given deployments file
+pub fn read_deployment_address(
     file_path: &str,
-    contract_key: &str,
+    deployment_key: &str,
+) -> Result<Address, ScriptError> {
+    let parsed_json = get_json_from_file(file_path)?;
+    let address_str = parsed_json[DEPLOYMENTS_KEY][deployment_key]
+        .as_str()
+        .ok_or_else(|| {
+            ScriptError::ReadFile("Could not parse address from deployments file".to_string())
+        })?;
+
+    Address::from_str(address_str).map_err(|e| ScriptError::ReadFile(e.to_string()))
+}
+
+/// Writes the given address for the deployed Stylus
+/// contract to the deployments file at the given path
+pub fn write_stylus_contract_address(
+    file_path: &str,
+    contract: &StylusContract,
     address: Address,
 ) -> Result<(), ScriptError> {
     // If the file doesn't exist, create it
@@ -131,7 +144,37 @@ pub fn write_deployed_address(
     }
     let mut parsed_json = get_json_from_file(file_path)?;
 
-    parsed_json[DEPLOYMENTS_KEY][contract_key] = JsonValue::String(format!("{address:#x}"));
+    match contract {
+        StylusContract::DummyErc20(symbol) => {
+            parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol] =
+                JsonValue::String(format!("{address:#x}"));
+        }
+        _ => {
+            parsed_json[DEPLOYMENTS_KEY][contract.to_string()] =
+                JsonValue::String(format!("{address:#x}"));
+        }
+    }
+
+    fs::write(file_path, json::stringify_pretty(parsed_json, 4))
+        .map_err(|e| ScriptError::WriteFile(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Writes the given address into the deployments file,
+/// to the exact specified key
+pub fn write_deployment_address(
+    file_path: &str,
+    deployments_key: &str,
+    address: Address,
+) -> Result<(), ScriptError> {
+    // If the file doesn't exist, create it
+    if !PathBuf::from(file_path).exists() {
+        fs::write(file_path, "{}").map_err(|e| ScriptError::WriteFile(e.to_string()))?;
+    }
+    let mut parsed_json = get_json_from_file(file_path)?;
+
+    parsed_json[DEPLOYMENTS_KEY][deployments_key] = JsonValue::String(format!("{address:#x}"));
 
     fs::write(file_path, json::stringify_pretty(parsed_json, 4))
         .map_err(|e| ScriptError::WriteFile(e.to_string()))?;
@@ -149,23 +192,6 @@ pub fn write_vkey_file(
     let vkey_file_path = vkeys_dir.join(vkey_file_name);
 
     fs::write(vkey_file_path, vkey_bytes).map_err(|e| ScriptError::WriteFile(e.to_string()))
-}
-
-/// Returns the JSON key used in the deployments file for the given contract
-pub fn get_contract_key(contract: StylusContract) -> &'static str {
-    match contract {
-        StylusContract::Darkpool | StylusContract::DarkpoolTestContract => DARKPOOL_CONTRACT_KEY,
-        StylusContract::CoreWalletOps => CORE_WALLET_OPS_CONTRACT_KEY,
-        StylusContract::CoreSettlement => CORE_SETTLEMENT_CONTRACT_KEY,
-        StylusContract::Merkle | StylusContract::MerkleTestContract => MERKLE_CONTRACT_KEY,
-        StylusContract::VerifierCore => VERIFIER_CORE_CONTRACT_KEY,
-        StylusContract::VerifierSettlement => VERIFIER_SETTLEMENT_CONTRACT_KEY,
-        StylusContract::Vkeys | StylusContract::TestVkeys => VKEYS_CONTRACT_KEY,
-        StylusContract::TransferExecutor => TRANSFER_EXECUTOR_CONTRACT_KEY,
-        StylusContract::DummyUpgradeTarget => TEST_UPGRADE_TARGET_CONTRACT_KEY,
-        StylusContract::PrecompileTestContract => PRECOMPILE_TEST_CONTRACT_KEY,
-        StylusContract::DummyErc20 => unreachable!("Must supply a ticker at which to find the deployment address of a dummy ERC20 contract"),
-    }
 }
 
 /// Parses an EC-ElGamal public encryption key from a hex string,
@@ -264,7 +290,7 @@ fn command_success_or(mut cmd: Command, err_msg: &str) -> Result<(), ScriptError
 
 /// Returns the RUSTFLAGS environment variable to use in the
 /// compilation of the given contract
-pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
+pub fn get_rustflags_for_contract(contract: &StylusContract) -> String {
     let rustflags = match contract {
         StylusContract::VerifierCore
         | StylusContract::VerifierSettlement
@@ -283,7 +309,7 @@ pub fn get_rustflags_for_contract(contract: StylusContract) -> String {
 
 /// Returns the wasm-opt flags to use in the optimization of the
 /// given contract
-pub fn get_wasm_opt_flags_for_contract(contract: StylusContract) -> &'static str {
+pub fn get_wasm_opt_flags_for_contract(contract: &StylusContract) -> &'static str {
     match contract {
         StylusContract::DarkpoolTestContract => AGGRESSIVE_SIZE_OPTIMIZATION_FLAG,
         _ => AGGRESSIVE_OPTIMIZATION_FLAG,
@@ -295,7 +321,7 @@ pub fn get_wasm_opt_flags_for_contract(contract: StylusContract) -> &'static str
 ///
 /// Assumes that `cargo`, the `nightly` toolchain, and `wasm-opt` are locally available.
 pub fn build_stylus_contract(
-    contract: StylusContract,
+    contract: &StylusContract,
     no_verify: bool,
 ) -> Result<PathBuf, ScriptError> {
     let current_dir = PathBuf::from(env::var(MANIFEST_DIR_ENV_VAR).unwrap());
@@ -380,14 +406,12 @@ pub async fn deploy_stylus_contract(
     rpc_url: &str,
     priv_key: &str,
     client: Arc<LocalWalletHttpClient>,
-    contract: StylusContract,
-    deployments_path: &str,
-    contract_key_override: Option<&str>,
+    contract: &StylusContract,
 ) -> Result<Address, ScriptError> {
     match contract {
         StylusContract::DarkpoolTestContract
         | StylusContract::MerkleTestContract
-        | StylusContract::DummyErc20 => {
+        | StylusContract::DummyErc20(_) => {
             warn!(
                 "Deploying `{}` - THIS SHOULD ONLY BE DONE FOR TESTING",
                 contract
@@ -422,15 +446,6 @@ pub async fn deploy_stylus_contract(
     deploy_cmd.arg("--no-verify");
 
     command_success_or(deploy_cmd, "Failed to deploy Stylus contract")?;
-
-    // Write deployed address to deployments file
-    let contract_key = if let Some(contract_key_override) = contract_key_override {
-        contract_key_override
-    } else {
-        get_contract_key(contract)
-    };
-
-    write_deployed_address(deployments_path, contract_key, deployed_address)?;
 
     Ok(deployed_address)
 }

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -16,10 +16,12 @@ use alloy_sol_types::SolCall;
 use ark_ed_on_bn254::EdwardsProjective as BabyJubJubProjective;
 use contracts_common::{custom_serde::scalar_to_u256, types::PublicEncryptionKey};
 use ethers::{
-    abi::Address,
+    abi::{Address, Detokenize},
+    contract::ContractCall,
     middleware::SignerMiddleware,
     providers::{Http, Middleware, Provider},
     signers::{LocalWallet, Signer},
+    types::TransactionReceipt,
     utils::get_contract_address,
 };
 use itertools::Itertools;
@@ -71,6 +73,18 @@ pub async fn setup_client(
     ));
 
     Ok(client)
+}
+
+/// Sends a contract call, waiting for the transaction to go from pending to executed,
+/// and returns the transaction receipt
+pub async fn send_contract_call<M: Middleware, D: Detokenize>(
+    call: ContractCall<M, D>,
+) -> Result<Option<TransactionReceipt>, ScriptError> {
+    call.send()
+        .await
+        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
+        .await
+        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))
 }
 
 /// Parses the JSON file at the given path


### PR DESCRIPTION
This PR tweaks the dummy ERC-20 testing contract to have settable symbol, name, and decimals parameters to allow greater flexibility in deploying testing tokens. I also took the time to clean up some of the scripting code around deploying contracts, including the ERC20s, and slightly changed the deployments file format to group all the ERC20 deployments together in a nested object. The purpose of this is to make it easier to programmatically generate a token mapping file from a deployments file.

I used the updated `deploy-erc20` script to deploy new dummy ERC20s to testnet which mirror our mainnet token list