### PR TITLE
contracts-stylus: core-helpers: Decode vkeys with `stylus_sdk::Bytes`

### DIFF
--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 use alloc::{vec, vec::Vec};
-use alloy_sol_types::{sol_data::Bytes as AlloyBytes, SolCall, SolType};
+use alloy_sol_types::{SolCall, SolType};
 use contracts_common::{
     custom_serde::{pk_to_u256s, scalar_to_u256},
     types::{ExternalTransfer, PublicEncryptionKey, PublicSigningKey, ScalarField},
@@ -72,7 +72,7 @@ pub fn fetch_vkeys<C: CoreContractStorage, S: TopLevelStorage + Borrow<C>>(
     let storage = s.borrow();
     let vkeys_address = storage.vkeys_address();
     let res = static_call(s, vkeys_address, selector).map_err(map_call_error)?;
-    let vkey_bytes = <(AlloyBytes,) as SolType>::abi_decode(&res, false /* validate */)
+    let vkey_bytes = Bytes::abi_decode(&res, false /* validate */)
         .map_err(|_| CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec())?
         .0;
 

--- a/contracts-stylus/src/contracts/test_contracts/mod.rs
+++ b/contracts-stylus/src/contracts/test_contracts/mod.rs
@@ -12,7 +12,7 @@ mod darkpool_test_contract;
 #[cfg(feature = "dummy-erc20")]
 mod dummy_erc20;
 
-#[cfg(feature = "dummy-erc20")]
+#[cfg(feature = "dummy-weth")]
 mod dummy_weth;
 
 #[cfg(feature = "dummy-upgrade-target")]

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -413,7 +413,7 @@ pub async fn deploy_erc20(
     }
 
     let contract = if args.as_wrapper {
-        StylusContract::DummyWeth
+        StylusContract::DummyWeth(args.symbol.clone())
     } else {
         StylusContract::DummyErc20(args.symbol.clone())
     };

--- a/scripts/src/types.rs
+++ b/scripts/src/types.rs
@@ -39,7 +39,8 @@ pub enum StylusContract {
     #[value(skip)]
     DummyErc20(String),
     /// The dummy WETH contract
-    DummyWeth,
+    #[value(skip)]
+    DummyWeth(String),
     /// The dummy upgrade target contract
     DummyUpgradeTarget,
     /// The precompile test contract
@@ -61,7 +62,7 @@ impl Display for StylusContract {
             StylusContract::TestVkeys => write!(f, "test-vkeys"),
             StylusContract::TransferExecutor => write!(f, "transfer-executor"),
             StylusContract::DummyErc20(_) => write!(f, "dummy-erc20"),
-            StylusContract::DummyWeth => write!(f, "dummy-weth"),
+            StylusContract::DummyWeth(_) => write!(f, "dummy-weth"),
             StylusContract::DummyUpgradeTarget => write!(f, "dummy-upgrade-target"),
             StylusContract::PrecompileTestContract => write!(f, "precompile-test-contract"),
         }

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -149,6 +149,10 @@ pub fn write_stylus_contract_address(
             parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol] =
                 JsonValue::String(format!("{address:#x}"));
         }
+        StylusContract::DummyWeth(symbol) => {
+            parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol] =
+                JsonValue::String(format!("{address:#x}"));
+        }
         _ => {
             parsed_json[DEPLOYMENTS_KEY][contract.to_string()] =
                 JsonValue::String(format!("{address:#x}"));


### PR DESCRIPTION
### Purpose
This PR fixes a few issues with the integration tests after bumping the stylus SDK to `v0.6.0`. Namely:
- We have to use the `stylus_sdk::Bytes` type for decoding vkey return data
- Fix the deployment setup for wrapper contracts

### Todo
- Add a test for native assets in atomic matches

### Testing
- All other integration tests pass