### PR TITLE
contracts-stylus: transfer-executor: Allow native ETH transfers

### DIFF
--- a/contracts-stylus/src/contracts/transfer_executor.rs
+++ b/contracts-stylus/src/contracts/transfer_executor.rs
@@ -1,6 +1,8 @@
 //! The transfer executor contract, responsible for executing external transfers to/from the darkpool
 //! (it is intended to be delegate-called by the darkpool)
 
+use core::str::FromStr;
+
 use crate::{
     if_verifying,
     utils::{
@@ -11,7 +13,10 @@ use crate::{
         helpers::{
             assert_valid_signature, call_helper, deserialize_from_calldata, postcard_serialize,
         },
-        solidity::{transferCall, transferFromCall, ExternalTransfer as ExternalTransferEvent},
+        solidity::{
+            depositCall, transferCall, transferFromCall, withdrawToCall,
+            ExternalTransfer as ExternalTransferEvent,
+        },
     },
 };
 use alloc::{string::ToString, vec::Vec};
@@ -28,15 +33,43 @@ use contracts_common::{
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::Address,
-    contract, evm,
+    call::Call,
+    contract, evm, msg,
     prelude::*,
     storage::{StorageAddress, StorageArray, StorageU256},
 };
+
+/// A dummy address for the native asset, constant across all chains
+/// 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
+const NATIVE_ETH_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/// The address of the WETH contract
+///
+/// We read this from an environment variable so that it must be set by the deployer.
+///
+/// For convenience, the addresses of WETH on Arbitrum chains are below:
+/// - Sepolia: 0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 // TODO: replace with dummy WETH address
+/// - Arbitrum One: 0x82aF49447D8a07e3bd95BD0d56f35241523fBabb
+const WETH_ADDRESS: &str = env!("WETH_ADDRESS");
 
 /// The error message emitted when a simple ERC20 deposit fails
 const SIMPLE_ERC20_DEPOSIT_ERROR_MESSAGE: &[u8] = b"Simple ERC20 deposit failed";
 /// The error message emitted when a simple ERC20 withdrawal fails
 const SIMPLE_ERC20_WITHDRAWAL_ERROR_MESSAGE: &[u8] = b"Simple ERC20 withdrawal failed";
+/// The error message emitted when the transaction payable amount is invalid
+const INVALID_TRANSACTION_PAYABLE_AMOUNT_ERROR_MESSAGE: &[u8] =
+    b"Invalid transaction payable amount";
+
+/// A helper method to parse the WETH address from a string
+fn get_weth_address() -> Address {
+    Address::from_str(WETH_ADDRESS).expect("WETH_ADDRESS must be a valid address")
+}
+
+/// A helper method to parse the native ETH address from a string
+fn is_native_eth_address(addr: Address) -> bool {
+    let native_addr = Address::from_str(NATIVE_ETH_ADDRESS).unwrap();
+    addr == native_addr
+}
 
 /// The transfer executor contract's storage layout
 #[solidity_storage]
@@ -184,7 +217,13 @@ impl TransferExecutorContract {
         &mut self,
         transfer: SimpleErc20Transfer,
     ) -> Result<(), Vec<u8>> {
+        // If the deposit is for native ETH, wrap it
         let erc20_address = transfer.mint;
+        if is_native_eth_address(erc20_address) {
+            return self.handle_native_eth_deposit(transfer);
+        }
+
+        // Otherwise, deposit the ERC20
         let contract_address = contract::address();
         let res = call_helper::<transferFromCall>(
             self,
@@ -203,7 +242,12 @@ impl TransferExecutorContract {
         &mut self,
         transfer: SimpleErc20Transfer,
     ) -> Result<(), Vec<u8>> {
+        // If the withdrawal is for native ETH, unwrap it
         let erc20_address = transfer.mint;
+        if is_native_eth_address(erc20_address) {
+            return self.handle_native_eth_withdrawal(transfer);
+        }
+
         let res = call_helper::<transferCall>(
             self,
             erc20_address,
@@ -213,6 +257,35 @@ impl TransferExecutorContract {
         if !res._0 {
             return Err(SIMPLE_ERC20_WITHDRAWAL_ERROR_MESSAGE.to_vec());
         }
+        Ok(())
+    }
+
+    /// Deposit native ETH into the contract by wrapping the transaction payable amount
+    fn handle_native_eth_deposit(&mut self, transfer: SimpleErc20Transfer) -> Result<(), Vec<u8>> {
+        let payable = msg::value();
+        if transfer.amount != payable {
+            return Err(INVALID_TRANSACTION_PAYABLE_AMOUNT_ERROR_MESSAGE.to_vec());
+        }
+
+        // Wrap the native asset
+        let weth_address = get_weth_address();
+        let call_ctx = Call::new_in(self).value(payable);
+        call_helper::<depositCall>(call_ctx, weth_address, ())?;
+        Ok(())
+    }
+
+    /// Withdraw native ETH from the contract to the caller by unwrapping the transfer amount
+    fn handle_native_eth_withdrawal(
+        &mut self,
+        transfer: SimpleErc20Transfer,
+    ) -> Result<(), Vec<u8>> {
+        let weth_address = get_weth_address();
+        let call_ctx = Call::new_in(self);
+        call_helper::<withdrawToCall>(
+            call_ctx,
+            weth_address,
+            (transfer.account_addr, transfer.amount),
+        )?;
         Ok(())
     }
 }

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{Address, U256},
-    call::{call, delegate_call, static_call},
+    call::{call, delegate_call, static_call, MutatingCallContext},
     storage::TopLevelStorage,
 };
 
@@ -177,7 +177,7 @@ pub fn delegate_call_helper<C: SolCall>(
 /// defined as a `SolCall` with the given arguments.
 #[cfg_attr(not(feature = "transfer-executor"), allow(dead_code))]
 pub fn call_helper<C: SolCall>(
-    storage: &mut impl TopLevelStorage,
+    storage: impl MutatingCallContext,
     address: Address,
     args: <C::Parameters<'_> as SolType>::RustType,
 ) -> Result<C::Return, Vec<u8>> {

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -53,6 +53,10 @@ sol! {
     function transfer(address to, uint256 value) external returns (bool);
     function transferFrom(address from, address to, uint256 value) external returns (bool);
 
+    // Native asset wrapper functions
+    function deposit() external payable;
+    function withdrawTo(address to, uint256 value) external;
+
     // Testing functions
     function isDummyUpgradeTarget() external view returns (bool);
 


### PR DESCRIPTION
### Purpose
This PR allows native ETH transfers by specifying the address `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`, which is the standard native address fill-in for swap APIs.

In the case of a native ETH deposit, the contract expects the transaction payable amount to be the amount of the transfer, and makes a call to the configured WETH contract's `deposit` method using this same `value`. 

In the case of a native ETH withdrawal, the contract will call the WETH contract's `withdrawTo` method, passing the recipient along with this call.

In order to specify the WETH contract address, we constantize the value, but leave it empty in committed code. We also add a compile-time assertion that this value is non-empty, which fails in the `main` branch. This prevents someone who is deploying with the wrong WETH address configured, as they must fill it in for the contract to compile.

### Testing
- Deployed transfer executor to check binary size
- Other testing deferred until dummy WETH contract is built