### PR TITLE
contracts-stylus: core-settlement: Use weth address in verifier calldata

### DIFF
--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -393,7 +393,7 @@ impl SimpleErc20Transfer {
 
 /// A fee take from a match
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct FeeTake {
     /// The fee the relayer takes
     #[serde_as(as = "U256Def")]
@@ -415,7 +415,7 @@ impl FeeTake {
 
 /// The result of an atomic match
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ExternalMatchResult {
     /// The mint (erc20 address) of the quote token
     #[serde_as(as = "AddressDef")]
@@ -540,7 +540,7 @@ pub struct ValidReblindStatement {
 
 /// The indices that specify where settlement logic should modify the wallet
 /// shares
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderSettlementIndices {
     /// The index of the balance that holds the mint that the wallet will
     /// send if a successful match occurs
@@ -590,7 +590,7 @@ pub struct MatchPayload {
 
 /// The statement type for `VALID MATCH SETTLE ATOMIC`
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ValidMatchSettleAtomicStatement {
     /// The result of the match
     pub match_result: ExternalMatchResult,

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -16,7 +16,8 @@ use crate::{
             TRANSFER_EXECUTOR_STORAGE_GAP_SIZE, VERIFICATION_FAILED_ERROR_MESSAGE,
         },
         helpers::{
-            delegate_call_helper, deserialize_from_calldata, postcard_serialize,
+            delegate_call_helper, deserialize_from_calldata, get_weth_address,
+            is_native_eth_address, postcard_serialize,
             serialize_atomic_match_statements_for_verification,
             serialize_match_statements_for_verification, u256_to_scalar,
         },
@@ -298,7 +299,7 @@ impl CoreSettlementContract {
             Self::batch_verify_process_atomic_match_settle(
                 storage,
                 &internal_party_match_payload,
-                &valid_match_settle_atomic_statement,
+                valid_match_settle_atomic_statement.clone(),
                 match_proofs,
                 match_linking_proofs,
             )?;
@@ -378,7 +379,7 @@ impl CoreSettlementContract {
     pub fn batch_verify_process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
         internal_party_match_payload: &MatchPayload,
-        valid_match_settle_atomic_statement: &ValidMatchSettleAtomicStatement,
+        mut valid_match_settle_atomic_statement: ValidMatchSettleAtomicStatement,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
@@ -386,10 +387,18 @@ impl CoreSettlementContract {
         let process_atomic_match_settle_vkeys =
             fetch_vkeys(storage, &processAtomicMatchSettleVkeysCall::SELECTOR)?;
 
+        // We allow native ETH transfers on external matches, but the verifier will expect WETH
+        // to be compatible with internal orders, so we change it here
+        let base_asset = valid_match_settle_atomic_statement.match_result.base_mint;
+        if is_native_eth_address(base_asset) {
+            let weth = get_weth_address();
+            valid_match_settle_atomic_statement.match_result.base_mint = weth;
+        }
+
         let atomic_match_public_inputs = serialize_atomic_match_statements_for_verification(
             &internal_party_match_payload.valid_commitments_statement,
             &internal_party_match_payload.valid_reblind_statement,
-            valid_match_settle_atomic_statement,
+            &valid_match_settle_atomic_statement,
         )?;
 
         let verifier_address = storage.borrow_mut().verifier_core_address();

--- a/contracts-stylus/src/contracts/transfer_executor.rs
+++ b/contracts-stylus/src/contracts/transfer_executor.rs
@@ -1,7 +1,6 @@
 //! The transfer executor contract, responsible for executing external transfers to/from the darkpool
 //! (it is intended to be delegate-called by the darkpool)
-
-use core::str::FromStr;
+#![cfg(feature = "transfer-executor")]
 
 use crate::{
     if_verifying,
@@ -11,7 +10,8 @@ use crate::{
             MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE,
         },
         helpers::{
-            assert_valid_signature, call_helper, deserialize_from_calldata, postcard_serialize,
+            assert_valid_signature, call_helper, deserialize_from_calldata, get_weth_address,
+            is_native_eth_address, postcard_serialize,
         },
         solidity::{
             depositCall, transferCall, transferFromCall, withdrawToCall,
@@ -39,19 +39,6 @@ use stylus_sdk::{
     storage::{StorageAddress, StorageArray, StorageU256},
 };
 
-/// A dummy address for the native asset, constant across all chains
-/// 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
-const NATIVE_ETH_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
-
-/// The address of the WETH contract
-///
-/// We read this from an environment variable so that it must be set by the deployer.
-///
-/// For convenience, the addresses of WETH on Arbitrum chains are below:
-/// - Sepolia: 0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 // TODO: replace with dummy WETH address
-/// - Arbitrum One: 0x82aF49447D8a07e3bd95BD0d56f35241523fBabb
-const WETH_ADDRESS: &str = env!("WETH_ADDRESS");
-
 /// The error message emitted when a simple ERC20 deposit fails
 const SIMPLE_ERC20_DEPOSIT_ERROR_MESSAGE: &[u8] = b"Simple ERC20 deposit failed";
 /// The error message emitted when a simple ERC20 withdrawal fails
@@ -59,17 +46,6 @@ const SIMPLE_ERC20_WITHDRAWAL_ERROR_MESSAGE: &[u8] = b"Simple ERC20 withdrawal f
 /// The error message emitted when the transaction payable amount is invalid
 const INVALID_TRANSACTION_PAYABLE_AMOUNT_ERROR_MESSAGE: &[u8] =
     b"Invalid transaction payable amount";
-
-/// A helper method to parse the WETH address from a string
-fn get_weth_address() -> Address {
-    Address::from_str(WETH_ADDRESS).expect("WETH_ADDRESS must be a valid address")
-}
-
-/// A helper method to parse the native ETH address from a string
-fn is_native_eth_address(addr: Address) -> bool {
-    let native_addr = Address::from_str(NATIVE_ETH_ADDRESS).unwrap();
-    addr == native_addr
-}
 
 /// The transfer executor contract's storage layout
 #[solidity_storage]

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -114,6 +114,21 @@ pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata"
 #[cfg(feature = "transfer-executor")]
 pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
 
+/// A dummy address for the native asset, constant across all chains
+/// 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
+#[cfg(any(feature = "transfer-executor", feature = "core-settlement"))]
+pub const NATIVE_ETH_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/// The address of the WETH contract
+///
+/// We read this from an environment variable so that it must be set by the deployer.
+///
+/// For convenience, the addresses of WETH on Arbitrum chains are below:
+/// - Sepolia: 0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 // TODO: replace with dummy WETH address
+/// - Arbitrum One: 0x82aF49447D8a07e3bd95BD0d56f35241523fBabb
+#[cfg(any(feature = "transfer-executor", feature = "core-settlement"))]
+pub const WETH_ADDRESS: &str = env!("WETH_ADDRESS");
+
 /// The last byte of the `ecAdd` precompile address, 0x06
 pub const EC_ADD_ADDRESS_LAST_BYTE: u8 = 6;
 /// The last byte of the `ecMul` precompile address, 0x07

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -1,5 +1,7 @@
 //! Miscellaneous helper functions for the contracts.
 
+use super::constants::NATIVE_ETH_ADDRESS;
+use crate::utils::constants::WETH_ADDRESS;
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
 use ark_ff::PrimeField;
@@ -13,6 +15,7 @@ use contracts_common::{
     },
 };
 use contracts_core::crypto::ecdsa::ecdsa_verify;
+use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 use stylus_sdk::{
     abi::Bytes,
@@ -30,6 +33,19 @@ use super::constants::{
     CALLDATA_DESER_ERROR_MESSAGE, CALLDATA_SER_ERROR_MESSAGE, CALL_RETDATA_DECODING_ERROR_MESSAGE,
     INVALID_ARR_LEN_ERROR_MESSAGE,
 };
+
+/// A helper to get the address of the WETH contract
+#[cfg(any(feature = "transfer-executor", feature = "core-settlement"))]
+pub fn get_weth_address() -> Address {
+    Address::from_str(WETH_ADDRESS).expect("WETH_ADDRESS must be a valid address")
+}
+
+/// A helper to check if a given address is the address representing native ETH
+#[cfg(any(feature = "transfer-executor", feature = "core-settlement"))]
+pub fn is_native_eth_address(addr: Address) -> bool {
+    let native_addr = Address::from_str(NATIVE_ETH_ADDRESS).unwrap();
+    addr == native_addr
+}
 
 /// Deserializes a byte-serialized type from calldata
 #[cfg_attr(


### PR DESCRIPTION
### Purpose
This PR clobbers the calldata sent to the verifier to replace native ETH dummy addresses with the constant WETH address. 

This is necessary because the external order generated prover side will use the WETH address as the `base_mint` field to ensure compatibility with internal user orders. Only after proving will the address be changed to the native ETH dummy address. So, we need to make the symmetric change verifier-side to ensure native asset deposit/withdrawals work properly.

### Testing
- Deferred until a dummy WETH contract is build, next PR
- Deployed the `core_settlement` contract to check binary size