### PR TITLE
rustfmt: Use relayer repo's rust fmt file

### DIFF
--- a/contracts-common/src/backends.rs
+++ b/contracts-common/src/backends.rs
@@ -19,11 +19,13 @@ pub trait HashBackend {
 #[derive(Debug)]
 pub struct G1ArithmeticError;
 
-/// Encapsulates the implementations of elliptic curve arithmetic done on the G1 source group,
-/// including a pairing identity check with elements of the G2 source group.
+/// Encapsulates the implementations of elliptic curve arithmetic done on the G1
+/// source group, including a pairing identity check with elements of the G2
+/// source group.
 ///
-/// The type that implements this trait should be a unit struct that either calls out to precompiles
-/// for EC arithmetic and pairings in a smart contract context, or call out to Arkworks code in a testing context.
+/// The type that implements this trait should be a unit struct that either
+/// calls out to precompiles for EC arithmetic and pairings in a smart contract
+/// context, or call out to Arkworks code in a testing context.
 pub trait G1ArithmeticBackend {
     /// Add two points in G1
     fn ec_add(a: G1Affine, b: G1Affine) -> Result<G1Affine, G1ArithmeticError>;
@@ -43,13 +45,10 @@ pub trait G1ArithmeticBackend {
             return Err(G1ArithmeticError);
         }
 
-        scalars
-            .iter()
-            .zip(points.iter())
-            .try_fold(G1Affine::identity(), |acc, (scalar, point)| {
-                let scaled_point = Self::ec_scalar_mul(*scalar, *point)?;
-                Self::ec_add(acc, scaled_point)
-            })
+        scalars.iter().zip(points.iter()).try_fold(G1Affine::identity(), |acc, (scalar, point)| {
+            let scaled_point = Self::ec_scalar_mul(*scalar, *point)?;
+            Self::ec_add(acc, scaled_point)
+        })
     }
 }
 
@@ -60,8 +59,9 @@ pub struct EcdsaError;
 /// A backend for recovering an Ethereum address from a
 /// secp256k1 ECDSA signature.
 ///
-/// The type that implements this trait should be a unit struct that either calls out to the
-/// `ecRecover` precompile, or calls out to a Rust implementation in the case of testing.
+/// The type that implements this trait should be a unit struct that either
+/// calls out to the `ecRecover` precompile, or calls out to a Rust
+/// implementation in the case of testing.
 pub trait EcRecoverBackend {
     /// Recovers an Ethereum address from a signature and a message hash.
     fn ec_recover(

--- a/contracts-common/src/constants.rs
+++ b/contracts-common/src/constants.rs
@@ -32,11 +32,13 @@ pub const HASH_OUTPUT_SIZE: usize = 32;
 /// The number of bytes of hash output to sample for a challenge
 pub const HASH_SAMPLE_BYTES: usize = 48;
 
-/// The number of bytes to represent field elements of the base or scalar fields for the G1 curve group,
-/// as well as the base field which is extended for the G2 curve group
+/// The number of bytes to represent field elements of the base or scalar fields
+/// for the G1 curve group, as well as the base field which is extended for the
+/// G2 curve group
 pub const NUM_BYTES_FELT: usize = 32;
 
-/// The index at which to split a hash output so that it can be directly converted to a field element.
+/// The index at which to split a hash output so that it can be directly
+/// converted to a field element.
 pub const SPLIT_INDEX: usize = NUM_BYTES_FELT - 1;
 
 /// The number of u64s it takes to represent a field element
@@ -60,8 +62,9 @@ pub const NUM_BYTES_ADDRESS: usize = 20;
 /// The number of bytes it takes to represent a secp256k1 ECDSA signature
 /// as expected by the Ethereum `ecRecover` precompile.
 ///
-/// Concretely, this is the concatenation of the `r` and `s` values of the signature,
-/// and `v`, a 1-byte recovery identifier (whose value is either 27 or 28)
+/// Concretely, this is the concatenation of the `r` and `s` values of the
+/// signature, and `v`, a 1-byte recovery identifier (whose value is either 27
+/// or 28)
 pub const NUM_BYTES_SIGNATURE: usize = 65;
 
 /// The height of the Merkle tree
@@ -75,12 +78,7 @@ pub const TEST_MERKLE_HEIGHT: usize = 3;
 /// reduced modulo the scalar field order when interpreted as a
 /// big-endian unsigned integer
 pub const EMPTY_LEAF_VALUE: ScalarField = Fp(
-    BigInt([
-        14542100412480080699,
-        1005430062575839833,
-        8810205500711505764,
-        2121377557688093532,
-    ]),
+    BigInt([14542100412480080699, 1005430062575839833, 8810205500711505764, 2121377557688093532]),
     PhantomData,
 );
 
@@ -96,8 +94,8 @@ pub const CORE_SETTLEMENT_ADDRESS_SELECTOR: u8 = 1;
 /// method on the Darkpool test contract
 pub const VERIFIER_CORE_ADDRESS_SELECTOR: u8 = 2;
 
-/// The selector for the verifier settlement address in the `is_implementation_upgraded`
-/// method on the Darkpool test contract
+/// The selector for the verifier settlement address in the
+/// `is_implementation_upgraded` method on the Darkpool test contract
 pub const VERIFIER_SETTLEMENT_ADDRESS_SELECTOR: u8 = 3;
 
 /// The selector for the vkeys address in the `is_implementation_upgraded`
@@ -124,7 +122,8 @@ pub const INVALID_INPUTS_ERROR_MESSAGE: &[u8] = b"invalid inputs";
 /// operation fails
 pub const ARITHMETIC_BACKEND_ERROR_MESSAGE: &[u8] = b"arithmetic backend error";
 
-/// The EIP-712 type string used for deposit witness data via `permitWitnessTransferFrom`.
+/// The EIP-712 type string used for deposit witness data via
+/// `permitWitnessTransferFrom`.
 ///
 /// For more details see: https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permitwitnesstransferfrom
 pub const DEPOSIT_WITNESS_TYPE_STRING: &str = "DepositWitness witness)DepositWitness(uint256[4] pkRoot)TokenPermissions(address token,uint256 amount)";

--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -1,5 +1,6 @@
 //! Custom de/serialization logic used to:
-//! 1. de/serialize objects to/from byte arrays for use in EVM precompiles & transcript operations
+//! 1. de/serialize objects to/from byte arrays for use in EVM precompiles &
+//!    transcript operations
 //! 2. serialize objects to scalar arrays for use as public proof inputs
 
 use alloc::{vec, vec::Vec};
@@ -76,9 +77,7 @@ impl BytesDeserializable for u64 {
     const SER_LEN: usize = 8;
 
     fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, SerdeError> {
-        Ok(u64::from_be_bytes(
-            bytes.try_into().map_err(|_| SerdeError::InvalidLength)?,
-        ))
+        Ok(u64::from_be_bytes(bytes.try_into().map_err(|_| SerdeError::InvalidLength)?))
     }
 }
 
@@ -105,8 +104,8 @@ impl<P: MontConfig<NUM_U64S_FELT>> BytesDeserializable for MontFp256<P> {
 impl BytesSerializable for G1Affine {
     /// Serializes a G1 point into a big-endian byte array of its coordinates.
     ///
-    /// This matches the format expected by the EVM `ecAdd`, `ecMul`, and `ecPairing`
-    /// precompiles as specified here:
+    /// This matches the format expected by the EVM `ecAdd`, `ecMul`, and
+    /// `ecPairing` precompiles as specified here:
     /// https://eips.ethereum.org/EIPS/eip-197#encoding
     fn serialize_to_bytes(&self) -> Vec<u8> {
         let zero = G1BaseField::zero();
@@ -123,8 +122,8 @@ impl BytesDeserializable for G1Affine {
 
     /// Deserializes a G1 point from a byte array.
     ///
-    /// This matches the format returned by the EVM `ecAdd` and `ecMul` precompiles,
-    /// as specified here:
+    /// This matches the format returned by the EVM `ecAdd` and `ecMul`
+    /// precompiles, as specified here:
     /// https://eips.ethereum.org/EIPS/eip-196#encoding
     fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, SerdeError> {
         // Note: although this performs modular reduction, it's safe to do so
@@ -134,11 +133,7 @@ impl BytesDeserializable for G1Affine {
         let x = deserialize_cursor(bytes, &mut cursor)?;
         let y = deserialize_cursor(bytes, &mut cursor)?;
 
-        Ok(G1Affine {
-            x,
-            y,
-            infinity: x.is_zero() && y.is_zero(),
-        })
+        Ok(G1Affine { x, y, infinity: x.is_zero() && y.is_zero() })
     }
 }
 
@@ -161,11 +156,12 @@ impl BytesSerializable for G2Affine {
     /// Serializes a G2 point into a big-endian byte array of the coefficients
     /// of its coordinates in the extension field, i.e.:
     ///
-    /// Given an element of the field extension F_p^2[i] represented as ai + b, where a and b are elements
-    /// of F_p, its serialization is the concatenation of a and b in big-endian order.
+    /// Given an element of the field extension F_p^2[i] represented as ai + b,
+    /// where a and b are elements of F_p, its serialization is the
+    /// concatenation of a and b in big-endian order.
     ///
-    /// This matches the format expected by the EVM `ecPairing` precompile, as specified here:
-    /// https://eips.ethereum.org/EIPS/eip-197#encoding
+    /// This matches the format expected by the EVM `ecPairing` precompile, as
+    /// specified here: https://eips.ethereum.org/EIPS/eip-197#encoding
     fn serialize_to_bytes(&self) -> Vec<u8> {
         let zero = G2BaseField::zero();
         let (x, y) = self.xy().unwrap_or((&zero, &zero));
@@ -191,11 +187,7 @@ impl BytesDeserializable for G2Affine {
         let x = G2BaseField { c0: x_c0, c1: x_c1 };
         let y = G2BaseField { c0: y_c0, c1: y_c1 };
 
-        Ok(G2Affine {
-            x,
-            y,
-            infinity: x.is_zero() && y.is_zero(),
-        })
+        Ok(G2Affine { x, y, infinity: x.is_zero() && y.is_zero() })
     }
 }
 
@@ -223,17 +215,12 @@ impl ScalarSerializable for ValidWalletCreateStatement {
 
 impl ScalarSerializable for ValidWalletUpdateStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
-        let mut scalars = vec![
-            self.old_shares_nullifier,
-            self.new_private_shares_commitment,
-        ];
+        let mut scalars = vec![self.old_shares_nullifier, self.new_private_shares_commitment];
         scalars.extend(&self.new_public_shares);
         scalars.push(self.merkle_root);
 
         scalars.extend(external_transfer_to_scalars(
-            self.external_transfer
-                .as_ref()
-                .unwrap_or(&ExternalTransfer::default()),
+            self.external_transfer.as_ref().unwrap_or(&ExternalTransfer::default()),
         )?);
         scalars.extend(pk_to_scalars(&self.old_pk_root));
         Ok(scalars)
@@ -252,11 +239,7 @@ impl ScalarSerializable for ValidReblindStatement {
 
 impl ScalarSerializable for OrderSettlementIndices {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
-        Ok(vec![
-            self.balance_send.into(),
-            self.balance_receive.into(),
-            self.order.into(),
-        ])
+        Ok(vec![self.balance_send.into(), self.balance_receive.into(), self.order.into()])
     }
 }
 
@@ -309,11 +292,8 @@ impl ScalarSerializable for ValidRelayerFeeSettlementStatement {
 
 impl ScalarSerializable for ValidOfflineFeeSettlementStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
-        let mut scalars: Vec<ScalarField> = vec![
-            self.merkle_root,
-            self.nullifier,
-            self.updated_wallet_commitment,
-        ];
+        let mut scalars: Vec<ScalarField> =
+            vec![self.merkle_root, self.nullifier, self.updated_wallet_commitment];
         scalars.extend(&self.updated_wallet_public_shares);
         scalars.extend(&note_ciphertext_to_scalars(&self.note_ciphertext));
         scalars.push(self.note_commitment);
@@ -355,7 +335,8 @@ fn deserialize_cursor<D: BytesDeserializable>(
 
 /// Converts a little-endian byte array into a [`BigInt`]
 pub fn bigint_from_le_bytes(bytes: &[u8]) -> Result<BigInt<NUM_U64S_FELT>, SerdeError> {
-    // This will right-pad the bytes with zero-bytes if the length is less than 8 * NUM_BYTES_U64
+    // This will right-pad the bytes with zero-bytes if the length is less than 8 *
+    // NUM_BYTES_U64
     let mut bytes_to_convert = [0_u8; NUM_BYTES_FELT];
     bytes_to_convert[..bytes.len()].copy_from_slice(bytes);
 
@@ -378,13 +359,14 @@ fn address_to_scalar(address: Address) -> Result<ScalarField, SerdeError> {
     // is the address bytes in big-endian form.
     let address_bytes = address.as_slice();
 
-    // We first left-pad the big-endian address bytes with zero-bytes to NUM_BYTES_FELT,
-    // preserving its numerical value
+    // We first left-pad the big-endian address bytes with zero-bytes to
+    // NUM_BYTES_FELT, preserving its numerical value
     let mut bytes = [0; NUM_BYTES_FELT];
     bytes[NUM_BYTES_FELT - NUM_BYTES_ADDRESS..].copy_from_slice(address_bytes);
 
-    // The circuits expect the scalar representation of the address to be its little-endian
-    // interpretation. We thus reverse the bytes before converting them to a scalar.
+    // The circuits expect the scalar representation of the address to be its
+    // little-endian interpretation. We thus reverse the bytes before converting
+    // them to a scalar.
     bytes.reverse();
     let bigint = bigint_from_le_bytes(&bytes)?;
     ScalarField::from_bigint(bigint).ok_or(SerdeError::ScalarConversion)
@@ -423,10 +405,7 @@ fn external_match_result_to_scalars(
 
 /// Converts a [`FeeTake`] into a vector of [`ScalarField`]s
 fn fee_take_to_scalars(fee_take: &FeeTake) -> Result<Vec<ScalarField>, SerdeError> {
-    Ok(vec![
-        amount_to_scalar(fee_take.relayer_fee)?,
-        amount_to_scalar(fee_take.protocol_fee)?,
-    ])
+    Ok(vec![amount_to_scalar(fee_take.relayer_fee)?, amount_to_scalar(fee_take.protocol_fee)?])
 }
 
 /// Converts a [`PublicSigningKey`] into a vector of [`ScalarField`]s
@@ -451,7 +430,8 @@ fn note_ciphertext_to_scalars(note_ciphertext: &NoteCiphertext) -> Vec<ScalarFie
     scalars
 }
 
-/// Serializes a statement type into a vector of `[ScalarField]` and wraps it in a [`PublicInputs`]
+/// Serializes a statement type into a vector of `[ScalarField]` and wraps it in
+/// a [`PublicInputs`]
 pub fn statement_to_public_inputs<S: ScalarSerializable>(
     statement: &S,
 ) -> Result<PublicInputs, SerdeError> {
@@ -463,7 +443,8 @@ pub fn scalar_to_u256(scalar: ScalarField) -> U256 {
     U256::from_be_slice(&scalar.serialize_to_bytes())
 }
 
-/// Converts a [`PublicSigningKey`] into the [`U256`] array representing its scalar serialization
+/// Converts a [`PublicSigningKey`] into the [`U256`] array representing its
+/// scalar serialization
 pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], SerdeError> {
     let scalars = pk_to_scalars(pk);
     scalars
@@ -492,8 +473,9 @@ mod tests {
         let mut rng = thread_rng();
         let a = G1Affine::rand(&mut rng);
         let res = a.serialize_to_bytes();
-        // EC precompiles return G1 points in the same format, i.e. big-endian serialization of x and y
-        // As such we can use this output to test deserialization
+        // EC precompiles return G1 points in the same format, i.e. big-endian
+        // serialization of x and y As such we can use this output to test
+        // deserialization
         let a_prime = G1Affine::deserialize_from_bytes(&res).unwrap();
         assert_eq!(a, a_prime)
     }

--- a/contracts-common/src/lib.rs
+++ b/contracts-common/src/lib.rs
@@ -1,4 +1,5 @@
-//! Common modules used throughout the project, including contracts & testing code
+//! Common modules used throughout the project, including contracts & testing
+//! code
 
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]

--- a/contracts-common/src/serde_def_types.rs
+++ b/contracts-common/src/serde_def_types.rs
@@ -1,5 +1,6 @@
-//! Types & trait implementations to enable deriving serde::{Serialize, Deserialize}
-//! on the foreign Arkworks, Alloy, and other types that we compose into complex structs.
+//! Types & trait implementations to enable deriving serde::{Serialize,
+//! Deserialize} on the foreign Arkworks, Alloy, and other types that we compose
+//! into complex structs.
 
 use alloy_primitives::{Address, FixedBytes, Uint};
 use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq2Config, FqConfig, FrConfig};
@@ -11,8 +12,9 @@ use serde_with::{serde_as, DeserializeAs, SerializeAs};
 
 use crate::types::{G1Affine, G1BaseField, G2Affine, G2BaseField, ScalarField};
 
-/// This macro implements the `SerializeAs` and `DeserializeAs` traits for a given type,
-/// allowing it to be serialized / deserialized as the remote type it mirrors.
+/// This macro implements the `SerializeAs` and `DeserializeAs` traits for a
+/// given type, allowing it to be serialized / deserialized as the remote type
+/// it mirrors.
 macro_rules! impl_serde_as {
     ($remote_type:ty, $def_type:ty, $($generics:tt)*) => {
         impl<$($generics)*> SerializeAs<$remote_type> for $def_type {

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -31,8 +31,8 @@ pub type G2BaseField = Fq2;
 /// Type alias for a 256-bit prime field element in Montgomery form
 pub type MontFp256<P> = Fp256<MontBackend<P, NUM_U64S_FELT>>;
 
-/// Preprocessed information derived from the circuit definition and universal SRS
-/// used by the verifier.
+/// Preprocessed information derived from the circuit definition and universal
+/// SRS used by the verifier.
 // TODO: Give these variable human-readable names once end-to-end verifier is complete
 #[serde_as]
 #[derive(Clone, Copy, Serialize, Deserialize, Debug)]
@@ -61,7 +61,8 @@ pub struct VerificationKey {
     pub x_h: G2Affine,
 }
 
-/// The Plonk verification keys used when verifying the matching and settlement of a trade
+/// The Plonk verification keys used when verifying the matching and settlement
+/// of a trade
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "test-helpers", derive(Clone))]
 pub struct MatchVkeys {
@@ -76,7 +77,8 @@ pub struct MatchVkeys {
 impl MatchVkeys {
     /// Convert the verification keys to a vector
     ///
-    /// We repeat `VALID COMMITMENTS` and `VALID REBLIND` twice, once for each of the parties
+    /// We repeat `VALID COMMITMENTS` and `VALID REBLIND` twice, once for each
+    /// of the parties
     pub fn to_vec(&self) -> Vec<VerificationKey> {
         [
             self.valid_commitments_vkey,
@@ -89,7 +91,8 @@ impl MatchVkeys {
     }
 }
 
-/// The Plonk verification keys used when verifying the settlement of an atomic match
+/// The Plonk verification keys used when verifying the settlement of an atomic
+/// match
 #[derive(Serialize, Deserialize)]
 pub struct MatchAtomicVkeys {
     /// The verification key for `VALID COMMITMENTS`
@@ -103,12 +106,8 @@ pub struct MatchAtomicVkeys {
 impl MatchAtomicVkeys {
     /// Convert the verification keys to a vector
     pub fn to_vec(&self) -> Vec<VerificationKey> {
-        [
-            self.valid_commitments_vkey,
-            self.valid_reblind_vkey,
-            self.valid_match_settle_atomic_vkey,
-        ]
-        .to_vec()
+        [self.valid_commitments_vkey, self.valid_reblind_vkey, self.valid_match_settle_atomic_vkey]
+            .to_vec()
     }
 }
 
@@ -140,7 +139,8 @@ pub struct MatchLinkingVkeys {
     pub valid_commitments_match_settle_1: LinkingVerificationKey,
 }
 
-/// The linking verification keys used when verifying the settlement of an atomic match
+/// The linking verification keys used when verifying the settlement of an
+/// atomic match
 #[derive(Serialize, Deserialize)]
 pub struct MatchAtomicLinkingVkeys {
     /// The verification key for the
@@ -158,7 +158,8 @@ pub struct Proof {
     /// The commitments to the wire polynomials
     #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
     pub wire_comms: [G1Affine; NUM_WIRE_TYPES],
-    /// The commitment to the grand product polynomial encoding the permutation argument (i.e., copy constraints)
+    /// The commitment to the grand product polynomial encoding the permutation
+    /// argument (i.e., copy constraints)
     #[serde_as(as = "G1AffineDef")]
     pub z_comm: G1Affine,
     /// The commitments to the split quotient polynomials
@@ -173,10 +174,12 @@ pub struct Proof {
     /// The evaluations of the wire polynomials at the challenge point `zeta`
     #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES]")]
     pub wire_evals: [ScalarField; NUM_WIRE_TYPES],
-    /// The evaluations of the permutation polynomials at the challenge point `zeta`
+    /// The evaluations of the permutation polynomials at the challenge point
+    /// `zeta`
     #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES - 1]")]
     pub sigma_evals: [ScalarField; NUM_WIRE_TYPES - 1],
-    /// The evaluation of the grand product polynomial at the challenge point `zeta * omega` (\bar{z})
+    /// The evaluation of the grand product polynomial at the challenge point
+    /// `zeta * omega` (\bar{z})
     #[serde_as(as = "ScalarFieldDef")]
     pub z_bar: ScalarField,
 }
@@ -267,12 +270,7 @@ pub struct MatchAtomicProofs {
 impl MatchAtomicProofs {
     /// Convert the proofs to a vector
     pub fn to_vec(&self) -> Vec<Proof> {
-        [
-            self.valid_commitments,
-            self.valid_reblind,
-            self.valid_match_settle_atomic,
-        ]
-        .to_vec()
+        [self.valid_commitments, self.valid_reblind, self.valid_match_settle_atomic].to_vec()
     }
 }
 
@@ -288,14 +286,16 @@ pub struct MatchAtomicLinkingProofs {
     pub valid_commitments_match_settle_atomic: LinkingProof,
 }
 
-/// The public coin challenges used throughout the Plonk protocol, obtained via a Fiat-Shamir transformation.
+/// The public coin challenges used throughout the Plonk protocol, obtained via
+/// a Fiat-Shamir transformation.
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct Challenges {
     /// The first permutation challenge, used in round 2 of the prover algorithm
     #[serde_as(as = "ScalarFieldDef")]
     pub beta: ScalarField,
-    /// The second permutation challenge, used in round 2 of the prover algorithm
+    /// The second permutation challenge, used in round 2 of the prover
+    /// algorithm
     #[serde_as(as = "ScalarFieldDef")]
     pub gamma: ScalarField,
     /// The quotient challenge, used in round 3 of the prover algorithm
@@ -307,7 +307,8 @@ pub struct Challenges {
     /// The opening challenge, used in round 5 of the prover algorithm
     #[serde_as(as = "ScalarFieldDef")]
     pub v: ScalarField,
-    /// The multipoint evaluation challenge, generated at the end of round 5 of the prover algorithm
+    /// The multipoint evaluation challenge, generated at the end of round 5 of
+    /// the prover algorithm
     #[serde_as(as = "ScalarFieldDef")]
     pub u: ScalarField,
 }
@@ -330,8 +331,8 @@ pub struct ExternalTransfer {
 }
 
 /// Auxiliary data passed alongside an external transfer to verify its validity.
-/// This includes a signature over the external transfer, and in the case of a deposit,
-/// the associated Permit2 data ([reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer))
+/// This includes a signature over the external transfer, and in the case of a
+/// deposit, the associated Permit2 data ([reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer))
 #[serde_as]
 #[derive(Default, Serialize, Deserialize)]
 pub struct TransferAuxData {
@@ -349,9 +350,9 @@ pub struct TransferAuxData {
 
 /// A simple erc20 transfer
 ///
-/// For deposits, we directly use the erc20 contracts `transfer` function assuming that
-/// the caller has approved the darkpool contract to spend the deposit. This means that no
-/// permit2 logic is needed.
+/// For deposits, we directly use the erc20 contracts `transfer` function
+/// assuming that the caller has approved the darkpool contract to spend the
+/// deposit. This means that no permit2 logic is needed.
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct SimpleErc20Transfer {
@@ -372,22 +373,12 @@ pub struct SimpleErc20Transfer {
 impl SimpleErc20Transfer {
     /// Create a new withdraw transfer
     pub fn new_withdraw(to: Address, mint: Address, amount: U256) -> Self {
-        Self {
-            mint,
-            account_addr: to,
-            amount,
-            is_withdrawal: true,
-        }
+        Self { mint, account_addr: to, amount, is_withdrawal: true }
     }
 
     /// Create a new deposit transfer
     pub fn new_deposit(from: Address, mint: Address, amount: U256) -> Self {
-        Self {
-            mint,
-            account_addr: from,
-            amount,
-            is_withdrawal: false,
-        }
+        Self { mint, account_addr: from, amount, is_withdrawal: false }
     }
 }
 
@@ -407,9 +398,7 @@ pub struct FeeTake {
 impl FeeTake {
     /// Get the total fee taken
     pub fn total(&self) -> U256 {
-        self.relayer_fee
-            .checked_add(self.protocol_fee)
-            .expect("fees overflow") // unwrap here for interface simplicity
+        self.relayer_fee.checked_add(self.protocol_fee).expect("fees overflow") // unwrap here for interface simplicity
     }
 }
 
@@ -458,8 +447,8 @@ impl ExternalMatchResult {
 }
 
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.
-/// Since the secp256k1 base field order is larger than that of Bn254's scalar field,
-/// it takes 2 Bn254 scalar field elements to represent each coordinate.
+/// Since the secp256k1 base field order is larger than that of Bn254's scalar
+/// field, it takes 2 Bn254 scalar field elements to represent each coordinate.
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct PublicSigningKey {
@@ -804,12 +793,7 @@ pub struct MatchAtomicPublicInputs {
 impl MatchAtomicPublicInputs {
     /// Convert the public inputs to a vector
     pub fn to_vec(self) -> Vec<PublicInputs> {
-        [
-            self.valid_commitments,
-            self.valid_reblind,
-            self.valid_match_settle_atomic,
-        ]
-        .to_vec()
+        [self.valid_commitments, self.valid_reblind, self.valid_match_settle_atomic].to_vec()
     }
 }
 

--- a/contracts-core/src/crypto/ecdsa.rs
+++ b/contracts-core/src/crypto/ecdsa.rs
@@ -8,8 +8,9 @@ use contracts_common::{
 };
 use ruint::aliases::U256;
 
-/// Verify a secp256k1 ECDSA signature given a public key (extracted from a `VALID_WALLET_UPDATE` statement),
-/// a (un-hashed) message, and a signature (in the format expected by the `ecRecover` precompile, i.e. including a `v`
+/// Verify a secp256k1 ECDSA signature given a public key (extracted from a
+/// `VALID_WALLET_UPDATE` statement), a (un-hashed) message, and a signature (in
+/// the format expected by the `ecRecover` precompile, i.e. including a `v`
 /// recovery identifier)
 pub fn ecdsa_verify<H: HashBackend, E: EcRecoverBackend>(
     pubkey: &PublicSigningKey,
@@ -24,11 +25,12 @@ pub fn ecdsa_verify<H: HashBackend, E: EcRecoverBackend>(
 // | HELPERS |
 // -----------
 
-/// Converts a public signing key, as expressed in the `VALID_WALLET_UPDATE` statement,
-/// into an Ethereum address.
+/// Converts a public signing key, as expressed in the `VALID_WALLET_UPDATE`
+/// statement, into an Ethereum address.
 pub fn pubkey_to_address<H: HashBackend>(pubkey: &PublicSigningKey) -> [u8; NUM_BYTES_ADDRESS] {
-    // An Ethereum address is obtained from the rightmost 20 bytes of the Keccak-256 hash
-    // of the public key's x & y affine coordinates, concatenated in big-endian form.
+    // An Ethereum address is obtained from the rightmost 20 bytes of the Keccak-256
+    // hash of the public key's x & y affine coordinates, concatenated in
+    // big-endian form.
 
     let scalar_mod = U256::from_limbs(ScalarField::MODULUS.0);
 
@@ -45,9 +47,7 @@ pub fn pubkey_to_address<H: HashBackend>(pubkey: &PublicSigningKey) -> [u8; NUM_
     let pubkey_bytes = [x_bytes, y_bytes].concat();
 
     // Unwrapping here is safe because we know that the hash output is 32 bytes long
-    H::hash(&pubkey_bytes)[HASH_OUTPUT_SIZE - NUM_BYTES_ADDRESS..]
-        .try_into()
-        .unwrap()
+    H::hash(&pubkey_bytes)[HASH_OUTPUT_SIZE - NUM_BYTES_ADDRESS..].try_into().unwrap()
 }
 
 #[cfg(test)]
@@ -67,10 +67,7 @@ mod tests {
         ) -> Result<[u8; NUM_BYTES_ADDRESS], EcdsaError> {
             let signature: Signature = signature.as_slice().try_into().map_err(|_| EcdsaError)?;
             let message_hash: RecoveryMessage = RecoveryMessage::Hash(message_hash.into());
-            Ok(signature
-                .recover(message_hash)
-                .map_err(|_| EcdsaError)?
-                .into())
+            Ok(signature.recover(message_hash).map_err(|_| EcdsaError)?.into())
         }
     }
 

--- a/contracts-core/src/crypto/poseidon.rs
+++ b/contracts-core/src/crypto/poseidon.rs
@@ -3,7 +3,8 @@
 use contracts_common::types::ScalarField;
 use renegade_crypto::hash::Poseidon2Sponge;
 
-/// Computes the Poseidon2 hash of the given scalar inputs, squeezing a single-element output
+/// Computes the Poseidon2 hash of the given scalar inputs, squeezing a
+/// single-element output
 pub fn compute_poseidon_hash(inputs: &[ScalarField]) -> ScalarField {
     let mut sponge = Poseidon2Sponge::new();
     sponge.hash(inputs)

--- a/contracts-core/src/lib.rs
+++ b/contracts-core/src/lib.rs
@@ -1,4 +1,5 @@
-//! Core smart contract functionality, defined agnostically of running in the Stylus VM
+//! Core smart contract functionality, defined agnostically of running in the
+//! Stylus VM
 
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -1,4 +1,5 @@
-//! A simple transcript used for computing challenge values via the Fiat-Shamir transformation.
+//! A simple transcript used for computing challenge values via the Fiat-Shamir
+//! transformation.
 
 use alloc::vec::Vec;
 use ark_ff::{BigInt, BigInteger, PrimeField};
@@ -51,8 +52,9 @@ impl<H: HashBackend> Transcript<H> {
 
         // Sample the first `HASH_SAMPLE_BYTES` bytes of hash output into a scalar.
 
-        // We begin by taking the lowest `NUM_BYTES_FELT-1` bytes of the hash output in little-endian order
-        // and converting them into a scalar directly, as no reduction is needed.
+        // We begin by taking the lowest `NUM_BYTES_FELT-1` bytes of the hash output in
+        // little-endian order and converting them into a scalar directly, as no
+        // reduction is needed.
         let (bytes_to_directly_convert, remaining_bytes) =
             self.state[..HASH_SAMPLE_BYTES].split_at(SPLIT_INDEX);
         let res = ScalarField::from_bigint(bigint_from_le_bytes(bytes_to_directly_convert)?)
@@ -63,8 +65,9 @@ impl<H: HashBackend> Transcript<H> {
         let mut rem_scalar = ScalarField::from_bigint(bigint_from_le_bytes(remaining_bytes)?)
             .ok_or(SerdeError::ScalarConversion)?;
 
-        // Now, we shift the latter scalar left by 31 bytes, which is equivalent to multiplying by 2^248.
-        // Reduction is done for us by using modular multiplication for the shift.
+        // Now, we shift the latter scalar left by 31 bytes, which is equivalent to
+        // multiplying by 2^248. Reduction is done for us by using modular
+        // multiplication for the shift.
 
         // 2^248 in big endian = 1 followed by 248 zeroes
         let mut shift_bits = [false; (SPLIT_INDEX) * 8 + 1];
@@ -73,7 +76,8 @@ impl<H: HashBackend> Transcript<H> {
             .ok_or(SerdeError::ScalarConversion)?;
         rem_scalar *= shift_by_31_bytes;
 
-        // Finally, we add the two scalars together. Again, reduction is done for us by using modular addition.
+        // Finally, we add the two scalars together. Again, reduction is done for us by
+        // using modular addition.
         Ok(res + rem_scalar)
     }
 
@@ -89,8 +93,9 @@ impl<H: HashBackend> Transcript<H> {
         self.append_message(&ScalarField::MODULUS_BIT_SIZE.to_le_bytes());
         self.append_message(&vkey.n.to_le_bytes());
         self.append_message(&vkey.l.to_le_bytes());
-        // For equivalency with Jellyfish, which expects as many coset constants as there are wire types,
-        // we inject an identity constant, which generates the first coset
+        // For equivalency with Jellyfish, which expects as many coset constants as
+        // there are wire types, we inject an identity constant, which generates
+        // the first coset
         self.append_message(&serialize_scalars_for_transcript(&vkey.k));
         self.append_message(&serialize_g1s_for_transcript(&vkey.q_comms));
         self.append_message(&serialize_g1s_for_transcript(&vkey.sigma_comms));
@@ -98,20 +103,23 @@ impl<H: HashBackend> Transcript<H> {
 
         // Prover round 1: absorb wire polynomial commitments
         self.append_message(&serialize_g1s_for_transcript(&proof.wire_comms));
-        // Here, for consistency with the Jellyfish implementation, we squeeze an unused challenge
-        // `tau`, which would be used for Plookup
+        // Here, for consistency with the Jellyfish implementation, we squeeze an unused
+        // challenge `tau`, which would be used for Plookup
         self.get_and_append_challenge()?;
 
-        // Prover round 2: squeeze beta & gamma challenges, absorb grand product polynomial commitment
+        // Prover round 2: squeeze beta & gamma challenges, absorb grand product
+        // polynomial commitment
         let beta = self.get_and_append_challenge()?;
         let gamma = self.get_and_append_challenge()?;
         self.append_message(&serialize_g1s_for_transcript(&[proof.z_comm]));
 
-        // Prover round 3: squeeze alpha challenge, absorb split quotient polynomial commitments
+        // Prover round 3: squeeze alpha challenge, absorb split quotient polynomial
+        // commitments
         let alpha = self.get_and_append_challenge()?;
         self.append_message(&serialize_g1s_for_transcript(&proof.quotient_comms));
 
-        // Prover round 4: squeeze zeta challenge, absorb wire, permutation, and grand product polynomial evaluations
+        // Prover round 4: squeeze zeta challenge, absorb wire, permutation, and grand
+        // product polynomial evaluations
         let zeta = self.get_and_append_challenge()?;
         self.append_message(&serialize_scalars_for_transcript(&proof.wire_evals));
         self.append_message(&serialize_scalars_for_transcript(&proof.sigma_evals));
@@ -125,14 +133,7 @@ impl<H: HashBackend> Transcript<H> {
         // Squeeze u challenge
         let u = self.get_and_append_challenge()?;
 
-        Ok(Challenges {
-            beta,
-            gamma,
-            alpha,
-            zeta,
-            v,
-            u,
-        })
+        Ok(Challenges { beta, gamma, alpha, zeta, v, u })
     }
 
     /// Compute the eta challenge used in the proof linking protocol,
@@ -154,8 +155,8 @@ impl<H: HashBackend> Transcript<H> {
 
 /// Serializes a slice of scalars into a little-endian byte array.
 ///
-/// This is the format expected by the transcript, whereas our serialization format
-/// is big-endian.
+/// This is the format expected by the transcript, whereas our serialization
+/// format is big-endian.
 pub fn serialize_scalars_for_transcript(scalars: &[ScalarField]) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(scalars.len() * NUM_BYTES_FELT);
     for scalar in scalars {
@@ -166,7 +167,8 @@ pub fn serialize_scalars_for_transcript(scalars: &[ScalarField]) -> Vec<u8> {
     bytes
 }
 
-/// Serializes a slice of [`G1Affine`]s into a the format expected by the transcript
+/// Serializes a slice of [`G1Affine`]s into a the format expected by the
+/// transcript
 pub fn serialize_g1s_for_transcript(points: &[G1Affine]) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(points.len() * NUM_BYTES_FELT * 2);
     for point in points {
@@ -274,9 +276,8 @@ pub mod tests {
         let public_inputs = PublicInputs(random_scalars(L, &mut rng));
 
         let mut stylus_transcript = Transcript::<NativeHasher>::new();
-        let challenges = stylus_transcript
-            .compute_plonk_challenges(&vkey, &proof, &public_inputs)
-            .unwrap();
+        let challenges =
+            stylus_transcript.compute_plonk_challenges(&vkey, &proof, &public_inputs).unwrap();
 
         let jf_challenges = get_jf_challenges(&jf_vkey, &public_inputs.0, &jf_proof, &None);
 

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -1,7 +1,9 @@
 //! The Plonk verifier, as described in section 8.3 of the paper: https://eprint.iacr.org/2019/953.pdf.
-//! Each of the steps of the verification algorithm described in the paper are represented as separate helper functions.
-//! This version of the verification algorithm currently only supports fan-in 2, fan-out 1 gates.
-//! The verifier is an object containing a verification key, a transcript, and a backend for elliptic curve arithmetic.
+//! Each of the steps of the verification algorithm described in the paper are
+//! represented as separate helper functions. This version of the verification
+//! algorithm currently only supports fan-in 2, fan-out 1 gates. The verifier is
+//! an object containing a verification key, a transcript, and a backend for
+//! elliptic curve arithmetic.
 
 pub mod errors;
 
@@ -24,7 +26,8 @@ use crate::transcript::{serialize_scalars_for_transcript, Transcript};
 
 use self::errors::VerifierError;
 
-/// The verifier struct, which is defined generically over elliptic curve arithmetic and hashing backends
+/// The verifier struct, which is defined generically over elliptic curve
+/// arithmetic and hashing backends
 pub struct Verifier<G: G1ArithmeticBackend, H: HashBackend> {
     #[doc(hidden)]
     _phantom_g: PhantomData<G>,
@@ -34,10 +37,7 @@ pub struct Verifier<G: G1ArithmeticBackend, H: HashBackend> {
 
 impl<G: G1ArithmeticBackend, H: HashBackend> Default for Verifier<G, H> {
     fn default() -> Self {
-        Self {
-            _phantom_g: PhantomData,
-            _phantom_h: PhantomData,
-        }
+        Self { _phantom_g: PhantomData, _phantom_h: PhantomData }
     }
 }
 
@@ -55,7 +55,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
     /// Batch-verifies a set of proofs
     ///
-    /// Optionally, additional opening elements may be passed to facilitate proof-linking
+    /// Optionally, additional opening elements may be passed to facilitate
+    /// proof-linking
     pub fn batch_verify(
         vkey_batch: &[VerificationKey],
         proof_batch: &[Proof],
@@ -76,9 +77,7 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
         opening_elems.g1_lhs_elems.extend(plonk_g1_lhs_elems);
         opening_elems.g1_rhs_elems.extend(plonk_g1_rhs_elems);
-        opening_elems
-            .transcript_elements
-            .extend(plonk_transcript_elements);
+        opening_elems.transcript_elements.extend(plonk_transcript_elements);
 
         Self::batch_opening(&opening_elems, x_h, h)
     }
@@ -106,9 +105,10 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
             let proof = &proof_batch[i];
             let public_inputs = &public_inputs_batch[i];
 
-            // Steps 1 & 2 of the verifier algorithm are assumed to be completed by this point,
-            // by virtue of the type system. I.e., the proof should be deserialized in a manner such that
-            // elements not in the scalar field, and points not in G1, would cause a panic.
+            // Steps 1 & 2 of the verifier algorithm are assumed to be completed by this
+            // point, by virtue of the type system. I.e., the proof should be
+            // deserialized in a manner such that elements not in the scalar
+            // field, and points not in G1, would cause a panic.
 
             Self::step_3(public_inputs, vkey)?;
 
@@ -148,12 +148,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
             let lagrange_1_eval = Self::step_6(lagrange_bases, domain_elements);
 
-            let pi_eval = Self::step_7(
-                lagrange_1_eval,
-                lagrange_bases,
-                domain_elements,
-                public_inputs,
-            );
+            let pi_eval =
+                Self::step_7(lagrange_1_eval, lagrange_bases, domain_elements, public_inputs);
 
             let r_0 = Self::step_8(pi_eval, lagrange_1_eval, challenges, proof);
 
@@ -177,15 +173,12 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
             transcript_elements.push(challenges.u);
         }
 
-        Ok(OpeningElems {
-            g1_lhs_elems,
-            g1_rhs_elems,
-            transcript_elements,
-        })
+        Ok(OpeningElems { g1_lhs_elems, g1_rhs_elems, transcript_elements })
     }
 
     /// Computes the elements used in the final KZG batch opening pairing check
-    /// for the linking proofs involved in the matching and settlement of a trade.
+    /// for the linking proofs involved in the matching and settlement of a
+    /// trade.
     pub fn prep_match_linking_proofs_opening(
         match_proofs: MatchProofs,
         match_linking_vkeys: MatchLinkingVkeys,
@@ -231,7 +224,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
     }
 
     /// Computes the elements used in the final KZG batch opening pairing check
-    /// for the linking proofs involved in the matching and settlement of an atomic match.
+    /// for the linking proofs involved in the matching and settlement of an
+    /// atomic match.
     pub fn prep_atomic_match_linking_proofs_opening(
         match_atomic_proofs: MatchAtomicProofs,
         match_atomic_linking_vkeys: MatchAtomicLinkingVkeys,
@@ -261,7 +255,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         Self::prep_linking_instances(linking_instances)
     }
 
-    /// Prepares the pairing product values for a set of link-proof verification instances
+    /// Prepares the pairing product values for a set of link-proof verification
+    /// instances
     fn prep_linking_instances(
         linking_instances: Vec<LinkingInstance>,
     ) -> Result<OpeningElems, VerifierError> {
@@ -281,28 +276,19 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
             transcript_elements.push(eta);
         }
 
-        Ok(OpeningElems {
-            g1_lhs_elems,
-            g1_rhs_elems,
-            transcript_elements,
-        })
+        Ok(OpeningElems { g1_lhs_elems, g1_rhs_elems, transcript_elements })
     }
 
-    /// Computes the KZG opening pairing check elements for a single linking proof
+    /// Computes the KZG opening pairing check elements for a single linking
+    /// proof
     pub fn prep_linking_proof_opening_elems(
         linking_vkey: LinkingVerificationKey,
         linking_proof: LinkingProof,
         wire_poly_comms: (G1Affine, G1Affine),
     ) -> Result<(G1Affine, G1Affine, ScalarField), VerifierError> {
-        let LinkingVerificationKey {
-            link_group_generator,
-            link_group_offset,
-            link_group_size,
-        } = linking_vkey;
-        let LinkingProof {
-            linking_poly_opening,
-            linking_quotient_poly_comm,
-        } = linking_proof;
+        let LinkingVerificationKey { link_group_generator, link_group_offset, link_group_size } =
+            linking_vkey;
+        let LinkingProof { linking_poly_opening, linking_quotient_poly_comm } = linking_proof;
         let one = ScalarField::one();
 
         // Compute eta challenge after absorbing commitments to wiring polynomials
@@ -329,11 +315,7 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         // Compute commitment to linking polynomial
         let linking_poly_comm = G::msm(
             &[one, -one, -subdomain_zero_poly_eval],
-            &[
-                wire_poly_comms.0,
-                wire_poly_comms.1,
-                linking_quotient_poly_comm,
-            ],
+            &[wire_poly_comms.0, wire_poly_comms.1, linking_quotient_poly_comm],
         )?;
 
         // Prepare LHS & RHS G1 elements for pairing check
@@ -353,8 +335,7 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         let domain_size = if n.is_power_of_two() {
             n
         } else {
-            n.checked_next_power_of_two()
-                .ok_or(VerifierError::InvalidInputs)?
+            n.checked_next_power_of_two().ok_or(VerifierError::InvalidInputs)?
         };
         let omega =
             ScalarField::get_root_of_unity(domain_size).ok_or(VerifierError::InvalidInputs)?;
@@ -365,15 +346,14 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
             domain_elements.push(domain_elements[i] * omega);
         }
 
-        let lagrange_basis_denominators: Vec<ScalarField> = (0..l)
-            .map(|i| ScalarField::from(n) * (zeta - domain_elements[i]))
-            .collect();
+        let lagrange_basis_denominators: Vec<ScalarField> =
+            (0..l).map(|i| ScalarField::from(n) * (zeta - domain_elements[i])).collect();
 
         Ok((domain_size, domain_elements, lagrange_basis_denominators))
     }
 
-    /// Performs Montgomery batch inversion on the denominators of the Lagrange basis polynomials
-    /// for a batch of proofs
+    /// Performs Montgomery batch inversion on the denominators of the Lagrange
+    /// basis polynomials for a batch of proofs
     fn batch_invert_lagrange_basis_denominators(
         lagrange_basis_denominators: &mut [ScalarField],
         zero_poly_evals_batch: &[ScalarField],
@@ -404,8 +384,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
     /// Validate public inputs
     ///
-    /// Similarly to the assumptions for step 2, the membership of the public inputs in the scalar field
-    /// should be enforced by the type system.
+    /// Similarly to the assumptions for step 2, the membership of the public
+    /// inputs in the scalar field should be enforced by the type system.
     fn step_3(public_inputs: &PublicInputs, vkey: &VerificationKey) -> Result<(), VerifierError> {
         if public_inputs.0.len() != vkey.l as usize {
             return Err(VerifierError::InvalidInputs);
@@ -461,15 +441,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         challenges: &Challenges,
         proof: &Proof,
     ) -> ScalarField {
-        let Challenges {
-            alpha, beta, gamma, ..
-        } = challenges;
-        let Proof {
-            wire_evals,
-            sigma_evals,
-            z_bar,
-            ..
-        } = proof;
+        let Challenges { alpha, beta, gamma, .. } = challenges;
+        let Proof { wire_evals, sigma_evals, z_bar, .. } = proof;
 
         let mut r_0 = pi_eval - lagrange_1_eval * *alpha * *alpha;
         let mut evals_rlc = alpha * z_bar * (wire_evals[NUM_WIRE_TYPES - 1] + gamma);
@@ -535,17 +508,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         challenges: &Challenges,
     ) -> Result<G1Affine, VerifierError> {
         let VerificationKey { k, .. } = vkey;
-        let Proof {
-            wire_evals, z_comm, ..
-        } = proof;
-        let Challenges {
-            alpha,
-            beta,
-            gamma,
-            zeta,
-            u,
-            ..
-        } = challenges;
+        let Proof { wire_evals, z_comm, .. } = proof;
+        let Challenges { alpha, beta, gamma, zeta, u, .. } = challenges;
 
         let mut z_scalar_coeff = *alpha;
         for i in 0..wire_evals.len() {
@@ -563,15 +527,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         challenges: &Challenges,
     ) -> Result<G1Affine, VerifierError> {
         let VerificationKey { sigma_comms, .. } = vkey;
-        let Proof {
-            wire_evals,
-            sigma_evals,
-            z_bar,
-            ..
-        } = proof;
-        let Challenges {
-            alpha, beta, gamma, ..
-        } = challenges;
+        let Proof { wire_evals, sigma_evals, z_bar, .. } = proof;
+        let Challenges { alpha, beta, gamma, .. } = challenges;
 
         let mut final_sigma_scalar_coeff = ScalarField::one();
         for i in 0..NUM_WIRE_TYPES - 1 {
@@ -593,10 +550,10 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         let Challenges { zeta, .. } = challenges;
         let one = ScalarField::one();
 
-        // In the Jellyfish implementation, they multiply each split quotient commtiment by increaseing powers of
-        // zeta^{n+2}, as opposed to zeta^n, as in the paper.
-        // This is in order to "achieve better balance among degrees of all splitting
-        // polynomials (especially the highest-degree/last one)"
+        // In the Jellyfish implementation, they multiply each split quotient commtiment
+        // by increaseing powers of zeta^{n+2}, as opposed to zeta^n, as in the
+        // paper. This is in order to "achieve better balance among degrees of
+        // all splitting polynomials (especially the highest-degree/last one)"
         // (As indicated in the doc comment here: https://github.com/EspressoSystems/jellyfish/blob/main/plonk/src/proof_system/prover.rs#L893)
         let zeta_to_n_plus_two = (zero_poly_eval + one) * zeta * zeta;
 
@@ -631,7 +588,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
     /// Compute group-encoded batch evaluation [E]1
     ///
-    /// We negate the scalar here to obtain -[E]1 so that we can avoid another EC scalar mul in step 12
+    /// We negate the scalar here to obtain -[E]1 so that we can avoid another
+    /// EC scalar mul in step 12
     fn step_11(
         r_0: ScalarField,
         v_powers: &[ScalarField; NUM_WIRE_TYPES * 2],
@@ -640,12 +598,7 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         challenges: &Challenges,
     ) -> Result<G1Affine, VerifierError> {
         let VerificationKey { g, .. } = vkey;
-        let Proof {
-            wire_evals,
-            sigma_evals,
-            z_bar,
-            ..
-        } = proof;
+        let Proof { wire_evals, sigma_evals, z_bar, .. } = proof;
         let Challenges { u, .. } = challenges;
 
         let mut e = -r_0;
@@ -663,8 +616,8 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
     /// Compute G1 elements to be used in the final pairing check
     /// for the given proof.
     ///
-    /// This is the final G1 arithmetic done in step 12 of the verifier algorithm
-    /// before the pairing check.
+    /// This is the final G1 arithmetic done in step 12 of the verifier
+    /// algorithm before the pairing check.
     fn step_12_part_1(
         f_1: G1Affine,
         neg_e_1: G1Affine,
@@ -672,11 +625,7 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
         proof: &Proof,
         challenges: &Challenges,
     ) -> Result<(G1Affine, G1Affine), VerifierError> {
-        let Proof {
-            w_zeta,
-            w_zeta_omega,
-            ..
-        } = proof;
+        let Proof { w_zeta, w_zeta_omega, .. } = proof;
         let Challenges { zeta, u, .. } = challenges;
         let one = ScalarField::one();
 
@@ -692,14 +641,16 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 
     /// Compute the final pairing check for a batch of proofs.
     ///
-    /// For the verification of a single proof, we do a pairing check of the form:
-    /// e(A, [x]2) == e(B, [1]2)
+    /// For the verification of a single proof, we do a pairing check of the
+    /// form: e(A, [x]2) == e(B, [1]2)
     ///
-    /// Now, for batch verification over `m` proofs, we extend the pairing check to the following:
-    /// e(A0 + ... + r^{m-1} * Am, [x]2) = e(B0 + ... + r^{m-1} * Bm, [1]2)
+    /// Now, for batch verification over `m` proofs, we extend the pairing check
+    /// to the following: e(A0 + ... + r^{m-1} * Am, [x]2) = e(B0 + ... +
+    /// r^{m-1} * Bm, [1]2)
     ///
-    /// By the Schwartz-Zippel lemma, for a random `r`, this check will succeed with overwhelming
-    /// probability if and only if the individual pairing checks do.
+    /// By the Schwartz-Zippel lemma, for a random `r`, this check will succeed
+    /// with overwhelming probability if and only if the individual pairing
+    /// checks do.
     ///
     /// This is taken from the Jellyfish implementation:
     /// https://github.com/renegade-fi/mpc-jellyfish/blob/main/plonk/src/proof_system/verifier.rs#L199
@@ -724,18 +675,18 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
             transcript.append_message(&serialize_scalars_for_transcript(
                 &opening_elems.transcript_elements,
             ));
-            transcript
-                .get_and_append_challenge()
-                .map_err(|_| VerifierError::ScalarConversion)?
+            transcript.get_and_append_challenge().map_err(|_| VerifierError::ScalarConversion)?
         };
 
-        // Compute successive powers of `r`, these are the coefficients in the random linear combination
+        // Compute successive powers of `r`, these are the coefficients in the random
+        // linear combination
         let mut r_powers = vec![ScalarField::one(); num_proofs];
         for i in 1..num_proofs {
             r_powers[i] = r_powers[i - 1] * r;
         }
 
-        // Compute the random linear combinations of G1 elements for the verification instances.
+        // Compute the random linear combinations of G1 elements for the verification
+        // instances.
         let lhs_rlc = G::msm(&r_powers, &opening_elems.g1_lhs_elems)?;
         let rhs_rlc = G::msm(&r_powers, &opening_elems.g1_rhs_elems)?;
 
@@ -812,15 +763,11 @@ mod tests {
     /// Generate a single linking proof and the associated data needed
     /// to verify it.
     ///
-    /// The simplest way to do this is to use the dummy `VALID REBLIND` and `VALID COMMITMENTS`
-    /// circuits.
+    /// The simplest way to do this is to use the dummy `VALID REBLIND` and
+    /// `VALID COMMITMENTS` circuits.
     fn gen_single_link_proof_and_vkey<R: CryptoRng + RngCore>(
         rng: &mut R,
-    ) -> (
-        LinkingProof,
-        LinkingVerificationKey,
-        (ProofLinkingHint, ProofLinkingHint),
-    ) {
+    ) -> (LinkingProof, LinkingVerificationKey, (ProofLinkingHint, ProofLinkingHint)) {
         let valid_commitments_statement = dummy_circuit_type(rng);
         let valid_reblind_statement = dummy_circuit_type(rng);
 
@@ -1025,10 +972,7 @@ mod tests {
             Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_linking_proof_opening_elems(
                 linking_vkey,
                 link_proof,
-                (
-                    lhs_link_hint.linking_wire_comm.0,
-                    rhs_link_hint.linking_wire_comm.0,
-                ),
+                (lhs_link_hint.linking_wire_comm.0, rhs_link_hint.linking_wire_comm.0),
             )
             .unwrap();
 
@@ -1061,10 +1005,7 @@ mod tests {
             Verifier::<ArkG1ArithmeticBackend, NativeHasher>::prep_linking_proof_opening_elems(
                 linking_vkey,
                 link_proof,
-                (
-                    lhs_link_hint.linking_wire_comm.0,
-                    rhs_link_hint.linking_wire_comm.0,
-                ),
+                (lhs_link_hint.linking_wire_comm.0, rhs_link_hint.linking_wire_comm.0),
             )
             .unwrap();
 

--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -63,8 +63,9 @@ pub fn check_root_in_history<C: CoreContractStorage, S: TopLevelStorage + Borrow
     assert_result!(res, ROOT_NOT_IN_HISTORY_ERROR_MESSAGE)
 }
 
-/// Fetches the verification keys by their associated method selector on the vkeys contract.
-/// This assumes that the vkeys contract method takes no arguments and returns a single `bytes` value.
+/// Fetches the verification keys by their associated method selector on the
+/// vkeys contract. This assumes that the vkeys contract method takes no
+/// arguments and returns a single `bytes` value.
 pub fn fetch_vkeys<C: CoreContractStorage, S: TopLevelStorage + Borrow<C>>(
     s: &S,
     selector: &[u8],
@@ -81,7 +82,8 @@ pub fn fetch_vkeys<C: CoreContractStorage, S: TopLevelStorage + Borrow<C>>(
 
 /// Calls the verifier contract with the given selector.
 ///
-/// Assumes that the argument type is a single `bytes` value and the return type is a single `bool`.
+/// Assumes that the argument type is a single `bytes` value and the return type
+/// is a single `bool`.
 pub fn call_verifier<Core, S, C>(
     storage: &S,
     args: <C::Parameters<'_> as SolType>::RustType,
@@ -141,18 +143,15 @@ pub fn mark_public_blinder_used<C: CoreContractStorage, S: TopLevelStorage + Bor
     // First check that the blinder hasn't been used
     let this = s.borrow_mut();
     let blinder = scalar_to_u256(blinder);
-    assert_result!(
-        !this.public_blinder_set().get(blinder),
-        PUBLIC_BLINDER_USED_ERROR_MESSAGE
-    )?;
+    assert_result!(!this.public_blinder_set().get(blinder), PUBLIC_BLINDER_USED_ERROR_MESSAGE)?;
 
     // Mark the blinder as used
     this.public_blinder_set_mut().insert(blinder, true);
     Ok(())
 }
 
-/// Prepares the wallet shares for insertion into the Merkle tree by converting them
-/// to a vector of [`U256`]
+/// Prepares the wallet shares for insertion into the Merkle tree by converting
+/// them to a vector of [`U256`]
 pub fn prepare_wallet_shares_for_insertion(
     private_shares_commitment: ScalarField,
     public_wallet_shares: &[ScalarField],
@@ -164,8 +163,9 @@ pub fn prepare_wallet_shares_for_insertion(
     total_wallet_shares
 }
 
-/// Prepares the private shares commitment & public wallet shares for insertion into the Merkle
-/// tree and delegate-calls the appropriate method on the Merkle contract
+/// Prepares the private shares commitment & public wallet shares for insertion
+/// into the Merkle tree and delegate-calls the appropriate method on the Merkle
+/// contract
 pub fn insert_wallet_commitment_to_merkle_tree<
     C: CoreContractStorage,
     S: TopLevelStorage + BorrowMut<C>,
@@ -183,9 +183,9 @@ pub fn insert_wallet_commitment_to_merkle_tree<
         .map(|_| ())
 }
 
-/// Prepares the private shares commitment & public wallet shares for insertion into the Merkle
-/// tree, as well as the signature & pubkey for verification, and delegate-calls the appropriate
-/// method on the Merkle contract
+/// Prepares the private shares commitment & public wallet shares for insertion
+/// into the Merkle tree, as well as the signature & pubkey for verification,
+/// and delegate-calls the appropriate method on the Merkle contract
 pub fn insert_signed_wallet_commitment_to_merkle_tree<
     C: CoreContractStorage,
     S: TopLevelStorage + BorrowMut<C>,
@@ -207,11 +207,7 @@ pub fn insert_signed_wallet_commitment_to_merkle_tree<
     delegate_call_helper::<verifyStateSigAndInsertCall>(
         s,
         merkle_address,
-        (
-            total_wallet_shares,
-            wallet_commitment_signature.to_vec().into(),
-            old_pk_root_u256s,
-        ),
+        (total_wallet_shares, wallet_commitment_signature.to_vec().into(), old_pk_root_u256s),
     )
     .map(|_| ())
 }
@@ -262,12 +258,7 @@ pub fn rotate_wallet<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
     new_wallet_private_shares_commitment: ScalarField,
     new_wallet_public_shares: &[ScalarField],
 ) -> Result<(), Vec<u8>> {
-    check_wallet_rotation(
-        s,
-        old_wallet_nullifier,
-        merkle_root,
-        new_wallet_public_shares,
-    )?;
+    check_wallet_rotation(s, old_wallet_nullifier, merkle_root, new_wallet_public_shares)?;
     insert_wallet_commitment_to_merkle_tree(
         s,
         new_wallet_private_shares_commitment,
@@ -286,12 +277,7 @@ pub fn rotate_wallet_with_signature<C: CoreContractStorage, S: TopLevelStorage +
     new_wallet_commitment_signature: Vec<u8>,
     old_pk_root: PublicSigningKey,
 ) -> Result<(), Vec<u8>> {
-    check_wallet_rotation(
-        s,
-        old_wallet_nullifier,
-        merkle_root,
-        new_wallet_public_shares,
-    )?;
+    check_wallet_rotation(s, old_wallet_nullifier, merkle_root, new_wallet_public_shares)?;
     insert_signed_wallet_commitment_to_merkle_tree(
         s,
         new_wallet_private_shares_commitment,
@@ -339,9 +325,7 @@ pub fn commit_note<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
     let merkle_address = s.borrow_mut().merkle_address();
     delegate_call_helper::<insertNoteCommitmentCall>(s, merkle_address, (note_commitment_u256,))?;
 
-    evm::log(NotePosted {
-        note_commitment: note_commitment_u256,
-    });
+    evm::log(NotePosted { note_commitment: note_commitment_u256 });
 
     Ok(())
 }
@@ -361,9 +345,7 @@ pub fn log_blinder_used<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C
 
     // Log the wallet update
     let blinder_u256 = scalar_to_u256(wallet_blinder_share);
-    evm::log(WalletUpdated {
-        wallet_blinder_share: blinder_u256,
-    });
+    evm::log(WalletUpdated { wallet_blinder_share: blinder_u256 });
 
     Ok(())
 }

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -1,7 +1,7 @@
 //! The core settlement contract is responsible for the settlement of trades
-//! This contract assumes it is being delegate-called by the "outer" darkpool contract
-//! and that certain storage elements are set by the outer contract. As such, its storage
-//! layout must exactly align with that of the outer contract.
+//! This contract assumes it is being delegate-called by the "outer" darkpool
+//! contract and that certain storage elements are set by the outer contract. As
+//! such, its storage layout must exactly align with that of the outer contract.
 
 use core::borrow::BorrowMut;
 
@@ -50,7 +50,8 @@ use super::CoreContractStorage;
 
 /// The core settlement contract's storage layout.
 /// Many storage elements are not used in the core settlement contract,
-/// but are listed here so that the storage layout lines up with that of the darkpool contract.
+/// but are listed here so that the storage layout lines up with that of the
+/// darkpool contract.
 #[storage]
 #[cfg_attr(feature = "core-settlement", entrypoint)]
 pub struct CoreSettlementContract {
@@ -93,10 +94,11 @@ pub struct CoreSettlementContract {
     /// boolean indicating whether or not the nullifier is spent
     nullifier_set: StorageMap<U256, StorageBool>,
 
-    /// The set of public blinder shares used by wallets committed into the darkpool
+    /// The set of public blinder shares used by wallets committed into the
+    /// darkpool
     ///
-    /// We disallow re-use of public blinder shares to prevent clients indexing the
-    /// pool from seeing conflicting wallet shares
+    /// We disallow re-use of public blinder shares to prevent clients indexing
+    /// the pool from seeing conflicting wallet shares
     public_blinder_set: StorageMap<U256, StorageBool>,
 
     /// The protocol fee, representing a percentage of the trade volume
@@ -180,8 +182,9 @@ impl CoreSettlementContract {
     /// Settles a matched order between two parties,
     /// inserting the updated wallets into the commitment tree.
     ///
-    /// The `match_proofs` argument is the serialization of the [`contracts_common::types::MatchProofs`]
-    /// struct, and the `match_linking_proofs` argument is the serialization of the
+    /// The `match_proofs` argument is the serialization of the
+    /// [`contracts_common::types::MatchProofs`] struct, and the
+    /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::MatchLinkingProofs`] struct
     pub fn process_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -232,38 +235,33 @@ impl CoreSettlementContract {
 
         rotate_wallet(
             storage,
-            party_0_match_payload
-                .valid_reblind_statement
-                .original_shares_nullifier,
+            party_0_match_payload.valid_reblind_statement.original_shares_nullifier,
             party_0_match_payload.valid_reblind_statement.merkle_root,
-            party_0_match_payload
-                .valid_reblind_statement
-                .reblinded_private_shares_commitment,
+            party_0_match_payload.valid_reblind_statement.reblinded_private_shares_commitment,
             &valid_match_settle_statement.party0_modified_shares,
         )?;
 
         rotate_wallet(
             storage,
-            party_1_match_payload
-                .valid_reblind_statement
-                .original_shares_nullifier,
+            party_1_match_payload.valid_reblind_statement.original_shares_nullifier,
             party_1_match_payload.valid_reblind_statement.merkle_root,
-            party_1_match_payload
-                .valid_reblind_statement
-                .reblinded_private_shares_commitment,
+            party_1_match_payload.valid_reblind_statement.reblinded_private_shares_commitment,
             &valid_match_settle_statement.party1_modified_shares,
         )?;
 
         Ok(())
     }
 
-    /// Processes an atomic match settlement between two parties; one internal and one external
+    /// Processes an atomic match settlement between two parties; one internal
+    /// and one external
     ///
-    /// An internal party is one with state committed into the darkpool, while an external party provides liquidity to the pool
-    /// during the transaction in which this method is called
+    /// An internal party is one with state committed into the darkpool, while
+    /// an external party provides liquidity to the pool during the
+    /// transaction in which this method is called
     ///
-    /// The `match_proofs` argument is the serialization of the [`contracts_common::types::ExternalMatchProofs`]
-    /// struct, and the `match_linking_proofs` argument is the serialization of the
+    /// The `match_proofs` argument is the serialization of the
+    /// [`contracts_common::types::ExternalMatchProofs`] struct, and the
+    /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::ExternalMatchLinkingProofs`] struct
     pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -279,9 +277,8 @@ impl CoreSettlementContract {
             deserialize_from_calldata(&valid_match_settle_statement)?;
 
         if_verifying!({
-            let commitments_indices = &internal_party_match_payload
-                .valid_commitments_statement
-                .indices;
+            let commitments_indices =
+                &internal_party_match_payload.valid_commitments_statement.indices;
             let settlement_indices = &valid_match_settle_atomic_statement.internal_party_indices;
             let same_indices = commitments_indices == settlement_indices;
 
@@ -307,12 +304,8 @@ impl CoreSettlementContract {
 
         rotate_wallet(
             storage,
-            internal_party_match_payload
-                .valid_reblind_statement
-                .original_shares_nullifier,
-            internal_party_match_payload
-                .valid_reblind_statement
-                .merkle_root,
+            internal_party_match_payload.valid_reblind_statement.original_shares_nullifier,
+            internal_party_match_payload.valid_reblind_statement.merkle_root,
             internal_party_match_payload
                 .valid_reblind_statement
                 .reblinded_private_shares_commitment,
@@ -346,7 +339,8 @@ impl CoreSettlementContract {
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        // Fetch the Plonk & linking verification keys used in verifying the matching of a trade
+        // Fetch the Plonk & linking verification keys used in verifying the matching of
+        // a trade
         let process_match_settle_vkeys =
             fetch_vkeys(storage, &processMatchSettleVkeysCall::SELECTOR)?;
 
@@ -383,12 +377,14 @@ impl CoreSettlementContract {
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        // Fetch the Plonk & linking verification keys used in verifying the matching of a trade
+        // Fetch the Plonk & linking verification keys used in verifying the matching of
+        // a trade
         let process_atomic_match_settle_vkeys =
             fetch_vkeys(storage, &processAtomicMatchSettleVkeysCall::SELECTOR)?;
 
-        // We allow native ETH transfers on external matches, but the verifier will expect WETH
-        // to be compatible with internal orders, so we change it here
+        // We allow native ETH transfers on external matches, but the verifier will
+        // expect WETH to be compatible with internal orders, so we change it
+        // here
         let base_asset = valid_match_settle_atomic_statement.match_result.base_mint;
         if is_native_eth_address(base_asset) {
             let weth = get_weth_address();
@@ -419,7 +415,8 @@ impl CoreSettlementContract {
         assert_result!(result._0, VERIFICATION_FAILED_ERROR_MESSAGE)
     }
 
-    /// Execute the transfers to/from the external party in an atomic match settlement
+    /// Execute the transfers to/from the external party in an atomic match
+    /// settlement
     pub fn execute_atomic_match_transfers<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
         fees: FeeTake,
@@ -442,9 +439,7 @@ impl CoreSettlementContract {
         ));
 
         // The fee charged by the protocol to the external party
-        let protocol_fee_address = storage
-            .borrow_mut()
-            .protocol_external_fee_collection_address();
+        let protocol_fee_address = storage.borrow_mut().protocol_external_fee_collection_address();
         transfers_batch.push(SimpleErc20Transfer::new_withdraw(
             protocol_fee_address,
             receive_mint,
@@ -462,11 +457,7 @@ impl CoreSettlementContract {
         ));
 
         // The amount sent by the external party to the darkpool
-        transfers_batch.push(SimpleErc20Transfer::new_deposit(
-            tx_sender,
-            send_mint,
-            send_amount,
-        ));
+        transfers_batch.push(SimpleErc20Transfer::new_deposit(tx_sender, send_mint, send_amount));
 
         Self::execute_transfers(storage, transfers_batch)
     }

--- a/contracts-stylus/src/contracts/core/core_wallet_ops.rs
+++ b/contracts-stylus/src/contracts/core/core_wallet_ops.rs
@@ -1,7 +1,8 @@
-//! The darkpool core contract, containing all of the critical, wallet-modifying functionality.
-//! This contract assumes it is being delegate-called by the "outer" darkpool contract and that
-//! certain storage elements are set by the outer contract. As such, its storage layout must
-//! exactly align with that of the outer contract.
+//! The darkpool core contract, containing all of the critical, wallet-modifying
+//! functionality. This contract assumes it is being delegate-called by the
+//! "outer" darkpool contract and that certain storage elements are set by the
+//! outer contract. As such, its storage layout must exactly align with that of
+//! the outer contract.
 
 use core::borrow::BorrowMut;
 
@@ -94,10 +95,11 @@ pub struct CoreWalletOpsContract {
     /// boolean indicating whether or not the nullifier is spent
     nullifier_set: StorageMap<U256, StorageBool>,
 
-    /// The set of public blinder shares used by wallets committed into the darkpool
+    /// The set of public blinder shares used by wallets committed into the
+    /// darkpool
     ///
-    /// We disallow re-use of public blinder shares to prevent clients indexing the
-    /// pool from seeing conflicting wallet shares
+    /// We disallow re-use of public blinder shares to prevent clients indexing
+    /// the pool from seeing conflicting wallet shares
     public_blinder_set: StorageMap<U256, StorageBool>,
 
     /// The protocol fee, representing a percentage of the trade volume
@@ -260,8 +262,8 @@ impl CoreWalletOpsContract {
         Ok(())
     }
 
-    /// Settles the fee accumulated by a relayer for a given balance in a managed wallet
-    /// into the relayer's wallet
+    /// Settles the fee accumulated by a relayer for a given balance in a
+    /// managed wallet into the relayer's wallet
     pub fn settle_online_relayer_fee<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
         proof: Bytes,
@@ -344,10 +346,7 @@ impl CoreWalletOpsContract {
             &valid_offline_fee_settlement_statement.updated_wallet_public_shares,
         )?;
 
-        commit_note(
-            storage,
-            valid_offline_fee_settlement_statement.note_commitment,
-        )
+        commit_note(storage, valid_offline_fee_settlement_statement.note_commitment)
     }
 
     /// Redeems a fee note into the recipient's wallet, nullifying the note

--- a/contracts-stylus/src/contracts/core/mod.rs
+++ b/contracts-stylus/src/contracts/core/mod.rs
@@ -13,7 +13,8 @@ pub mod core_settlement;
 #[cfg(any(feature = "core-wallet-ops", feature = "darkpool-test-contract"))]
 pub mod core_wallet_ops;
 
-/// A trait that allows for storage access to the standard storage layout for core contracts
+/// A trait that allows for storage access to the standard storage layout for
+/// core contracts
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
 pub trait CoreContractStorage {
     /// Get the address of the verifier core contract

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -1,5 +1,6 @@
-//! The darkpool smart contract, responsible for maintaining the set of nullified wallets,
-//! verifying the various proofs of the Renegade protocol, and handling deposits / withdrawals.
+//! The darkpool smart contract, responsible for maintaining the set of
+//! nullified wallets, verifying the various proofs of the Renegade protocol,
+//! and handling deposits / withdrawals.
 
 use alloc::{vec, vec::Vec};
 use core::borrow::{Borrow, BorrowMut};
@@ -71,10 +72,11 @@ pub struct DarkpoolContract {
     /// boolean indicating whether or not the nullifier is spent
     pub(crate) nullifier_set: StorageMap<U256, StorageBool>,
 
-    /// The set of public blinder shares used by wallets committed into the darkpool
+    /// The set of public blinder shares used by wallets committed into the
+    /// darkpool
     ///
-    /// We disallow re-use of public blinder shares to prevent clients indexing the
-    /// pool from seeing conflicting wallet shares
+    /// We disallow re-use of public blinder shares to prevent clients indexing
+    /// the pool from seeing conflicting wallet shares
     pub(crate) public_blinder_set: StorageMap<U256, StorageBool>,
 
     /// The protocol fee, representing a percentage of the trade volume
@@ -89,7 +91,8 @@ pub struct DarkpoolContract {
     // --- Updated Fields for Atomic Settlement --- //
     /// The address of the protocol external fee collection wallet
     ///
-    /// This is the address at which the protocol collects fees from external parties
+    /// This is the address at which the protocol collects fees from external
+    /// parties
     pub(crate) protocol_external_fee_collection_address: StorageAddress,
 
     /// The address of the core settlement contract
@@ -273,10 +276,7 @@ impl DarkpoolContract {
     pub fn get_protocol_external_fee_collection_address<S: TopLevelStorage + Borrow<Self>>(
         storage: &S,
     ) -> Result<Address, Vec<u8>> {
-        Ok(storage
-            .borrow()
-            .protocol_external_fee_collection_address
-            .get())
+        Ok(storage.borrow().protocol_external_fee_collection_address.get())
     }
 
     // -----------
@@ -301,18 +301,10 @@ impl DarkpoolContract {
         new_public_encryption_key: [U256; 2],
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage)?;
-        let mut pubkey_x = storage
-            .borrow_mut()
-            .protocol_public_encryption_key
-            .setter(0)
-            .unwrap();
+        let mut pubkey_x = storage.borrow_mut().protocol_public_encryption_key.setter(0).unwrap();
         pubkey_x.set(new_public_encryption_key[0]);
 
-        let mut pubkey_y = storage
-            .borrow_mut()
-            .protocol_public_encryption_key
-            .setter(1)
-            .unwrap();
+        let mut pubkey_y = storage.borrow_mut().protocol_public_encryption_key.setter(1).unwrap();
         pubkey_y.set(new_public_encryption_key[1]);
 
         evm::log(PubkeyRotated {
@@ -348,14 +340,9 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(core_wallet_ops_address)?;
-        storage
-            .borrow_mut()
-            .core_wallet_ops_address
-            .set(core_wallet_ops_address);
+        storage.borrow_mut().core_wallet_ops_address.set(core_wallet_ops_address);
 
-        evm::log(CoreWalletOpsAddressChanged {
-            new_address: core_wallet_ops_address,
-        });
+        evm::log(CoreWalletOpsAddressChanged { new_address: core_wallet_ops_address });
 
         Ok(())
     }
@@ -367,14 +354,9 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(core_settlement_address)?;
-        storage
-            .borrow_mut()
-            .core_settlement_address
-            .set(core_settlement_address);
+        storage.borrow_mut().core_settlement_address.set(core_settlement_address);
 
-        evm::log(CoreSettlementAddressChanged {
-            new_address: core_settlement_address,
-        });
+        evm::log(CoreSettlementAddressChanged { new_address: core_settlement_address });
         Ok(())
     }
 
@@ -385,13 +367,8 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(verifier_core_address)?;
-        storage
-            .borrow_mut()
-            .verifier_core_address
-            .set(verifier_core_address);
-        evm::log(VerifierCoreAddressChanged {
-            new_address: verifier_core_address,
-        });
+        storage.borrow_mut().verifier_core_address.set(verifier_core_address);
+        evm::log(VerifierCoreAddressChanged { new_address: verifier_core_address });
         Ok(())
     }
 
@@ -402,14 +379,9 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(verifier_settlement_address)?;
-        storage
-            .borrow_mut()
-            .verifier_settlement_address
-            .set(verifier_settlement_address);
+        storage.borrow_mut().verifier_settlement_address.set(verifier_settlement_address);
 
-        evm::log(VerifierSettlementAddressChanged {
-            new_address: verifier_settlement_address,
-        });
+        evm::log(VerifierSettlementAddressChanged { new_address: verifier_settlement_address });
         Ok(())
     }
 
@@ -421,9 +393,7 @@ impl DarkpoolContract {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(vkeys_address)?;
         storage.borrow_mut().vkeys_address.set(vkeys_address);
-        evm::log(VkeysAddressChanged {
-            new_address: vkeys_address,
-        });
+        evm::log(VkeysAddressChanged { new_address: vkeys_address });
         Ok(())
     }
 
@@ -435,9 +405,7 @@ impl DarkpoolContract {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(merkle_address)?;
         storage.borrow_mut().merkle_address.set(merkle_address);
-        evm::log(MerkleAddressChanged {
-            new_address: merkle_address,
-        });
+        evm::log(MerkleAddressChanged { new_address: merkle_address });
         Ok(())
     }
 
@@ -449,14 +417,9 @@ impl DarkpoolContract {
         DarkpoolContract::_check_owner(storage)?;
         DarkpoolContract::check_address_not_zero(transfer_executor_address)?;
 
-        storage
-            .borrow_mut()
-            .transfer_executor_address
-            .set(transfer_executor_address);
+        storage.borrow_mut().transfer_executor_address.set(transfer_executor_address);
 
-        evm::log(TransferExecutorAddressChanged {
-            new_address: transfer_executor_address,
-        });
+        evm::log(TransferExecutorAddressChanged { new_address: transfer_executor_address });
         Ok(())
     }
 
@@ -476,10 +439,7 @@ impl DarkpoolContract {
         delegate_call_helper::<newWalletCall>(
             storage,
             core_wallet_ops_address,
-            (
-                proof.to_vec().into(),
-                valid_wallet_create_statement_bytes.to_vec().into(),
-            ),
+            (proof.to_vec().into(), valid_wallet_create_statement_bytes.to_vec().into()),
         )
         .map(|_| ())
     }
@@ -511,8 +471,9 @@ impl DarkpoolContract {
     /// Settles a matched order between two parties,
     /// inserting the updated wallets into the commitment tree.
     ///
-    /// The `match_proofs` argument is the serialization of the [`contracts_common::types::MatchProofs`]
-    /// struct, and the `match_linking_proofs` argument is the serialization of the
+    /// The `match_proofs` argument is the serialization of the
+    /// [`contracts_common::types::MatchProofs`] struct, and the
+    /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::MatchLinkingProofs`] struct
     pub fn process_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -539,13 +500,16 @@ impl DarkpoolContract {
         .map(|_| ())
     }
 
-    /// Processes an atomic match settlement between two parties; one internal and one external
+    /// Processes an atomic match settlement between two parties; one internal
+    /// and one external
     ///
-    /// An internal party is one with state committed into the darkpool, while an external party provides liquidity to the pool
-    /// during the transaction in which this method is called
+    /// An internal party is one with state committed into the darkpool, while
+    /// an external party provides liquidity to the pool during the
+    /// transaction in which this method is called
     ///
-    /// The `match_proofs` argument is the serialization of the [`contracts_common::types::ExternalMatchProofs`]
-    /// struct, and the `match_linking_proofs` argument is the serialization of the
+    /// The `match_proofs` argument is the serialization of the
+    /// [`contracts_common::types::ExternalMatchProofs`] struct, and the
+    /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::ExternalMatchLinkingProofs`] struct
     pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -570,8 +534,8 @@ impl DarkpoolContract {
         .map(|_| ())
     }
 
-    /// Settles the fee accumulated by a relayer for a given balance in a managed wallet
-    /// into the relayer's wallet
+    /// Settles the fee accumulated by a relayer for a given balance in a
+    /// managed wallet into the relayer's wallet
     pub fn settle_online_relayer_fee<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
         proof: Bytes,
@@ -606,10 +570,7 @@ impl DarkpoolContract {
         delegate_call_helper::<settleOfflineFeeCall>(
             storage,
             core_wallet_ops_address,
-            (
-                proof.to_vec().into(),
-                valid_offline_fee_settlement_statement.to_vec().into(),
-            ),
+            (proof.to_vec().into(), valid_offline_fee_settlement_statement.to_vec().into()),
         )
         .map(|_| ())
     }
@@ -650,10 +611,7 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         let version_uint64 = U64::from_limbs([version]);
         let this = storage.borrow_mut();
-        assert_result!(
-            this.initialized.get() < version_uint64,
-            INVALID_VERSION_ERROR_MESSAGE
-        )?;
+        assert_result!(this.initialized.get() < version_uint64, INVALID_VERSION_ERROR_MESSAGE)?;
         this.initialized.set(version_uint64);
         Ok(())
     }
@@ -673,10 +631,7 @@ impl DarkpoolContract {
 
     /// Checks that the sender is the owner
     pub fn _check_owner<S: TopLevelStorage + Borrow<Self>>(storage: &S) -> Result<(), Vec<u8>> {
-        assert_result!(
-            storage.borrow().owner.get() == msg::sender(),
-            NOT_OWNER_ERROR_MESSAGE
-        )
+        assert_result!(storage.borrow().owner.get() == msg::sender(), NOT_OWNER_ERROR_MESSAGE)
     }
 
     // ------------
@@ -719,17 +674,9 @@ impl DarkpoolContract {
     pub fn _get_protocol_pubkey_coords<S: TopLevelStorage + Borrow<Self>>(
         storage: &S,
     ) -> [U256; 2] {
-        let protocol_pubkey_x = storage
-            .borrow()
-            .protocol_public_encryption_key
-            .get(0)
-            .unwrap();
+        let protocol_pubkey_x = storage.borrow().protocol_public_encryption_key.get(0).unwrap();
 
-        let protocol_pubkey_y = storage
-            .borrow()
-            .protocol_public_encryption_key
-            .get(1)
-            .unwrap();
+        let protocol_pubkey_y = storage.borrow().protocol_public_encryption_key.get(1).unwrap();
 
         [protocol_pubkey_x, protocol_pubkey_y]
     }

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -1,11 +1,12 @@
-//! A Merkle tree smart contract, used to accumulate all of the wallet commitments
-//! in the dark pool.
+//! A Merkle tree smart contract, used to accumulate all of the wallet
+//! commitments in the dark pool.
 //!
-//! NOTE: This contract is `delegatecall`ed by the `DarkpoolContract`. This makes our contract
-//! "topology" a lot simpler: we can apply access controls and upgradability only to the top-level
-//! `DarkpoolContract` and not worry about it here.
-//! However, it is important that we NEVER CALL A `selfdestruct` (or `delegatecall` some other contract
-//! which `selfdestruct`s) WITHIN THE MERKLE CONTRACT, AS THIS WOULD DESTROY THE DARKPOOL.
+//! NOTE: This contract is `delegatecall`ed by the `DarkpoolContract`. This
+//! makes our contract "topology" a lot simpler: we can apply access controls
+//! and upgradability only to the top-level `DarkpoolContract` and not worry
+//! about it here. However, it is important that we NEVER CALL A `selfdestruct`
+//! (or `delegatecall` some other contract which `selfdestruct`s) WITHIN THE
+//! MERKLE CONTRACT, AS THIS WOULD DESTROY THE DARKPOOL.
 
 use core::marker::PhantomData;
 
@@ -73,8 +74,7 @@ where
         let root = compute_poseidon_hash(&[P::ZEROS[0], P::ZEROS[0]]);
         self.store_root(root);
         for i in 0..P::HEIGHT {
-            self.sibling_path
-                .insert(i as u8, scalar_to_u256(P::ZEROS[i]));
+            self.sibling_path.insert(i as u8, scalar_to_u256(P::ZEROS[i]));
         }
         Ok(())
     }
@@ -97,13 +97,11 @@ where
     // | SETTERS |
     // -----------
 
-    /// Computes a commitment to the given wallet shares & inserts it into the Merkle tree
+    /// Computes a commitment to the given wallet shares & inserts it into the
+    /// Merkle tree
     pub fn insert_shares_commitment(&mut self, shares: Vec<U256>) -> Result<(), Vec<u8>> {
         let insert_index: u128 = self.next_index.get().to();
-        assert_result!(
-            insert_index < 2_u128.pow(P::HEIGHT as u32),
-            TREE_FULL_ERROR_MESSAGE
-        )?;
+        assert_result!(insert_index < 2_u128.pow(P::HEIGHT as u32), TREE_FULL_ERROR_MESSAGE)?;
 
         let shares_commitment = self.compute_shares_commitment(shares)?;
 
@@ -111,7 +109,7 @@ where
             shares_commitment,
             P::HEIGHT as u8,
             insert_index,
-            true, /* subtree_filled */
+            true, // subtree_filled
         )?;
 
         Ok(())
@@ -132,22 +130,13 @@ where
         old_pk_root: [U256; NUM_SCALARS_PK],
     ) -> Result<(), Vec<u8>> {
         let insert_index: u128 = self.next_index.get().to();
-        assert_result!(
-            insert_index < 2_u128.pow(P::HEIGHT as u32),
-            TREE_FULL_ERROR_MESSAGE
-        )?;
+        assert_result!(insert_index < 2_u128.pow(P::HEIGHT as u32), TREE_FULL_ERROR_MESSAGE)?;
 
         let shares_commitment = self.compute_shares_commitment(shares)?;
 
         let old_pk_root = PublicSigningKey {
-            x: [
-                u256_to_scalar(old_pk_root[0])?,
-                u256_to_scalar(old_pk_root[1])?,
-            ],
-            y: [
-                u256_to_scalar(old_pk_root[2])?,
-                u256_to_scalar(old_pk_root[3])?,
-            ],
+            x: [u256_to_scalar(old_pk_root[0])?, u256_to_scalar(old_pk_root[1])?],
+            y: [u256_to_scalar(old_pk_root[2])?, u256_to_scalar(old_pk_root[3])?],
         };
 
         if_verifying!(assert_valid_signature(
@@ -160,7 +149,7 @@ where
             shares_commitment,
             P::HEIGHT as u8,
             insert_index,
-            true, /* subtree_filled */
+            true, // subtree_filled
         )?;
 
         Ok(())
@@ -169,16 +158,13 @@ where
     /// Inserts a note commitment into the Merkle tree
     pub fn insert_note_commitment(&mut self, note_commitment: U256) -> Result<(), Vec<u8>> {
         let insert_index: u128 = self.next_index.get().to();
-        assert_result!(
-            insert_index < 2_u128.pow(P::HEIGHT as u32),
-            TREE_FULL_ERROR_MESSAGE
-        )?;
+        assert_result!(insert_index < 2_u128.pow(P::HEIGHT as u32), TREE_FULL_ERROR_MESSAGE)?;
 
         self.insert_helper(
             u256_to_scalar(note_commitment)?,
             P::HEIGHT as u8,
             insert_index,
-            true, /* subtree_filled */
+            true, // subtree_filled
         )?;
 
         Ok(())
@@ -216,10 +202,7 @@ where
         subtree_filled: bool,
     ) -> Result<(), Vec<u8>> {
         self.insert_recursive(value, height, insert_index, subtree_filled)?;
-        evm::log(MerkleInsertion {
-            index: insert_index,
-            value: scalar_to_u256(value),
-        });
+        evm::log(MerkleInsertion { index: insert_index, value: scalar_to_u256(value) });
 
         Ok(())
     }
@@ -252,10 +235,10 @@ where
         // for the next insertion. There are two cases here:
         //      1. The current insertion index is a left child; in this case the updated
         //         sibling value is the newly computed node value.
-        //      2. The current insertion index is a right child; in this case, the subtree
-        //         of the parent is filled as well, meaning we should set the updated sibling
-        //         to the zero value at this height; representing an empty child of the parent's
-        //         sibling
+        //      2. The current insertion index is a right child; in this case, the
+        //         subtree of the parent is filled as well, meaning we should set the
+        //         updated sibling to the zero value at this height; representing an
+        //         empty child of the parent's sibling
         let current_sibling_value = u256_to_scalar(self.sibling_path.get(height - 1))?;
         if subtree_filled {
             if is_left {
@@ -266,8 +249,8 @@ where
             }
         }
 
-        // Mux between hashing the current value as the left or right sibling depending on
-        // the index being inserted into
+        // Mux between hashing the current value as the left or right sibling depending
+        // on the index being inserted into
         let mut new_subtree_filled = false;
         let inputs = if is_left {
             [value, current_sibling_value]
@@ -280,11 +263,7 @@ where
         self.insert_recursive(next_value, height - 1, next_index, new_subtree_filled)?;
 
         // Emit the sibling coordinates and value
-        let sibling_idx = if is_left {
-            insert_index + 1
-        } else {
-            insert_index - 1
-        };
+        let sibling_idx = if is_left { insert_index + 1 } else { insert_index - 1 };
 
         evm::log(MerkleOpeningNode {
             height,
@@ -342,8 +321,7 @@ impl ProdMerkleContract {
         sig: Bytes,
         old_pk_root: [U256; NUM_SCALARS_PK],
     ) -> Result<(), Vec<u8>> {
-        self.merkle
-            .verify_state_sig_and_insert(shares, sig, old_pk_root)
+        self.merkle.verify_state_sig_and_insert(shares, sig, old_pk_root)
     }
 
     #[doc(hidden)]

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -1,4 +1,5 @@
-//! A test contract inheriting from the Darkpool contract, and exposing some of its internal helper methods
+//! A test contract inheriting from the Darkpool contract, and exposing some of
+//! its internal helper methods
 
 use core::borrow::{Borrow, BorrowMut};
 
@@ -83,13 +84,15 @@ impl CoreContractStorage for DarkpoolTestContract {
     }
 }
 
-// We manually implement `Borrow` and `BorrowMut` to enable the `DarkpoolTestContract` to
-// call the internal methods of the `DarkpoolCoreContract` on the nested `DarkpoolContract`.
-// We do this by unsafely casting a pointer to the `DarkpoolContract` to a pointer to the
-// `DarkpoolCoreContract`. This allows us to avoid duplicating the internal methods of the
-// `DarkpoolCoreContract` on the `DarkpoolContract`, where they're only used for testing.
-// This is possible because we already maintain that the `DarkpoolContract` and
-// `DarkpoolCoreContract` have exactly the same storage / memory layout.
+// We manually implement `Borrow` and `BorrowMut` to enable the
+// `DarkpoolTestContract` to call the internal methods of the
+// `DarkpoolCoreContract` on the nested `DarkpoolContract`. We do this by
+// unsafely casting a pointer to the `DarkpoolContract` to a pointer to the
+// `DarkpoolCoreContract`. This allows us to avoid duplicating the internal
+// methods of the `DarkpoolCoreContract` on the `DarkpoolContract`, where
+// they're only used for testing. This is possible because we already maintain
+// that the `DarkpoolContract` and `DarkpoolCoreContract` have exactly the same
+// storage / memory layout.
 
 impl Borrow<CoreWalletOpsContract> for DarkpoolTestContract {
     fn borrow(&self) -> &CoreWalletOpsContract {
@@ -122,11 +125,12 @@ impl DarkpoolTestContract {
         mark_nullifier_spent::<Self, _>(self, nullifier)
     }
 
-    /// Attempts to call [`DummyUpgradeTarget::is_dummy_upgrade_target`] on either
-    /// the verifier, vkeys, or Merkle contract, depending on the given address selector.
+    /// Attempts to call [`DummyUpgradeTarget::is_dummy_upgrade_target`] on
+    /// either the verifier, vkeys, or Merkle contract, depending on the
+    /// given address selector.
     ///
-    /// A succesful call implies that the verifier / vkeys / Merkle contract has been upgraded
-    /// to the dummy upgrade target.
+    /// A succesful call implies that the verifier / vkeys / Merkle contract has
+    /// been upgraded to the dummy upgrade target.
     pub fn is_implementation_upgraded(&mut self, address_selector: u8) -> Result<bool, Vec<u8>> {
         let this = BorrowMut::<DarkpoolContract>::borrow_mut(self);
         let implementation_address = match address_selector {
@@ -149,9 +153,7 @@ impl DarkpoolTestContract {
 
     /// Re-initializes the Merkle tree, resetting it to an empty tree
     pub fn clear_merkle(&mut self) -> Result<(), Vec<u8>> {
-        let merkle_address = BorrowMut::<DarkpoolContract>::borrow_mut(self)
-            .merkle_address
-            .get();
+        let merkle_address = BorrowMut::<DarkpoolContract>::borrow_mut(self).merkle_address.get();
 
         delegate_call_helper::<initMerkleCall>(self, merkle_address, ()).map(|_| ())
     }

--- a/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
@@ -121,11 +121,7 @@ impl Erc20 {
         let new_balance = balance.get() + value;
         balance.set(new_balance);
         self.total_supply.set(self.total_supply.get() + value);
-        evm::log(Transfer {
-            from: Address::ZERO,
-            to: address,
-            value,
-        });
+        evm::log(Transfer { from: Address::ZERO, to: address, value });
     }
 
     pub fn burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
@@ -140,11 +136,7 @@ impl Erc20 {
         }
         balance.set(old_balance - value);
         self.total_supply.set(self.total_supply.get() - value);
-        evm::log(Transfer {
-            from: address,
-            to: Address::ZERO,
-            value,
-        });
+        evm::log(Transfer { from: address, to: Address::ZERO, value });
         Ok(())
     }
 

--- a/contracts-stylus/src/contracts/test_contracts/dummy_upgrade_target.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_upgrade_target.rs
@@ -1,4 +1,5 @@
-//! A dummy contract intended to be used as an upgrade target for testing purposes.
+//! A dummy contract intended to be used as an upgrade target for testing
+//! purposes.
 
 use alloc::vec::Vec;
 use stylus_sdk::prelude::*;
@@ -12,8 +13,8 @@ struct DummyUpgradeTargetContract;
 impl DummyUpgradeTargetContract {
     /// Simply returns `true`.
     ///
-    /// In the upgrade tests, this is used to check whether the contract in question
-    /// has been upgraded, and exposes this method
+    /// In the upgrade tests, this is used to check whether the contract in
+    /// question has been upgraded, and exposes this method
     pub fn is_dummy_upgrade_target(&self) -> Result<bool, Vec<u8>> {
         Ok(true)
     }

--- a/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
@@ -1,4 +1,5 @@
-//! A mock ERC20 token implementation with wrapper functionality used for testing.
+//! A mock ERC20 token implementation with wrapper functionality used for
+//! testing.
 //!
 //! Modeled after the WETH9 contract code:
 //!     https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code
@@ -18,7 +19,8 @@ use super::dummy_erc20::Erc20;
 
 /// The error message returned when a deposit overflows
 const ERR_DEPOSIT_OVERFLOW: &[u8] = b"Deposit overflowed";
-/// The error message returned when a withdrawal amount is greater than the sender's balance
+/// The error message returned when a withdrawal amount is greater than the
+/// sender's balance
 const ERR_WITHDRAWAL_EXCEEDS_BALANCE: &[u8] = b"Withdrawal amount exceeds balance";
 
 sol_storage! {
@@ -70,10 +72,7 @@ impl DummyWeth {
         bal.set(new_bal);
 
         // Emit a deposit event
-        evm::log(Deposit {
-            from: sender,
-            value: amount,
-        });
+        evm::log(Deposit { from: sender, value: amount });
         Ok(())
     }
 

--- a/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/merkle_test_contract.rs
@@ -58,8 +58,7 @@ impl TestMerkleContract {
         sig: Bytes,
         old_pk_root: [U256; NUM_SCALARS_PK],
     ) -> Result<(), Vec<u8>> {
-        self.merkle
-            .verify_state_sig_and_insert(shares, sig, old_pk_root)
+        self.merkle.verify_state_sig_and_insert(shares, sig, old_pk_root)
     }
 
     #[doc(hidden)]

--- a/contracts-stylus/src/contracts/test_contracts/mod.rs
+++ b/contracts-stylus/src/contracts/test_contracts/mod.rs
@@ -1,4 +1,5 @@
-//! Testing contracts which wrap various contract functionality for testing purposes.
+//! Testing contracts which wrap various contract functionality for testing
+//! purposes.
 
 #[cfg(feature = "precompile-test-contract")]
 mod precompile_test_contract;

--- a/contracts-stylus/src/contracts/test_contracts/precompile_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/precompile_test_contract.rs
@@ -1,6 +1,6 @@
-//! Testing contract which wraps EVM precompile functionality for testing purposes.
-//! This contract is intended to be used in conjunction with a local devnet, along with testing scripts
-//! in the `integration` crate
+//! Testing contract which wraps EVM precompile functionality for testing
+//! purposes. This contract is intended to be used in conjunction with a local
+//! devnet, along with testing scripts in the `integration` crate
 
 use alloc::vec::Vec;
 use contracts_common::{

--- a/contracts-stylus/src/contracts/transfer_executor.rs
+++ b/contracts-stylus/src/contracts/transfer_executor.rs
@@ -1,5 +1,5 @@
-//! The transfer executor contract, responsible for executing external transfers to/from the darkpool
-//! (it is intended to be delegate-called by the darkpool)
+//! The transfer executor contract, responsible for executing external transfers
+//! to/from the darkpool (it is intended to be delegate-called by the darkpool)
 #![cfg(feature = "transfer-executor")]
 
 use crate::{
@@ -60,7 +60,8 @@ pub struct TransferExecutorContract {
 
 #[public]
 impl TransferExecutorContract {
-    /// Initializes the transfer executor with the address of the Permit2 contract being used
+    /// Initializes the transfer executor with the address of the Permit2
+    /// contract being used
     // TODO: Deploy Permit2 using `CREATE2` and use a static address
     pub fn init(&mut self, permit2_address: Address) -> Result<(), Vec<u8>> {
         self.permit2_address.set(permit2_address);
@@ -79,18 +80,14 @@ impl TransferExecutorContract {
         let transfer: ExternalTransfer = deserialize_from_calldata(&transfer)?;
         let transfer_aux_data: TransferAuxData = deserialize_from_calldata(&transfer_aux_data)?;
 
-        let ExternalTransfer {
-            mint,
-            account_addr,
-            amount,
-            is_withdrawal,
-        } = transfer;
+        let ExternalTransfer { mint, account_addr, amount, is_withdrawal } = transfer;
 
         let old_pk_root: PublicSigningKey = deserialize_from_calldata(&old_pk_root_bytes)?;
 
         if is_withdrawal {
-            // In the case of a withdrawal, we check the signature over the external transfer,
-            // and then make a simple `transfer` call from the contract to the user.
+            // In the case of a withdrawal, we check the signature over the external
+            // transfer, and then make a simple `transfer` call from the
+            // contract to the user.
 
             if_verifying!(assert_valid_signature(
                 &old_pk_root,
@@ -102,7 +99,7 @@ impl TransferExecutorContract {
 
             call_helper::<transferCall>(
                 self,
-                mint, /* address */
+                mint, // address
                 (account_addr /* to */, amount),
             )?;
         } else {
@@ -113,10 +110,7 @@ impl TransferExecutorContract {
             let permit2_address = self.permit2_address.get();
 
             let permit = CalldataPermitWitnessTransferFrom {
-                permitted: TokenPermissions {
-                    amount,
-                    token: mint,
-                },
+                permitted: TokenPermissions { amount, token: mint },
                 nonce: transfer_aux_data
                     .permit_nonce
                     .ok_or(MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE)?,
@@ -125,10 +119,8 @@ impl TransferExecutorContract {
                     .ok_or(MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE)?,
             };
 
-            let signature_transfer_details = SignatureTransferDetails {
-                to: contract_address,
-                requestedAmount: amount,
-            };
+            let signature_transfer_details =
+                SignatureTransferDetails { to: contract_address, requestedAmount: amount };
 
             // Hash the Permit2 witness data for the deposit
             let deposit_witness = DepositWitness {
@@ -139,11 +131,11 @@ impl TransferExecutorContract {
 
             call_helper::<permitWitnessTransferFromCall>(
                 self,
-                permit2_address, /* address */
+                permit2_address, // address
                 (
                     permit,
                     signature_transfer_details,
-                    account_addr, /* owner */
+                    account_addr, // owner
                     deposit_witness_hash.into(),
                     DEPOSIT_WITNESS_TYPE_STRING.to_string(),
                     transfer_aux_data
@@ -154,12 +146,7 @@ impl TransferExecutorContract {
             )?;
         };
 
-        evm::log(ExternalTransferEvent {
-            account: account_addr,
-            mint,
-            is_withdrawal,
-            amount,
-        });
+        evm::log(ExternalTransferEvent { account: account_addr, mint, is_withdrawal, amount });
 
         Ok(())
     }
@@ -236,7 +223,8 @@ impl TransferExecutorContract {
         Ok(())
     }
 
-    /// Deposit native ETH into the contract by wrapping the transaction payable amount
+    /// Deposit native ETH into the contract by wrapping the transaction payable
+    /// amount
     fn handle_native_eth_deposit(&mut self, transfer: SimpleErc20Transfer) -> Result<(), Vec<u8>> {
         let payable = msg::value();
         if transfer.amount != payable {
@@ -250,7 +238,8 @@ impl TransferExecutorContract {
         Ok(())
     }
 
-    /// Withdraw native ETH from the contract to the caller by unwrapping the transfer amount
+    /// Withdraw native ETH from the contract to the caller by unwrapping the
+    /// transfer amount
     fn handle_native_eth_withdrawal(
         &mut self,
         transfer: SimpleErc20Transfer,

--- a/contracts-stylus/src/contracts/verifier/verifier_core.rs
+++ b/contracts-stylus/src/contracts/verifier/verifier_core.rs
@@ -27,7 +27,8 @@ impl CoreVerifierContract {
 
     /// Verify a batch of proofs
     ///
-    /// Allows for extra data added to the KZG batch opening to facilitate proof-linking
+    /// Allows for extra data added to the KZG batch opening to facilitate
+    /// proof-linking
     pub fn verify_batch(&self, verification_bundle: Bytes) -> Result<bool, Vec<u8>> {
         // Deserialize the bundle
         let (vkeys, proofs, public_inputs, link_opening): (

--- a/contracts-stylus/src/contracts/vkeys.rs
+++ b/contracts-stylus/src/contracts/vkeys.rs
@@ -48,8 +48,8 @@ impl VkeysContract {
     /// Returns the serialization of the
     /// [`VALID COMMITMENTS`, `VALID REBLIND`, `VALID MATCH SETTLE`]
     /// Plonk verification keys, concatenated with the serialzation of the
-    /// [`VALID REBLIND <-> VALID COMMITMENTS`, `VALID COMMITMENTS <-> VALID MATCH SETTLE`]
-    /// linking verification keys
+    /// [`VALID REBLIND <-> VALID COMMITMENTS`, `VALID COMMITMENTS <-> VALID
+    /// MATCH SETTLE`] linking verification keys
     pub fn process_match_settle_vkeys(&self) -> Result<Bytes, Vec<u8>> {
         Ok(PROCESS_MATCH_SETTLE_VKEYS_BYTES.to_vec().into())
     }
@@ -57,8 +57,8 @@ impl VkeysContract {
     /// Returns the serialization of the
     /// [`VALID COMMITMENTS`, `VALID REBLIND`, `VALID MATCH SETTLE ATOMIC`]
     /// Plonk verification keys, concatenated with the serialzation of the
-    /// [`VALID REBLIND <-> VALID COMMITMENTS`, `VALID COMMITMENTS <-> VALID MATCH SETTLE ATOMIC`]
-    /// linking verification keys
+    /// [`VALID REBLIND <-> VALID COMMITMENTS`, `VALID COMMITMENTS <-> VALID
+    /// MATCH SETTLE ATOMIC`] linking verification keys
     pub fn process_atomic_match_settle_vkeys(&self) -> Result<Bytes, Vec<u8>> {
         Ok(PROCESS_ATOMIC_MATCH_SETTLE_VKEYS_BYTES.to_vec().into())
     }

--- a/contracts-stylus/src/utils/backends.rs
+++ b/contracts-stylus/src/utils/backends.rs
@@ -1,4 +1,5 @@
-//! Common utilities used throughout the smart contracts, including testing contracts.
+//! Common utilities used throughout the smart contracts, including testing
+//! contracts.
 
 use ark_ff::One;
 use contracts_common::{
@@ -33,7 +34,8 @@ impl HashBackend for StylusHasher {
 pub struct PrecompileG1ArithmeticBackend;
 
 impl G1ArithmeticBackend for PrecompileG1ArithmeticBackend {
-    /// Calls the `ecAdd` precompile with the given points, handling de/serialization
+    /// Calls the `ecAdd` precompile with the given points, handling
+    /// de/serialization
     fn ec_add(a: G1Affine, b: G1Affine) -> Result<G1Affine, G1ArithmeticError> {
         if a == G1Affine::identity() {
             return Ok(b);
@@ -55,7 +57,8 @@ impl G1ArithmeticBackend for PrecompileG1ArithmeticBackend {
         G1Affine::deserialize_from_bytes(&res_xy_bytes).map_err(|_| G1ArithmeticError)
     }
 
-    /// Calls the `ecMul` precompile with the given scalar and point, handling de/serialization
+    /// Calls the `ecMul` precompile with the given scalar and point, handling
+    /// de/serialization
     fn ec_scalar_mul(a: ScalarField, b: G1Affine) -> Result<G1Affine, G1ArithmeticError> {
         if a == ScalarField::one() {
             return Ok(b);
@@ -75,7 +78,8 @@ impl G1ArithmeticBackend for PrecompileG1ArithmeticBackend {
         G1Affine::deserialize_from_bytes(&res_xy_bytes).map_err(|_| G1ArithmeticError)
     }
 
-    /// Calls the `ecPairing` precompile with the given points, handling de/serialization
+    /// Calls the `ecPairing` precompile with the given points, handling
+    /// de/serialization
     fn ec_pairing_check(
         a_1: G1Affine,
         b_1: G2Affine,

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -121,10 +121,12 @@ pub const NATIVE_ETH_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
 
 /// The address of the WETH contract
 ///
-/// We read this from an environment variable so that it must be set by the deployer.
+/// We read this from an environment variable so that it must be set by the
+/// deployer.
 ///
 /// For convenience, the addresses of WETH on Arbitrum chains are below:
-/// - Sepolia: 0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 // TODO: replace with dummy WETH address
+/// - Sepolia: 0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 // TODO: replace with
+///   dummy WETH address
 /// - Arbitrum One: 0x82aF49447D8a07e3bd95BD0d56f35241523fBabb
 #[cfg(any(feature = "transfer-executor", feature = "core-settlement"))]
 pub const WETH_ADDRESS: &str = env!("WETH_ADDRESS");
@@ -159,11 +161,7 @@ pub const MERKLE_STORAGE_GAP_SIZE: usize = 64;
 /// The number of storage slots to allocate for the transfer executor
 /// contract, used in creating storage gaps in contracts in the same
 /// context to ensure that there are no storage collisions
-#[cfg(any(
-    feature = "darkpool",
-    feature = "darkpool-test-contract",
-    feature = "darkpool-core"
-))]
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
 pub const TRANSFER_EXECUTOR_STORAGE_GAP_SIZE: usize = 64;
 
 /// The serialized VALID WALLET CREATE verification key
@@ -318,12 +316,7 @@ pub const ZEROS: [ScalarField; MERKLE_HEIGHT] = [
         PhantomData,
     ),
     Fp(
-        BigInt([
-            13724767344552159288,
-            881032855553829299,
-            1641667393102138459,
-            92653500913936485,
-        ]),
+        BigInt([13724767344552159288, 881032855553829299, 1641667393102138459, 92653500913936485]),
         PhantomData,
     ),
     Fp(

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -49,11 +49,7 @@ pub fn is_native_eth_address(addr: Address) -> bool {
 
 /// Deserializes a byte-serialized type from calldata
 #[cfg_attr(
-    not(any(
-        feature = "darkpool-core",
-        feature = "verifier",
-        feature = "transfer-executor"
-    )),
+    not(any(feature = "darkpool-core", feature = "verifier", feature = "transfer-executor")),
     allow(dead_code)
 )]
 pub fn deserialize_from_calldata<'a, D: Deserialize<'a>>(
@@ -63,10 +59,7 @@ pub fn deserialize_from_calldata<'a, D: Deserialize<'a>>(
 }
 
 /// Serializes the given type into bytes for calldata
-#[cfg_attr(
-    not(any(feature = "darkpool-core", feature = "transfer-executor")),
-    allow(dead_code)
-)]
+#[cfg_attr(not(any(feature = "darkpool-core", feature = "transfer-executor")), allow(dead_code))]
 pub fn postcard_serialize<S: Serialize>(s: &S) -> Result<Vec<u8>, Vec<u8>> {
     postcard::to_allocvec(s).map_err(map_calldata_ser_error)
 }
@@ -108,8 +101,9 @@ pub fn serialize_match_statements_for_verification(
 }
 
 /// Serializes the statements used in verifying the settlement of an atomic
-/// matched trade into scalars, builds the [`AtomicMatchSettlePublicInputs`] struct,
-/// and then serializes it into bytes, as expected by the verifier contract.
+/// matched trade into scalars, builds the [`AtomicMatchSettlePublicInputs`]
+/// struct, and then serializes it into bytes, as expected by the verifier
+/// contract.
 #[cfg_attr(not(feature = "core-settlement"), allow(dead_code))]
 pub fn serialize_atomic_match_statements_for_verification(
     valid_commitments: &ValidCommitmentsStatement,
@@ -141,7 +135,7 @@ pub fn map_call_error(e: stylus_sdk::call::Error) -> Vec<u8> {
         stylus_sdk::call::Error::Revert(msg) => msg,
         stylus_sdk::call::Error::AbiDecodingFailed(_) => {
             CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec()
-        }
+        },
     }
 }
 
@@ -152,7 +146,8 @@ pub fn map_calldata_ser_error<E>(_e: E) -> Vec<u8> {
     CALLDATA_SER_ERROR_MESSAGE.to_vec()
 }
 
-/// Performs a `staticcall` to the given address, calling the function defined as a `SolCall` with the given arguments
+/// Performs a `staticcall` to the given address, calling the function defined
+/// as a `SolCall` with the given arguments
 #[cfg_attr(
     not(any(feature = "darkpool-core", feature = "darkpool-test-contract")),
     allow(dead_code)
@@ -171,11 +166,7 @@ pub fn static_call_helper<C: SolCall>(
 /// Performs a `delegatecall` to the given address, calling the function
 /// defined as a `SolCall` with the given arguments.
 #[cfg_attr(
-    not(any(
-        feature = "darkpool-core",
-        feature = "darkpool",
-        feature = "darkpool-test-contract"
-    )),
+    not(any(feature = "darkpool-core", feature = "darkpool", feature = "darkpool-test-contract")),
     allow(dead_code)
 )]
 pub fn delegate_call_helper<C: SolCall>(
@@ -218,14 +209,10 @@ pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, Vec<u8>> {
     ScalarField::from_bigint(bigint).ok_or(SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())
 }
 
-/// Asserts the validity of the given signature using the given public signing key,
-/// if verification is enabled
+/// Asserts the validity of the given signature using the given public signing
+/// key, if verification is enabled
 #[cfg_attr(
-    not(any(
-        feature = "transfer-executor",
-        feature = "merkle",
-        feature = "merkle-test-contract",
-    )),
+    not(any(feature = "transfer-executor", feature = "merkle", feature = "merkle-test-contract",)),
     allow(dead_code)
 )]
 pub fn assert_valid_signature(
@@ -237,9 +224,7 @@ pub fn assert_valid_signature(
         ecdsa_verify::<StylusHasher, PrecompileEcRecoverBackend>(
             pk_root,
             message,
-            signature
-                .try_into()
-                .map_err(|_| INVALID_ARR_LEN_ERROR_MESSAGE)?,
+            signature.try_into().map_err(|_| INVALID_ARR_LEN_ERROR_MESSAGE)?,
         )
         .map_err(|_| ECDSA_ERROR_MESSAGE)?,
         INVALID_SIGNATURE_ERROR_MESSAGE

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -1,4 +1,5 @@
-//! Various Solidity definitions, including ABI-compatible interfaces, events, functions, etc.
+//! Various Solidity definitions, including ABI-compatible interfaces, events,
+//! functions, etc.
 
 use alloy_sol_types::sol;
 

--- a/contracts-utils/src/conversion.rs
+++ b/contracts-utils/src/conversion.rs
@@ -13,7 +13,8 @@ use eyre::Result;
 use mpc_plonk::proof_system::structs::VerifyingKey;
 use mpc_relation::proof_linking::GroupLayout;
 
-/// Converts a [`GroupLayout`] (from prover-side code) to a [`LinkingVerificationKey`]
+/// Converts a [`GroupLayout`] (from prover-side code) to a
+/// [`LinkingVerificationKey`]
 pub fn to_linking_vkey(group_layout: &GroupLayout) -> LinkingVerificationKey {
     LinkingVerificationKey {
         link_group_generator: group_layout.get_domain_generator(),
@@ -22,8 +23,8 @@ pub fn to_linking_vkey(group_layout: &GroupLayout) -> LinkingVerificationKey {
     }
 }
 
-/// Attempts to convert a slice of [`PolynomialCommitment`]s (from prover-side code)
-/// to a fixed-size array of [`G1Affine`]z
+/// Attempts to convert a slice of [`PolynomialCommitment`]s (from prover-side
+/// code) to a fixed-size array of [`G1Affine`]z
 fn try_unwrap_commitments<const N: usize>(
     comms: &[PolynomialCommitment],
 ) -> Result<[G1Affine; N], ConversionError> {
@@ -42,10 +43,7 @@ pub fn to_contract_vkey(
     Ok(VerificationKey {
         n: jf_vkey.domain_size as u64,
         l: jf_vkey.num_inputs as u64,
-        k: jf_vkey
-            .k
-            .try_into()
-            .map_err(|_| ConversionError::InvalidLength)?,
+        k: jf_vkey.k.try_into().map_err(|_| ConversionError::InvalidLength)?,
         q_comms: try_unwrap_commitments(&jf_vkey.selector_comms)?,
         sigma_comms: try_unwrap_commitments(&jf_vkey.sigma_comms)?,
         g: jf_vkey.open_key.g,
@@ -54,7 +52,8 @@ pub fn to_contract_vkey(
     })
 }
 
-/// Converts a [`ContractPublicSigningKey`] (from contract-side code) to a [`CircuitPublicSigningKey`]
+/// Converts a [`ContractPublicSigningKey`] (from contract-side code) to a
+/// [`CircuitPublicSigningKey`]
 pub fn to_circuit_pubkey(contract_pubkey: ContractPublicSigningKey) -> CircuitPublicSigningKey {
     let x = NonNativeScalar {
         scalar_words: contract_pubkey

--- a/contracts-utils/src/crypto.rs
+++ b/contracts-utils/src/crypto.rs
@@ -22,8 +22,8 @@ impl HashBackend for NativeHasher {
     }
 }
 
-/// Generates a random secp256k1 signing keypair, returning the [`SigningKey`] and the
-/// [`PublicSigningKey`] type
+/// Generates a random secp256k1 signing keypair, returning the [`SigningKey`]
+/// and the [`PublicSigningKey`] type
 pub fn random_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SigningKey, PublicSigningKey) {
     let signing_key = SigningKey::random(rng);
     let verifying_key = signing_key.verifying_key();
@@ -34,16 +34,12 @@ pub fn random_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SigningKey, Publi
     (signing_key, contract_pubkey)
 }
 
-/// Hashes the given message and generates a signature over it using the signing key,
-/// as expected in ECDSA
+/// Hashes the given message and generates a signature over it using the signing
+/// key, as expected in ECDSA
 pub fn hash_and_sign_message(signing_key: &SigningKey, msg: &[u8]) -> Signature {
     let msg_hash = keccak256(msg);
     let (sig, recovery_id) = signing_key.sign_prehash_recoverable(&msg_hash).unwrap();
     let r: U256 = U256::from_big_endian(&sig.r().to_bytes());
     let s: U256 = U256::from_big_endian(&sig.s().to_bytes());
-    Signature {
-        r,
-        s,
-        v: recovery_id.to_byte() as u64,
-    }
+    Signature { r, s, v: recovery_id.to_byte() as u64 }
 }

--- a/contracts-utils/src/lib.rs
+++ b/contracts-utils/src/lib.rs
@@ -1,4 +1,5 @@
-//! Common utiltiies used outside of the Stylus contracts themselves, e.g. for deploy scripts & testing
+//! Common utiltiies used outside of the Stylus contracts themselves, e.g. for
+//! deploy scripts & testing
 
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]

--- a/contracts-utils/src/merkle.rs
+++ b/contracts-utils/src/merkle.rs
@@ -1,4 +1,5 @@
-//! Implementation of a Merkle tree using the Poseidon2 implementation from the relayer codebase.
+//! Implementation of a Merkle tree using the Poseidon2 implementation from the
+//! relayer codebase.
 
 use ark_crypto_primitives::{
     crh::{CRHScheme, TwoToOneCRHScheme},
@@ -71,8 +72,8 @@ impl Config for MerkleConfig {
     type LeafDigest = ScalarField;
     type InnerDigest = ScalarField;
 
-    // We expect pre-hashed leaves, so the Merkle tree itself should not do any hashing of the leaves
-    // upon setup / insertion
+    // We expect pre-hashed leaves, so the Merkle tree itself should not do any
+    // hashing of the leaves upon setup / insertion
     type LeafHash = IdentityCRH;
     type TwoToOneHash = PoseidonTwoToOneCRH;
     type LeafInnerDigestConverter = IdentityDigestConverter<ScalarField>;

--- a/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
+++ b/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
@@ -1,5 +1,6 @@
-//! Defines mock circuits that expect the same statements & linking relationships
-//! as the Renegade protocol circuits, but are trivially satisfiable
+//! Defines mock circuits that expect the same statements & linking
+//! relationships as the Renegade protocol circuits, but are trivially
+//! satisfiable
 
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
@@ -153,14 +154,8 @@ impl SingleProverCircuit for DummyValidCommitments {
 
         Ok(vec![
             (VALID_REBLIND_COMMITMENTS_LINK.to_string(), Some(layout1)),
-            (
-                VALID_COMMITMENTS_MATCH_SETTLE_LINK0.to_string(),
-                Some(layout2),
-            ),
-            (
-                VALID_COMMITMENTS_MATCH_SETTLE_LINK1.to_string(),
-                Some(layout3),
-            ),
+            (VALID_COMMITMENTS_MATCH_SETTLE_LINK0.to_string(), Some(layout2)),
+            (VALID_COMMITMENTS_MATCH_SETTLE_LINK1.to_string(), Some(layout3)),
         ])
     }
 }
@@ -239,10 +234,7 @@ impl SingleProverCircuit for DummyValidMatchSettleAtomic {
     fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
         let layout = DummyValidMatchSettle::get_circuit_layout()?;
         let group_layout = layout.get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK0);
-        Ok(vec![(
-            VALID_COMMITMENTS_MATCH_SETTLE_LINK0.to_string(),
-            Some(group_layout),
-        )])
+        Ok(vec![(VALID_COMMITMENTS_MATCH_SETTLE_LINK0.to_string(), Some(group_layout))])
     }
 }
 

--- a/contracts-utils/src/proof_system/mod.rs
+++ b/contracts-utils/src/proof_system/mod.rs
@@ -25,10 +25,12 @@ pub mod test_data;
 // | HIGH-LEVEL UTILITIES |
 // ------------------------
 
-/// Generate the verification keys for the circuits involved in settling a matched trade.
+/// Generate the verification keys for the circuits involved in settling a
+/// matched trade.
 ///
-/// Defined generically over the `VALID COMMITMENTS`, `VALID REBLIND`, and `VALID MATCH SETTLE`
-/// circuits, so that this can be used in both testing and production setings.
+/// Defined generically over the `VALID COMMITMENTS`, `VALID REBLIND`, and
+/// `VALID MATCH SETTLE` circuits, so that this can be used in both testing and
+/// production setings.
 pub fn gen_match_vkeys<C, R, M>() -> Result<MatchVkeys, ProofSystemError>
 where
     C: SingleProverCircuit,
@@ -39,14 +41,11 @@ where
     let valid_reblind_vkey = to_contract_vkey((*R::verifying_key()).clone())?;
     let valid_match_settle_vkey = to_contract_vkey((*M::verifying_key()).clone())?;
 
-    Ok(MatchVkeys {
-        valid_commitments_vkey,
-        valid_reblind_vkey,
-        valid_match_settle_vkey,
-    })
+    Ok(MatchVkeys { valid_commitments_vkey, valid_reblind_vkey, valid_match_settle_vkey })
 }
 
-/// Generate the verification keys for the circuits involved in settling a matched trade
+/// Generate the verification keys for the circuits involved in settling a
+/// matched trade
 pub fn gen_match_atomic_vkeys<C, R, M>() -> Result<MatchAtomicVkeys, ProofSystemError>
 where
     C: SingleProverCircuit,
@@ -68,16 +67,19 @@ where
 pub struct MatchGroupLayouts {
     /// The `VALID REBLIND` <-> `VALID COMMITMENTS` link group layout
     pub valid_reblind_commitments: GroupLayout,
-    /// The first party's `VALID COMMITMENTS` <-> `VALID MATCH SETTLE` link group layout
+    /// The first party's `VALID COMMITMENTS` <-> `VALID MATCH SETTLE` link
+    /// group layout
     pub valid_commitments_match_settle_0: GroupLayout,
-    /// The second party's `VALID COMMITMENTS` <-> `VALID MATCH SETTLE` link group layout
+    /// The second party's `VALID COMMITMENTS` <-> `VALID MATCH SETTLE` link
+    /// group layout
     pub valid_commitments_match_settle_1: GroupLayout,
 }
 
-/// Generates the group layouts for the linked circuits involved in settling a matched trade.
+/// Generates the group layouts for the linked circuits involved in settling a
+/// matched trade.
 ///
-/// Defined generically over the `VALID COMMITMENTS` circuit, so that this can be used in both
-/// the testing and production setting.
+/// Defined generically over the `VALID COMMITMENTS` circuit, so that this can
+/// be used in both the testing and production setting.
 pub fn gen_match_layouts<C: SingleProverCircuit>() -> Result<MatchGroupLayouts, ProofSystemError> {
     let valid_commitments_layout = C::get_circuit_layout()
         .map_err(|e| ProofSystemError::ProverError(ProverError::Plonk(e)))?;
@@ -98,10 +100,11 @@ pub fn gen_match_layouts<C: SingleProverCircuit>() -> Result<MatchGroupLayouts, 
     })
 }
 
-/// Generates the linking verification keys for the linked circuits involved in settling a matched trade.
+/// Generates the linking verification keys for the linked circuits involved in
+/// settling a matched trade.
 ///
-/// Defined generically over the `VALID COMMITMENTS` circuit, so that this can be used in both
-/// the testing and production setting.
+/// Defined generically over the `VALID COMMITMENTS` circuit, so that this can
+/// be used in both the testing and production setting.
 pub fn gen_match_linking_vkeys<C: SingleProverCircuit>(
 ) -> Result<MatchLinkingVkeys, ProofSystemError> {
     let MatchGroupLayouts {
@@ -117,14 +120,12 @@ pub fn gen_match_linking_vkeys<C: SingleProverCircuit>(
     })
 }
 
-/// Generate the linking verification keys for the circuits involved in settling an atomic match
+/// Generate the linking verification keys for the circuits involved in settling
+/// an atomic match
 pub fn gen_match_atomic_linking_vkeys<C: SingleProverCircuit>(
 ) -> Result<MatchAtomicLinkingVkeys, ProofSystemError> {
-    let MatchGroupLayouts {
-        valid_reblind_commitments,
-        valid_commitments_match_settle_0,
-        ..
-    } = gen_match_layouts::<C>()?;
+    let MatchGroupLayouts { valid_reblind_commitments, valid_commitments_match_settle_0, .. } =
+        gen_match_layouts::<C>()?;
 
     Ok(MatchAtomicLinkingVkeys {
         valid_reblind_commitments: to_linking_vkey(&valid_reblind_commitments),

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -107,10 +107,7 @@ pub fn dummy_valid_reblind_statement<R: RngCore + CryptoRng>(
     rng: &mut R,
     merkle_root: Scalar,
 ) -> ValidReblindStatement {
-    ValidReblindStatement {
-        merkle_root,
-        ..dummy_circuit_type(rng)
-    }
+    ValidReblindStatement { merkle_root, ..dummy_circuit_type(rng) }
 }
 
 /// Generates a dummy [`SizedValidWalletUpdateStatement`] with the given
@@ -201,14 +198,11 @@ pub fn dummy_valid_fee_redemption_statement<R: RngCore + CryptoRng>(
 /// Creates a dummy statement, uses it to compute a valid proof,
 /// and generates its associated verification key.
 ///
-/// The simplest way to do this is to use the dummy `VALID WALLET CREATE` circuit.
+/// The simplest way to do this is to use the dummy `VALID WALLET CREATE`
+/// circuit.
 pub fn gen_verification_bundle<R: CryptoRng + RngCore>(
     rng: &mut R,
-) -> Result<(
-    ContractValidWalletCreateStatement,
-    ContractProof,
-    VerificationKey,
-)> {
+) -> Result<(ContractValidWalletCreateStatement, ContractProof, VerificationKey)> {
     let statement = dummy_circuit_type(rng);
     let contract_statement = to_contract_valid_wallet_create_statement(&statement);
 
@@ -237,8 +231,8 @@ pub fn gen_new_wallet_data<R: CryptoRng + RngCore>(
 }
 
 /// Generates the inputs for the `update_wallet` darkpool method, namely
-/// a dummy statement and associated proof for the `VALID WALLET UPDATE` circuit,
-/// along with a signature over the commitment to the wallet shares
+/// a dummy statement and associated proof for the `VALID WALLET UPDATE`
+/// circuit, along with a signature over the commitment to the wallet shares
 pub fn gen_update_wallet_data<R: CryptoRng + RngCore>(
     rng: &mut R,
     merkle_root: Scalar,
@@ -277,17 +271,14 @@ pub fn gen_update_wallet_data<R: CryptoRng + RngCore>(
     Ok((proof, contract_statement, wallet_commitment_signature))
 }
 
-/// Generates the inputs for the `settle_online_relayer_fee` darkpool method, namely
-/// a dummy statement and associated proof for the `VALID RELAYER FEE SETTLEMENT` circuit,
-/// along with a signature over the commitment to the wallet shares
+/// Generates the inputs for the `settle_online_relayer_fee` darkpool method,
+/// namely a dummy statement and associated proof for the `VALID RELAYER FEE
+/// SETTLEMENT` circuit, along with a signature over the commitment to the
+/// wallet shares
 pub fn gen_settle_online_relayer_fee_data<R: CryptoRng + RngCore>(
     rng: &mut R,
     merkle_root: Scalar,
-) -> Result<(
-    ContractProof,
-    ContractValidRelayerFeeSettlementStatement,
-    Bytes,
-)> {
+) -> Result<(ContractProof, ContractValidRelayerFeeSettlementStatement, Bytes)> {
     // Generate signing keypair
     let (signing_key, contract_pubkey) = random_keypair(rng);
 
@@ -319,7 +310,8 @@ pub fn gen_settle_online_relayer_fee_data<R: CryptoRng + RngCore>(
 }
 
 /// Generates the inputs for the `settle_offline_fee` darkpool method, namely
-/// a dummy statement and associated proof for the `VALID OFFLINE FEE SETTLEMENT` circuit
+/// a dummy statement and associated proof for the `VALID OFFLINE FEE
+/// SETTLEMENT` circuit
 pub fn gen_settle_offline_fee_data<R: CryptoRng + RngCore>(
     rng: &mut R,
     merkle_root: Scalar,
@@ -344,8 +336,8 @@ pub fn gen_settle_offline_fee_data<R: CryptoRng + RngCore>(
 }
 
 /// Generates the inputs for the `redeem_fee` darkpool method, namely
-/// a dummy statement and associated proof for the `VALID FEE REDEMPTION` circuit,
-/// along with a signature over the commitment to the wallet shares
+/// a dummy statement and associated proof for the `VALID FEE REDEMPTION`
+/// circuit, along with a signature over the commitment to the wallet shares
 pub fn gen_redeem_fee_data<R: CryptoRng + RngCore>(
     rng: &mut R,
     merkle_root: Scalar,
@@ -399,11 +391,7 @@ fn dummy_match_statements<R: CryptoRng + RngCore>(
     rng: &mut R,
     merkle_root: Scalar,
     protocol_fee: FixedPoint,
-) -> (
-    [ValidCommitmentsStatement; 2],
-    [ValidReblindStatement; 2],
-    SizedValidMatchSettleStatement,
-) {
+) -> ([ValidCommitmentsStatement; 2], [ValidReblindStatement; 2], SizedValidMatchSettleStatement) {
     let valid_commitments0: ValidCommitmentsStatement = dummy_circuit_type(rng);
     let valid_commitments1: ValidCommitmentsStatement = dummy_circuit_type(rng);
 
@@ -415,21 +403,15 @@ fn dummy_match_statements<R: CryptoRng + RngCore>(
     valid_match_settle.party1_indices = valid_commitments1.indices;
     valid_match_settle.protocol_fee = protocol_fee;
 
-    (
-        [valid_commitments0, valid_commitments1],
-        [valid_reblind0, valid_reblind1],
-        valid_match_settle,
-    )
+    ([valid_commitments0, valid_commitments1], [valid_reblind0, valid_reblind1], valid_match_settle)
 }
 
-/// Generates dummy witnesses to be used in the proofs submitted to `process_match_settle`
+/// Generates dummy witnesses to be used in the proofs submitted to
+/// `process_match_settle`
 fn dummy_match_witnesses<R: CryptoRng + RngCore>(
     rng: &mut R,
-) -> (
-    [DummyValidCommitmentsWitness; 2],
-    [DummyValidReblindWitness; 2],
-    DummyValidMatchSettleWitness,
-) {
+) -> ([DummyValidCommitmentsWitness; 2], [DummyValidReblindWitness; 2], DummyValidMatchSettleWitness)
+{
     let valid_commitments0: DummyValidCommitmentsWitness = dummy_circuit_type(rng);
     let valid_commitments1: DummyValidCommitmentsWitness = dummy_circuit_type(rng);
 
@@ -445,17 +427,15 @@ fn dummy_match_witnesses<R: CryptoRng + RngCore>(
         valid_commitments_match_settle1: valid_commitments1.valid_commitments_match_settle1,
     };
 
-    (
-        [valid_commitments0, valid_commitments1],
-        [valid_reblind0, valid_reblind1],
-        valid_match_settle,
-    )
+    ([valid_commitments0, valid_commitments1], [valid_reblind0, valid_reblind1], valid_match_settle)
 }
 
-/// A type alias for the proofs and linking hints generated for the `process_match_settle` method
+/// A type alias for the proofs and linking hints generated for the
+/// `process_match_settle` method
 type MatchProofsAndHints = (MatchProofs, [(ProofLinkingHint, ProofLinkingHint); 4]);
 
-/// Generates the proofs and linking hints to be submitted to `process_match_settle`
+/// Generates the proofs and linking hints to be submitted to
+/// `process_match_settle`
 fn match_proofs_and_hints(
     valid_commitments_statements: [ValidCommitmentsStatement; 2],
     valid_commitments_witnesses: [DummyValidCommitmentsWitness; 2],
@@ -528,9 +508,7 @@ fn match_link_proofs(
 
     let (valid_reblind_hint_0, valid_commitments_hint_0) = &link_hints[0];
     let valid_reblind_commitments_0 =
-        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<
-            SolidityTranscript,
-        >(
+        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<SolidityTranscript>(
             valid_reblind_hint_0,
             valid_commitments_hint_0,
             &valid_reblind_commitments_layout,
@@ -539,9 +517,7 @@ fn match_link_proofs(
 
     let (valid_reblind_hint_1, valid_commitments_hint_1) = &link_hints[1];
     let valid_reblind_commitments_1 =
-        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<
-            SolidityTranscript,
-        >(
+        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<SolidityTranscript>(
             valid_reblind_hint_1,
             valid_commitments_hint_1,
             &valid_reblind_commitments_layout,
@@ -550,9 +526,7 @@ fn match_link_proofs(
 
     let (valid_commitments_hint_0, valid_match_settle_hint_0) = &link_hints[2];
     let valid_commitments_match_settle_0 =
-        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<
-            SolidityTranscript,
-        >(
+        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<SolidityTranscript>(
             valid_commitments_hint_0,
             valid_match_settle_hint_0,
             &valid_commitments_match_settle_0_layout,
@@ -561,9 +535,7 @@ fn match_link_proofs(
 
     let (valid_commitments_hint_1, valid_match_settle_hint_1) = &link_hints[3];
     let valid_commitments_match_settle_1 =
-        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<
-            SolidityTranscript,
-        >(
+        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<SolidityTranscript>(
             valid_commitments_hint_1,
             valid_match_settle_hint_1,
             &valid_commitments_match_settle_1_layout,
@@ -622,7 +594,8 @@ pub fn gen_process_match_settle_data<R: CryptoRng + RngCore>(
     })
 }
 
-/// Extract the public inputs from the [`ProcessMatchSettleData`] test data struct
+/// Extract the public inputs from the [`ProcessMatchSettleData`] test data
+/// struct
 fn extract_match_public_inputs(data: &ProcessMatchSettleData) -> MatchPublicInputs {
     MatchPublicInputs {
         valid_commitments_0: statement_to_public_inputs(
@@ -701,11 +674,7 @@ fn dummy_match_atomic_statements<R: CryptoRng + RngCore>(
     protocol_fee: FixedPoint,
     external_party_fees: FeeTake,
     match_result: ExternalMatchResult,
-) -> (
-    ValidCommitmentsStatement,
-    ValidReblindStatement,
-    SizedValidMatchSettleAtomicStatement,
-) {
+) -> (ValidCommitmentsStatement, ValidReblindStatement, SizedValidMatchSettleAtomicStatement) {
     let relayer_fee_address = random_address(rng);
     let relayer_fee_address_biguint = address_to_biguint(relayer_fee_address);
 
@@ -723,14 +692,11 @@ fn dummy_match_atomic_statements<R: CryptoRng + RngCore>(
     (valid_commitments, valid_reblind, valid_match_settle_atomic)
 }
 
-/// Generates dummy witnesses to be used in the proofs submitted to `process_atomic_match_settle`
+/// Generates dummy witnesses to be used in the proofs submitted to
+/// `process_atomic_match_settle`
 fn dummy_match_atomic_witnesses<R: CryptoRng + RngCore>(
     rng: &mut R,
-) -> (
-    DummyValidCommitmentsWitness,
-    DummyValidReblindWitness,
-    DummyValidMatchSettleAtomicWitness,
-) {
+) -> (DummyValidCommitmentsWitness, DummyValidReblindWitness, DummyValidMatchSettleAtomicWitness) {
     let valid_commitments: DummyValidCommitmentsWitness = dummy_circuit_type(rng);
     let valid_reblind = DummyValidReblindWitness {
         valid_reblind_commitments: valid_commitments.valid_reblind_commitments,
@@ -742,10 +708,12 @@ fn dummy_match_atomic_witnesses<R: CryptoRng + RngCore>(
     (valid_commitments, valid_reblind, valid_match_settle_atomic)
 }
 
-/// A type alias for the proofs and linking hints generated for the `process_atomic_match_settle` method
+/// A type alias for the proofs and linking hints generated for the
+/// `process_atomic_match_settle` method
 type MatchAtomicProofsAndHints = (MatchAtomicProofs, [(ProofLinkingHint, ProofLinkingHint); 2]);
 
-/// Generates the proofs and linking hints to be submitted to `process_atomic_match_settle`
+/// Generates the proofs and linking hints to be submitted to
+/// `process_atomic_match_settle`
 fn match_atomic_proofs_and_hints(
     valid_commitments_statement: ValidCommitmentsStatement,
     valid_reblind_statement: ValidReblindStatement,
@@ -772,11 +740,7 @@ fn match_atomic_proofs_and_hints(
     let valid_match_settle_atomic = to_contract_proof(&valid_match_settle_atomic)?;
 
     Ok((
-        MatchAtomicProofs {
-            valid_commitments,
-            valid_reblind,
-            valid_match_settle_atomic,
-        },
+        MatchAtomicProofs { valid_commitments, valid_reblind, valid_match_settle_atomic },
         [
             (valid_reblind_hint, valid_commitments_hint.clone()),
             (valid_commitments_hint, valid_match_settle_atomic_hint),
@@ -784,23 +748,19 @@ fn match_atomic_proofs_and_hints(
     ))
 }
 
-/// Generates the linking proofs to be submitted to `process_atomic_match_settle`
+/// Generates the linking proofs to be submitted to
+/// `process_atomic_match_settle`
 fn match_atomic_link_proofs(
     link_hints: [(ProofLinkingHint, ProofLinkingHint); 2],
 ) -> Result<MatchAtomicLinkingProofs> {
     let commit_key = SYSTEM_SRS.extract_prover_param(DUMMY_CIRCUIT_SRS_DEGREE);
 
-    let MatchGroupLayouts {
-        valid_reblind_commitments,
-        valid_commitments_match_settle_0,
-        ..
-    } = gen_match_layouts::<DummyValidCommitments>()?;
+    let MatchGroupLayouts { valid_reblind_commitments, valid_commitments_match_settle_0, .. } =
+        gen_match_layouts::<DummyValidCommitments>()?;
 
     let (valid_reblind_hint, valid_commitments_hint) = &link_hints[0];
     let valid_reblind_commitments =
-        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<
-            SolidityTranscript,
-        >(
+        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<SolidityTranscript>(
             valid_reblind_hint,
             valid_commitments_hint,
             &valid_reblind_commitments,
@@ -809,9 +769,7 @@ fn match_atomic_link_proofs(
 
     let (valid_commitments_hint, valid_match_settle_atomic_hint) = &link_hints[1];
     let valid_commitments_match_settle_atomic =
-        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<
-            SolidityTranscript,
-        >(
+        to_contract_link_proof(&PlonkKzgSnark::<SystemCurve>::link_proofs::<SolidityTranscript>(
             valid_commitments_hint,
             valid_match_settle_atomic_hint,
             &valid_commitments_match_settle_0,
@@ -824,7 +782,8 @@ fn match_atomic_link_proofs(
     })
 }
 
-/// Generate a `process_atomic_match_settle` payload with the given match and fees
+/// Generate a `process_atomic_match_settle` payload with the given match and
+/// fees
 pub fn gen_atomic_match_with_match_and_fees<R: CryptoRng + RngCore>(
     rng: &mut R,
     merkle_root: Scalar,
@@ -864,7 +823,8 @@ pub fn gen_atomic_match_with_match_and_fees<R: CryptoRng + RngCore>(
     })
 }
 
-/// Picks a random Plonk proof from the batch of proofs verified in `verify_match` and mutates it
+/// Picks a random Plonk proof from the batch of proofs verified in
+/// `verify_match` and mutates it
 pub fn mutate_random_plonk_proof<R: CryptoRng + RngCore>(
     rng: &mut R,
     match_proofs: &mut MatchProofs,
@@ -880,7 +840,8 @@ pub fn mutate_random_plonk_proof<R: CryptoRng + RngCore>(
     proof.z_bar += ScalarField::one();
 }
 
-/// Picks a random linking proof from the batch of proofs verified in `verify_match` and mutates it
+/// Picks a random linking proof from the batch of proofs verified in
+/// `verify_match` and mutates it
 pub fn mutate_random_linking_proof<R: CryptoRng + RngCore>(
     rng: &mut R,
     match_linking_proofs: &mut MatchLinkingProofs,

--- a/integration/src/cli.rs
+++ b/integration/src/cli.rs
@@ -6,7 +6,8 @@ use test_helpers::types::TestVerbosity;
 
 /// CLI tool for running integration tests against a running devnet node.
 ///
-/// Assumes that the contracts invoked in the tests have already been deployed to the devnet.
+/// Assumes that the contracts invoked in the tests have already been deployed
+/// to the devnet.
 #[derive(Parser, Clone)]
 pub(crate) struct Cli {
     /// Test to run

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -19,16 +19,19 @@ pub(crate) const UNPAUSE_METHOD_NAME: &str = "unpause";
 /// The name of the `set_fee` method on the Darkpool contract
 pub(crate) const SET_FEE_METHOD_NAME: &str = "setFee";
 
-/// The name of the `set_core_wallet_ops_address` method on the Darkpool contract
+/// The name of the `set_core_wallet_ops_address` method on the Darkpool
+/// contract
 pub(crate) const SET_CORE_WALLET_OPS_ADDRESS_METHOD_NAME: &str = "setCoreWalletOpsAddress";
 
-/// The name of the `set_core_settlement_address` method on the Darkpool contract
+/// The name of the `set_core_settlement_address` method on the Darkpool
+/// contract
 pub(crate) const SET_CORE_SETTLEMENT_ADDRESS_METHOD_NAME: &str = "setCoreSettlementAddress";
 
 /// The name of the `set_verifier_core_address` method on the Darkpool contract
 pub(crate) const SET_VERIFIER_CORE_ADDRESS_METHOD_NAME: &str = "setVerifierCoreAddress";
 
-/// The name of the `set_verifier_settlement_address` method on the Darkpool contract
+/// The name of the `set_verifier_settlement_address` method on the Darkpool
+/// contract
 pub(crate) const SET_VERIFIER_SETTLEMENT_ADDRESS_METHOD_NAME: &str = "setVerifierSettlementAddress";
 
 /// The name of the `set_vkeys_address` method on the Darkpool contract
@@ -37,7 +40,8 @@ pub(crate) const SET_VKEYS_ADDRESS_METHOD_NAME: &str = "setVkeysAddress";
 /// The name of the `set_merkle_address` method on the Darkpool contract
 pub(crate) const SET_MERKLE_ADDRESS_METHOD_NAME: &str = "setMerkleAddress";
 
-/// The name of the `set_transfer_executor_address` method on the Darkpool contract
+/// The name of the `set_transfer_executor_address` method on the Darkpool
+/// contract
 pub(crate) const SET_TRANSFER_EXECUTOR_ADDRESS_METHOD_NAME: &str = "setTransferExecutorAddress";
 
 /// The name of the domain separator for Permit2 typed data

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,4 +1,5 @@
-//! Basic tests for Stylus programs. These assume that a devnet is already running locally.
+//! Basic tests for Stylus programs. These assume that a devnet is already
+//! running locally.
 
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
@@ -82,20 +83,14 @@ impl TestArgs {
         address: Address,
     ) -> Result<U256> {
         let contract = DummyErc20Contract::new(erc20_address, self.client.clone());
-        contract
-            .balance_of(address)
-            .call()
-            .await
-            .map_err(Into::into)
-            .map(u256_to_alloy_u256)
+        contract.balance_of(address).call().await.map_err(Into::into).map(u256_to_alloy_u256)
     }
 }
 
 impl From<Cli> for TestArgs {
     fn from(value: Cli) -> Self {
-        let client = Handle::current()
-            .block_on(setup_client(&value.priv_key, &value.rpc_url))
-            .unwrap();
+        let client =
+            Handle::current().block_on(setup_client(&value.priv_key, &value.rpc_url)).unwrap();
 
         let darkpool_proxy_address =
             read_deployment_address(&value.deployments_file, DARKPOOL_PROXY_CONTRACT_KEY).unwrap();

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -81,7 +81,8 @@ async fn dummy_external_match_result_and_fees(
     mint_dummy_erc20s(base_mint, base_amount.into(), test_args).await?;
     mint_dummy_erc20s(quote_mint, quote_amount.into(), test_args).await?;
 
-    // The price here does not matter for testing, so we just trade the default funding amount
+    // The price here does not matter for testing, so we just trade the default
+    // funding amount
     let match_result = ExternalMatchResult {
         base_mint: ethers_address_to_biguint(&base_mint),
         quote_mint: ethers_address_to_biguint(&quote_mint),
@@ -189,10 +190,8 @@ async fn test_ec_recover(test_args: TestArgs) -> Result<()> {
     let sig = hash_and_sign_message(&signing_key, &msg);
 
     let msg_hash = keccak256(msg);
-    let res = contract
-        .test_ec_recover(msg_hash.to_vec().into(), sig.to_vec().into())
-        .call()
-        .await?;
+    let res =
+        contract.test_ec_recover(msg_hash.to_vec().into(), sig.to_vec().into()).call().await?;
 
     assert_eq!(
         res,
@@ -212,25 +211,15 @@ async fn test_merkle(test_args: TestArgs) -> Result<()> {
 
     let contract_root = u256_to_scalar(contract.root().call().await?)?;
 
-    assert_eq!(
-        ark_merkle.root(),
-        contract_root,
-        "Initial merkle root incorrect"
-    );
+    assert_eq!(ark_merkle.root(), contract_root, "Initial merkle root incorrect");
 
     let num_leaves = 2_u128.pow((TEST_MERKLE_HEIGHT) as u32);
     let mut rng = thread_rng();
     let leaves = random_scalars(num_leaves as usize, &mut rng);
 
     for (i, leaf) in leaves.into_iter().enumerate() {
-        ark_merkle
-            .update(i, &compute_poseidon_hash(&[leaf]))
-            .map_err(|e| eyre!("{}", e))?;
-        contract
-            .insert_shares_commitment(vec![scalar_to_u256(leaf)])
-            .send()
-            .await?
-            .await?;
+        ark_merkle.update(i, &compute_poseidon_hash(&[leaf])).map_err(|e| eyre!("{}", e))?;
+        contract.insert_shares_commitment(vec![scalar_to_u256(leaf)]).send().await?.await?;
 
         let contract_root = u256_to_scalar(contract.root().call().await?)?;
 
@@ -297,10 +286,8 @@ async fn test_verifier(test_args: TestArgs) -> Result<()> {
         &match_linking_proofs,
     )?;
 
-    let successful_res = settlement_verifier
-        .verify_match(match_verification_bundle_calldata)
-        .call()
-        .await?;
+    let successful_res =
+        settlement_verifier.verify_match(match_verification_bundle_calldata).call().await?;
     assert!(successful_res, "Valid match bundle did not verify");
     // Test invalid batch verification
 
@@ -320,10 +307,8 @@ async fn test_verifier(test_args: TestArgs) -> Result<()> {
         &match_linking_proofs,
     )?;
 
-    let unsuccessful_res = settlement_verifier
-        .verify_match(match_verification_bundle_calldata)
-        .call()
-        .await?;
+    let unsuccessful_res =
+        settlement_verifier.verify_match(match_verification_bundle_calldata).call().await?;
     assert!(!unsuccessful_res, "Invalid match bundle verified");
 
     Ok(())
@@ -341,11 +326,7 @@ async fn test_upgradeable(test_args: TestArgs) -> Result<()> {
     let mut rng = thread_rng();
     let nullifier = scalar_to_u256(ScalarField::rand(&mut rng));
 
-    darkpool
-        .mark_nullifier_spent(nullifier)
-        .send()
-        .await?
-        .await?;
+    darkpool.mark_nullifier_spent(nullifier).send().await?.await?;
 
     // Ensure that only the owner can upgrade the contract
     let dummy_signer = setup_dummy_client(test_args.client.clone()).await?;
@@ -357,7 +338,7 @@ async fn test_upgradeable(test_args: TestArgs) -> Result<()> {
             .upgrade_and_call(
                 test_args.darkpool_proxy_address,
                 test_args.test_upgrade_target_address,
-                Bytes::new(), /* data */
+                Bytes::new(), // data
             )
             .send()
             .await
@@ -370,7 +351,7 @@ async fn test_upgradeable(test_args: TestArgs) -> Result<()> {
         .upgrade_and_call(
             test_args.darkpool_proxy_address,
             test_args.test_upgrade_target_address,
-            Bytes::new(), /* data */
+            Bytes::new(), // data
         )
         .send()
         .await?
@@ -383,10 +364,7 @@ async fn test_upgradeable(test_args: TestArgs) -> Result<()> {
     // by attempting to call the `is_dummy_upgrade_target` method through
     // the proxy, which only exists on the dummy upgrade target
     assert!(
-        dummy_upgrade_target_contract
-            .is_dummy_upgrade_target()
-            .call()
-            .await?,
+        dummy_upgrade_target_contract.is_dummy_upgrade_target().call().await?,
         "Upgrade target contract not upgraded"
     );
 
@@ -437,16 +415,8 @@ async fn test_implementation_address_setters(test_args: TestArgs) -> Result<()> 
             VERIFIER_SETTLEMENT_ADDRESS_SELECTOR,
             test_args.verifier_settlement_address,
         ),
-        (
-            SET_VKEYS_ADDRESS_METHOD_NAME,
-            VKEYS_ADDRESS_SELECTOR,
-            test_args.vkeys_address,
-        ),
-        (
-            SET_MERKLE_ADDRESS_METHOD_NAME,
-            MERKLE_ADDRESS_SELECTOR,
-            test_args.merkle_address,
-        ),
+        (SET_VKEYS_ADDRESS_METHOD_NAME, VKEYS_ADDRESS_SELECTOR, test_args.vkeys_address),
+        (SET_MERKLE_ADDRESS_METHOD_NAME, MERKLE_ADDRESS_SELECTOR, test_args.merkle_address),
         (
             SET_TRANSFER_EXECUTOR_ADDRESS_METHOD_NAME,
             TRANSFER_EXECUTOR_ADDRESS_SELECTOR,
@@ -462,27 +432,16 @@ async fn test_implementation_address_setters(test_args: TestArgs) -> Result<()> 
 
         // Check that the implementation address was set
         assert!(
-            contract
-                .is_implementation_upgraded(address_selector)
-                .call()
-                .await?,
+            contract.is_implementation_upgraded(address_selector).call().await?,
             "Implementation address not set"
         );
 
         // Set the implementation address back to the original address
-        contract
-            .method::<Address, ()>(method, original_address)?
-            .send()
-            .await?
-            .await?;
+        contract.method::<Address, ()>(method, original_address)?.send().await?.await?;
 
         // Check that the implementation address was unset
         assert!(
-            contract
-                .is_implementation_upgraded(address_selector)
-                .call()
-                .await
-                .is_err(),
+            contract.is_implementation_upgraded(address_selector).call().await.is_err(),
             "Implementation address not unset"
         );
     }
@@ -538,13 +497,10 @@ async fn test_ownable(test_args: TestArgs) -> Result<()> {
     let initial_owner = test_args.client.default_sender().unwrap();
 
     // Assert that the owner is set correctly initially
-    assert_eq!(
-        contract.owner().call().await?,
-        initial_owner,
-        "Incorrect initial owner"
-    );
+    assert_eq!(contract.owner().call().await?, initial_owner, "Incorrect initial owner");
 
-    // Set up a dummy owner account and a contract instance with that account attached as the sender
+    // Set up a dummy owner account and a contract instance with that account
+    // attached as the sender
     let dummy_owner = setup_dummy_client(test_args.client.clone()).await?;
     let dummy_owner_address = dummy_owner.default_sender().unwrap();
     let contract_with_dummy_owner = DarkpoolTestContract::new(contract.address(), dummy_owner);
@@ -559,11 +515,7 @@ async fn test_ownable(test_args: TestArgs) -> Result<()> {
     .await?;
 
     // Assert that ownership was properly transferred
-    assert_eq!(
-        contract.owner().call().await?,
-        dummy_owner_address,
-        "Incorrect new owner"
-    );
+    assert_eq!(contract.owner().call().await?, dummy_owner_address, "Incorrect new owner");
 
     // Transfer ownership back so that future tests have the correct owner
     // To do so, we need to fund the dummy signer with some ETH for gas
@@ -573,28 +525,15 @@ async fn test_ownable(test_args: TestArgs) -> Result<()> {
         .to(dummy_owner_address)
         .value(parse_ether(1_u64)?);
 
-    test_args
-        .client
-        .send_transaction(transfer_tx, None)
-        .await?
-        .await?;
+    test_args.client.send_transaction(transfer_tx, None).await?.await?;
 
-    contract_with_dummy_owner
-        .transfer_ownership(initial_owner)
-        .send()
-        .await?
-        .await?;
+    contract_with_dummy_owner.transfer_ownership(initial_owner).send().await?.await?;
 
     // Assert that only the owner can call the `pause`/`unpause` methods
     assert_only_owner::<_, ()>(&contract, &contract_with_dummy_owner, PAUSE_METHOD_NAME, ())
         .await?;
-    assert_only_owner::<_, ()>(
-        &contract,
-        &contract_with_dummy_owner,
-        UNPAUSE_METHOD_NAME,
-        (),
-    )
-    .await?;
+    assert_only_owner::<_, ()>(&contract, &contract_with_dummy_owner, UNPAUSE_METHOD_NAME, ())
+        .await?;
 
     // Assert that only the owner can call the `set_fee` method
     assert_only_owner::<_, U256>(
@@ -644,9 +583,8 @@ async fn test_pausable(test_args: TestArgs) -> Result<()> {
 
     let mut rng = thread_rng();
     let contract_root = Scalar::new(u256_to_scalar(contract.get_root().call().await?)?);
-    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(
-        contract.get_fee().call().await?,
-    )?));
+    let protocol_fee =
+        FixedPoint::from(Scalar::new(u256_to_scalar(contract.get_fee().call().await?)?));
 
     contract.pause().send().await?.await?;
 
@@ -681,7 +619,7 @@ async fn test_pausable(test_args: TestArgs) -> Result<()> {
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
                 update_wallet_commitment_signature.clone(),
-                Bytes::new(), /* transfer_aux_data */
+                Bytes::new(), // transfer_aux_data
             )
             .send(),
         contract
@@ -720,7 +658,7 @@ async fn test_pausable(test_args: TestArgs) -> Result<()> {
                 serialize_to_calldata(&update_wallet_proof)?,
                 serialize_to_calldata(&update_wallet_statement)?,
                 update_wallet_commitment_signature,
-                Bytes::new(), /* transfer_aux_data */
+                Bytes::new(), // transfer_aux_data
             )
             .send(),
         contract
@@ -756,11 +694,7 @@ async fn test_nullifier_set(test_args: TestArgs) -> Result<()> {
 
     assert!(!nullifier_spent, "Nullifier already spent");
 
-    contract
-        .mark_nullifier_spent(nullifier)
-        .send()
-        .await?
-        .await?;
+    contract.mark_nullifier_spent(nullifier).send().await?.await?;
 
     let nullifier_spent = contract.is_nullifier_spent(nullifier).call().await?;
 
@@ -780,10 +714,7 @@ async fn test_public_blinder_uniqueness_check(test_args: TestArgs) -> Result<()>
     let blinder_idx = statement.public_wallet_shares.len() - 1;
     let original_blinder = statement.public_wallet_shares[blinder_idx];
     contract
-        .new_wallet(
-            serialize_to_calldata(&proof)?,
-            serialize_to_calldata(&statement)?,
-        )
+        .new_wallet(serialize_to_calldata(&proof)?, serialize_to_calldata(&statement)?)
         .send()
         .await?
         .await?;
@@ -792,10 +723,7 @@ async fn test_public_blinder_uniqueness_check(test_args: TestArgs) -> Result<()>
     let (proof, mut statement) = gen_new_wallet_data(&mut rng)?;
     statement.public_wallet_shares[blinder_idx] = original_blinder;
     let is_err = contract
-        .new_wallet(
-            serialize_to_calldata(&proof)?,
-            serialize_to_calldata(&statement)?,
-        )
+        .new_wallet(serialize_to_calldata(&proof)?, serialize_to_calldata(&statement)?)
         .send()
         .await
         .is_err();
@@ -814,12 +742,9 @@ async fn test_external_transfer(test_args: TestArgs) -> Result<()> {
         test_args.client.clone(),
     );
 
-    // Initialize the transfer executor with the address of the Permit2 contract being used
-    transfer_executor_contract
-        .init(test_args.permit2_address)
-        .send()
-        .await?
-        .await?;
+    // Initialize the transfer executor with the address of the Permit2 contract
+    // being used
+    transfer_executor_contract.init(test_args.permit2_address).send().await?.await?;
 
     let test_erc20_contract =
         DummyErc20Contract::new(test_args.test_erc20_address1, test_args.client.clone());
@@ -827,14 +752,9 @@ async fn test_external_transfer(test_args: TestArgs) -> Result<()> {
     let account_address = test_args.client.default_sender().unwrap();
     let mint = test_args.test_erc20_address1;
 
-    let contract_initial_balance = test_erc20_contract
-        .balance_of(test_args.transfer_executor_address)
-        .call()
-        .await?;
-    let user_initial_balance = test_erc20_contract
-        .balance_of(account_address)
-        .call()
-        .await?;
+    let contract_initial_balance =
+        test_erc20_contract.balance_of(test_args.transfer_executor_address).call().await?;
+    let user_initial_balance = test_erc20_contract.balance_of(account_address).call().await?;
 
     let (signing_key, pk_root) = random_keypair(&mut thread_rng());
 
@@ -877,10 +797,7 @@ async fn test_external_transfer(test_args: TestArgs) -> Result<()> {
         contract_balance, contract_initial_balance,
         "Post-withdrawal contract balance incorrect"
     );
-    assert_eq!(
-        user_balance, user_initial_balance,
-        "Post-withdrawal user balance incorrect"
-    );
+    assert_eq!(user_balance, user_initial_balance, "Post-withdrawal user balance incorrect");
 
     Ok(())
 }
@@ -894,12 +811,9 @@ async fn test_external_transfer__wrong_eth_addr(test_args: TestArgs) -> Result<(
         test_args.client.clone(),
     );
 
-    // Initialize the transfer executor with the address of the Permit2 contract being used
-    transfer_executor_contract
-        .init(test_args.permit2_address)
-        .send()
-        .await?
-        .await?;
+    // Initialize the transfer executor with the address of the Permit2 contract
+    // being used
+    transfer_executor_contract.init(test_args.permit2_address).send().await?.await?;
 
     let test_erc20_contract =
         DummyErc20Contract::new(test_args.test_erc20_address1, test_args.client.clone());
@@ -910,15 +824,12 @@ async fn test_external_transfer__wrong_eth_addr(test_args: TestArgs) -> Result<(
     // Generate dummy address & fund with some ERC20 tokens
     // (lack of funding should not be the reason the test fails)
     let dummy_address = Address::random();
-    test_erc20_contract
-        .mint(dummy_address, U256::from(TEST_FUNDING_AMOUNT))
-        .send()
-        .await?
-        .await?;
+    test_erc20_contract.mint(dummy_address, U256::from(TEST_FUNDING_AMOUNT)).send().await?.await?;
 
     let (signing_key, pk_root) = random_keypair(&mut thread_rng());
 
-    // Create & execute deposit external transfer, attempting to deposit from the dummy address
+    // Create & execute deposit external transfer, attempting to deposit from the
+    // dummy address
     let deposit = dummy_erc20_deposit(dummy_address, mint);
     assert!(
         execute_transfer_and_get_balances(
@@ -949,12 +860,9 @@ async fn test_external_transfer__wrong_rng_wallet(test_args: TestArgs) -> Result
         test_args.client.clone(),
     );
 
-    // Initialize the transfer executor with the address of the Permit2 contract being used
-    transfer_executor_contract
-        .init(test_args.permit2_address)
-        .send()
-        .await?
-        .await?;
+    // Initialize the transfer executor with the address of the Permit2 contract
+    // being used
+    transfer_executor_contract.init(test_args.permit2_address).send().await?.await?;
 
     let account_address = test_args.client.default_sender().unwrap();
     let mint = test_args.test_erc20_address1;
@@ -972,7 +880,8 @@ async fn test_external_transfer__wrong_rng_wallet(test_args: TestArgs) -> Result
     )
     .await?;
 
-    // Execute the deposit with a pk_root that does not match the one in the aux data
+    // Execute the deposit with a pk_root that does not match the one in the aux
+    // data
     let (_, dummy_pk_root) = random_keypair(&mut rng);
     assert!(
         transfer_executor_contract
@@ -999,12 +908,9 @@ async fn test_external_transfer__malicious_withdrawal(test_args: TestArgs) -> Re
         test_args.client.clone(),
     );
 
-    // Initialize the transfer executor with the address of the Permit2 contract being used
-    transfer_executor_contract
-        .init(test_args.permit2_address)
-        .send()
-        .await?
-        .await?;
+    // Initialize the transfer executor with the address of the Permit2 contract
+    // being used
+    transfer_executor_contract.init(test_args.permit2_address).send().await?.await?;
 
     let test_erc20_contract =
         DummyErc20Contract::new(test_args.test_erc20_address1, test_args.client.clone());
@@ -1015,10 +921,7 @@ async fn test_external_transfer__malicious_withdrawal(test_args: TestArgs) -> Re
     // Fund contract with some ERC20 tokens
     // (lack of funding should not be the reason the test fails)
     test_erc20_contract
-        .mint(
-            test_args.transfer_executor_address,
-            U256::from(TEST_FUNDING_AMOUNT),
-        )
+        .mint(test_args.transfer_executor_address, U256::from(TEST_FUNDING_AMOUNT))
         .send()
         .await?
         .await?;
@@ -1056,10 +959,7 @@ async fn test_external_transfer__malicious_withdrawal(test_args: TestArgs) -> Re
 
     // Burn contract tokens so future tests are unaffected
     test_erc20_contract
-        .burn(
-            test_args.transfer_executor_address,
-            U256::from(TEST_FUNDING_AMOUNT),
-        )
+        .burn(test_args.transfer_executor_address, U256::from(TEST_FUNDING_AMOUNT))
         .send()
         .await?
         .await?;
@@ -1080,10 +980,7 @@ async fn test_new_wallet(test_args: TestArgs) -> Result<()> {
 
     // Call `new_wallet`
     contract
-        .new_wallet(
-            serialize_to_calldata(&proof)?,
-            serialize_to_calldata(&statement)?,
-        )
+        .new_wallet(serialize_to_calldata(&proof)?, serialize_to_calldata(&statement)?)
         .send()
         .await?
         .await?;
@@ -1095,7 +992,7 @@ async fn test_new_wallet(test_args: TestArgs) -> Result<()> {
         &mut ark_merkle,
         statement.private_shares_commitment,
         &statement.public_wallet_shares,
-        0, /* index */
+        0, // index
     )?;
 
     let contract_root = u256_to_scalar(contract.get_root().call().await?)?;
@@ -1128,7 +1025,7 @@ async fn test_update_wallet(test_args: TestArgs) -> Result<()> {
             serialize_to_calldata(&proof)?,
             serialize_to_calldata(&statement)?,
             wallet_commitment_signature,
-            Bytes::new(), /* transfer_aux_data */
+            Bytes::new(), // transfer_aux_data
         )
         .send()
         .await?
@@ -1145,7 +1042,7 @@ async fn test_update_wallet(test_args: TestArgs) -> Result<()> {
         &mut ark_merkle,
         statement.new_private_shares_commitment,
         &statement.new_public_shares,
-        0, /* index */
+        0, // index
     )
     .map_err(|e| eyre!("{}", e))?;
 
@@ -1168,9 +1065,8 @@ async fn test_process_match_settle_success(test_args: TestArgs) -> Result<()> {
     let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
 
     let contract_root = Scalar::new(u256_to_scalar(contract.get_root().call().await?)?);
-    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(
-        contract.get_fee().call().await?,
-    )?));
+    let protocol_fee =
+        FixedPoint::from(Scalar::new(u256_to_scalar(contract.get_fee().call().await?)?));
     let mut rng = thread_rng();
     let data = gen_process_match_settle_data(&mut rng, contract_root, protocol_fee)?;
 
@@ -1188,46 +1084,30 @@ async fn test_process_match_settle_success(test_args: TestArgs) -> Result<()> {
         .await?;
 
     // Assert that correct nullifiers are spent
-    let party_0_nullifier = scalar_to_u256(
-        data.match_payload_0
-            .valid_reblind_statement
-            .original_shares_nullifier,
-    );
-    let party_1_nullifier = scalar_to_u256(
-        data.match_payload_1
-            .valid_reblind_statement
-            .original_shares_nullifier,
-    );
+    let party_0_nullifier =
+        scalar_to_u256(data.match_payload_0.valid_reblind_statement.original_shares_nullifier);
+    let party_1_nullifier =
+        scalar_to_u256(data.match_payload_1.valid_reblind_statement.original_shares_nullifier);
 
-    let party_0_nullifier_spent = contract
-        .is_nullifier_spent(party_0_nullifier)
-        .call()
-        .await?;
+    let party_0_nullifier_spent = contract.is_nullifier_spent(party_0_nullifier).call().await?;
     assert!(party_0_nullifier_spent, "Party 0 nullifier not spent");
 
-    let party_1_nullifier_spent = contract
-        .is_nullifier_spent(party_1_nullifier)
-        .call()
-        .await?;
+    let party_1_nullifier_spent = contract.is_nullifier_spent(party_1_nullifier).call().await?;
     assert!(party_1_nullifier_spent, "Party 1 nullifier not spent");
 
     // Assert that Merkle root is correct
     insert_shares_and_get_root(
         &mut ark_merkle,
-        data.match_payload_0
-            .valid_reblind_statement
-            .reblinded_private_shares_commitment,
+        data.match_payload_0.valid_reblind_statement.reblinded_private_shares_commitment,
         &data.valid_match_settle_statement.party0_modified_shares,
-        0, /* index */
+        0, // index
     )
     .map_err(|e| eyre!("{}", e))?;
     let ark_root = insert_shares_and_get_root(
         &mut ark_merkle,
-        data.match_payload_1
-            .valid_reblind_statement
-            .reblinded_private_shares_commitment,
+        data.match_payload_1.valid_reblind_statement.reblinded_private_shares_commitment,
         &data.valid_match_settle_statement.party1_modified_shares,
-        1, /* index */
+        1, // index
     )
     .map_err(|e| eyre!("{}", e))?;
 
@@ -1249,16 +1129,13 @@ async fn test_process_match_settle__inconsistent_indices(test_args: TestArgs) ->
     contract.clear_merkle().send().await?.await?;
 
     let contract_root = Scalar::new(u256_to_scalar(contract.get_root().call().await?)?);
-    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(
-        contract.get_fee().call().await?,
-    )?));
+    let protocol_fee =
+        FixedPoint::from(Scalar::new(u256_to_scalar(contract.get_fee().call().await?)?));
     let mut rng = thread_rng();
 
     let mut data = gen_process_match_settle_data(&mut rng, contract_root, protocol_fee)?;
     // Mutate the order settlement indices to be inconsistent
-    data.valid_match_settle_statement
-        .party0_indices
-        .balance_receive += 1;
+    data.valid_match_settle_statement.party0_indices.balance_receive += 1;
 
     // Call `process_match_settle` with invalid data
     assert!(
@@ -1290,9 +1167,8 @@ async fn test_process_match_settle__inconsistent_fee(test_args: TestArgs) -> Res
     contract.clear_merkle().send().await?.await?;
 
     let contract_root = Scalar::new(u256_to_scalar(contract.get_root().call().await?)?);
-    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(
-        contract.get_fee().call().await?,
-    )?));
+    let protocol_fee =
+        FixedPoint::from(Scalar::new(u256_to_scalar(contract.get_fee().call().await?)?));
     let mut rng = thread_rng();
 
     let mut data = gen_process_match_settle_data(&mut rng, contract_root, protocol_fee)?;
@@ -1332,9 +1208,8 @@ async fn setup_atomic_match_settle_test(
 
     let mut rng = thread_rng();
     let contract_root = Scalar::new(u256_to_scalar(contract.get_root().call().await?)?);
-    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(
-        contract.get_fee().call().await?,
-    )?));
+    let protocol_fee =
+        FixedPoint::from(Scalar::new(u256_to_scalar(contract.get_fee().call().await?)?));
 
     let (match_result, fees) = dummy_external_match_result_and_fees(buy_side, test_args).await?;
     let data = gen_atomic_match_with_match_and_fees(
@@ -1371,9 +1246,7 @@ async fn test_process_atomic_match_settle__internal_party(test_args: TestArgs) -
 
     // Assert nullifier is spent
     let nullifier = scalar_to_u256(
-        data.internal_party_match_payload
-            .valid_reblind_statement
-            .original_shares_nullifier,
+        data.internal_party_match_payload.valid_reblind_statement.original_shares_nullifier,
     );
     let nullifier_spent = contract.is_nullifier_spent(nullifier).call().await?;
     assert!(nullifier_spent, "Nullifier not spent");
@@ -1385,9 +1258,7 @@ async fn test_process_atomic_match_settle__internal_party(test_args: TestArgs) -
         data.internal_party_match_payload
             .valid_reblind_statement
             .reblinded_private_shares_commitment,
-        &data
-            .valid_match_settle_atomic_statement
-            .internal_party_modified_shares,
+        &data.valid_match_settle_atomic_statement.internal_party_modified_shares,
         0,
     )?;
     let actual_root = u256_to_scalar(contract.get_root().call().await?)?;
@@ -1413,20 +1284,15 @@ async fn test_process_atomic_match_settle__external_party_buy_side(
     let relayer_fee_addr = alloy_address_to_ethers_address(
         &data.valid_match_settle_atomic_statement.relayer_fee_address,
     );
-    let protocol_fee_addr = darkpool
-        .get_protocol_external_fee_collection_address()
-        .call()
-        .await?;
+    let protocol_fee_addr = darkpool.get_protocol_external_fee_collection_address().call().await?;
 
     // Record initial balances
     let initial_base_balance = test_args.get_erc20_balance(base_addr).await?;
     let initial_quote_balance = test_args.get_erc20_balance(quote_addr).await?;
-    let initial_relayer_balance = test_args
-        .get_erc20_balance_of(base_addr, relayer_fee_addr)
-        .await?;
-    let initial_protocol_balance = test_args
-        .get_erc20_balance_of(base_addr, protocol_fee_addr)
-        .await?;
+    let initial_relayer_balance =
+        test_args.get_erc20_balance_of(base_addr, relayer_fee_addr).await?;
+    let initial_protocol_balance =
+        test_args.get_erc20_balance_of(base_addr, protocol_fee_addr).await?;
 
     // Call process_atomic_match_settle
     darkpool
@@ -1445,12 +1311,8 @@ async fn test_process_atomic_match_settle__external_party_buy_side(
     let fees = &data.valid_match_settle_atomic_statement.external_party_fees;
     let final_balance_base = test_args.get_erc20_balance(base_addr).await?;
     let final_balance_quote = test_args.get_erc20_balance(quote_addr).await?;
-    let relayer_balance = test_args
-        .get_erc20_balance_of(base_addr, relayer_fee_addr)
-        .await?;
-    let protocol_balance = test_args
-        .get_erc20_balance_of(base_addr, protocol_fee_addr)
-        .await?;
+    let relayer_balance = test_args.get_erc20_balance_of(base_addr, relayer_fee_addr).await?;
+    let protocol_balance = test_args.get_erc20_balance_of(base_addr, protocol_fee_addr).await?;
 
     let expected_quote_balance = initial_quote_balance - match_result.quote_amount;
     let expected_base_balance = initial_base_balance + match_result.base_amount - fees.total();
@@ -1494,20 +1356,15 @@ async fn test_process_atomic_match_settle__external_party_sell_side(
     let relayer_fee_addr = alloy_address_to_ethers_address(
         &data.valid_match_settle_atomic_statement.relayer_fee_address,
     );
-    let protocol_fee_addr = darkpool
-        .get_protocol_external_fee_collection_address()
-        .call()
-        .await?;
+    let protocol_fee_addr = darkpool.get_protocol_external_fee_collection_address().call().await?;
 
     // Record initial balances
     let initial_base_balance = test_args.get_erc20_balance(base_addr).await?;
     let initial_quote_balance = test_args.get_erc20_balance(quote_addr).await?;
-    let initial_relayer_balance = test_args
-        .get_erc20_balance_of(quote_addr, relayer_fee_addr)
-        .await?;
-    let initial_protocol_balance = test_args
-        .get_erc20_balance_of(quote_addr, protocol_fee_addr)
-        .await?;
+    let initial_relayer_balance =
+        test_args.get_erc20_balance_of(quote_addr, relayer_fee_addr).await?;
+    let initial_protocol_balance =
+        test_args.get_erc20_balance_of(quote_addr, protocol_fee_addr).await?;
 
     // Call process_atomic_match_settle
     darkpool
@@ -1526,12 +1383,8 @@ async fn test_process_atomic_match_settle__external_party_sell_side(
     let fees = &data.valid_match_settle_atomic_statement.external_party_fees;
     let final_balance_base = test_args.get_erc20_balance(base_addr).await?;
     let final_balance_quote = test_args.get_erc20_balance(quote_addr).await?;
-    let relayer_balance = test_args
-        .get_erc20_balance_of(quote_addr, relayer_fee_addr)
-        .await?;
-    let protocol_balance = test_args
-        .get_erc20_balance_of(quote_addr, protocol_fee_addr)
-        .await?;
+    let relayer_balance = test_args.get_erc20_balance_of(quote_addr, relayer_fee_addr).await?;
+    let protocol_balance = test_args.get_erc20_balance_of(quote_addr, protocol_fee_addr).await?;
 
     let expected_quote_balance = initial_quote_balance + match_result.quote_amount - fees.total();
     let expected_base_balance = initial_base_balance - match_result.base_amount;
@@ -1566,9 +1419,7 @@ async fn test_process_atomic_match_settle_inconsistent_indices(test_args: TestAr
     let mut data = setup_atomic_match_settle_test(true /* buy_side */, &test_args).await?;
 
     // Modify the index to make it inconsistent
-    data.valid_match_settle_atomic_statement
-        .internal_party_indices
-        .balance_receive += 1;
+    data.valid_match_settle_atomic_statement.internal_party_indices.balance_receive += 1;
 
     // Call process_atomic_match_settle
     let call = contract.process_atomic_match_settle(
@@ -1579,10 +1430,7 @@ async fn test_process_atomic_match_settle_inconsistent_indices(test_args: TestAr
     );
     let result = call.send().await;
 
-    assert!(
-        result.is_err(),
-        "Expected error due to inconsistent indices"
-    );
+    assert!(result.is_err(), "Expected error due to inconsistent indices");
 
     Ok(())
 }
@@ -1608,10 +1456,7 @@ async fn test_process_atomic_match_settle_inconsistent_protocol_fee(
     );
     let result = call.send().await;
 
-    assert!(
-        result.is_err(),
-        "Expected error due to inconsistent protocol fee"
-    );
+    assert!(result.is_err(), "Expected error due to inconsistent protocol fee");
 
     Ok(())
 }
@@ -1651,10 +1496,7 @@ async fn test_settle_online_relayer_fee(test_args: TestArgs) -> Result<()> {
     assert!(nullifier_spent, "Sender nullifier not spent");
 
     let recipient_nullifier = scalar_to_u256(statement.recipient_nullifier);
-    let nullifier_spent = contract
-        .is_nullifier_spent(recipient_nullifier)
-        .call()
-        .await?;
+    let nullifier_spent = contract.is_nullifier_spent(recipient_nullifier).call().await?;
     assert!(nullifier_spent, "Recipient nullifier not spent");
 
     // Assert that Merkle root is correct
@@ -1663,7 +1505,7 @@ async fn test_settle_online_relayer_fee(test_args: TestArgs) -> Result<()> {
         &mut ark_merkle,
         statement.sender_wallet_commitment,
         &statement.sender_updated_public_shares,
-        0, /* index */
+        0, // index
     )
     .map_err(|e| eyre!("{}", e))?;
 
@@ -1671,7 +1513,7 @@ async fn test_settle_online_relayer_fee(test_args: TestArgs) -> Result<()> {
         &mut ark_merkle,
         statement.recipient_wallet_commitment,
         &statement.recipient_updated_public_shares,
-        1, /* index */
+        1, // index
     )
     .map_err(|e| eyre!("{}", e))?;
 
@@ -1701,15 +1543,12 @@ async fn test_settle_offline_fee(test_args: TestArgs) -> Result<()> {
         &mut rng,
         Scalar::new(contract_root),
         protocol_pubkey,
-        true, /* is_protocol_fee */
+        true, // is_protocol_fee
     )?;
 
     // Call `settle_offline_fee`
     contract
-        .settle_offline_fee(
-            serialize_to_calldata(&proof)?,
-            serialize_to_calldata(&statement)?,
-        )
+        .settle_offline_fee(serialize_to_calldata(&proof)?, serialize_to_calldata(&statement)?)
         .send()
         .await?
         .await?;
@@ -1726,12 +1565,12 @@ async fn test_settle_offline_fee(test_args: TestArgs) -> Result<()> {
         &mut ark_merkle,
         statement.updated_wallet_commitment,
         &statement.updated_wallet_public_shares,
-        0, /* index */
+        0, // index
     )
     .map_err(|e| eyre!("{}", e))?;
 
     ark_merkle
-        .update(1 /*index */, &statement.note_commitment)
+        .update(1 /* index */, &statement.note_commitment)
         .map_err(|_| eyre!("Failed to update Arkworks Merkle tree"))?;
 
     let contract_root = u256_to_scalar(contract.get_root().call().await?)?;
@@ -1763,16 +1602,13 @@ async fn test_settle_offline_fee__incorrect_protocol_key(test_args: TestArgs) ->
         &mut rng,
         Scalar::new(contract_root),
         protocol_pubkey,
-        true, /* is_protocol_fee */
+        true, // is_protocol_fee
     )?;
 
     // Call `settle_offline_fee` with invalid data
     assert!(
         contract
-            .settle_offline_fee(
-                serialize_to_calldata(&proof)?,
-                serialize_to_calldata(&statement)?,
-            )
+            .settle_offline_fee(serialize_to_calldata(&proof)?, serialize_to_calldata(&statement)?,)
             .send()
             .await
             .is_err(),
@@ -1813,10 +1649,7 @@ async fn test_redeem_fee(test_args: TestArgs) -> Result<()> {
     // Assert that both recipient & note nullifiers are spent
 
     let recipient_nullifier = scalar_to_u256(statement.nullifier);
-    let nullifier_spent = contract
-        .is_nullifier_spent(recipient_nullifier)
-        .call()
-        .await?;
+    let nullifier_spent = contract.is_nullifier_spent(recipient_nullifier).call().await?;
     assert!(nullifier_spent, "Recipient nullifier not spent");
 
     let note_nullifier = scalar_to_u256(statement.note_nullifier);
@@ -1829,7 +1662,7 @@ async fn test_redeem_fee(test_args: TestArgs) -> Result<()> {
         &mut ark_merkle,
         statement.new_wallet_commitment,
         &statement.new_wallet_public_shares,
-        0, /* index */
+        0, // index
     )
     .map_err(|e| eyre!("{}", e))?;
 

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -64,7 +64,8 @@ pub fn alloy_address_to_ethers_address(address: &AlloyAddress) -> Address {
 
 /// Convert an ethers `Address` to a `BigUint`
 ///
-/// Call out to the alloy helper to ensure that address formats are the same throughout test helpers
+/// Call out to the alloy helper to ensure that address formats are the same
+/// throughout test helpers
 pub fn ethers_address_to_biguint(address: &Address) -> BigUint {
     let alloy_address = ethers_address_to_alloy_address(address);
     address_to_biguint(alloy_address)
@@ -131,7 +132,8 @@ pub(crate) fn dummy_erc20_withdrawal(account_addr: Address, mint: Address) -> Ex
     dummy_erc20_external_transfer(account_addr, mint, true)
 }
 
-/// Executes the given transfer and returns the resulting balances of the darkpool and user
+/// Executes the given transfer and returns the resulting balances of the
+/// darkpool and user
 pub(crate) async fn execute_transfer_and_get_balances(
     transfer_executor_contract: &TransferExecutorContract<LocalWalletHttpClient>,
     dummy_erc20_contract: &DummyErc20Contract<LocalWalletHttpClient>,
@@ -160,15 +162,10 @@ pub(crate) async fn execute_transfer_and_get_balances(
         .await?
         .await?;
 
-    let darkpool_balance = dummy_erc20_contract
-        .balance_of(transfer_executor_contract.address())
-        .call()
-        .await?;
+    let darkpool_balance =
+        dummy_erc20_contract.balance_of(transfer_executor_contract.address()).call().await?;
 
-    let user_balance = dummy_erc20_contract
-        .balance_of(account_address)
-        .call()
-        .await?;
+    let user_balance = dummy_erc20_contract.balance_of(account_address).call().await?;
 
     Ok((darkpool_balance, user_balance))
 }
@@ -228,13 +225,8 @@ pub(crate) async fn gen_permit_payload(
         pkRoot: pk_to_u256s(&pk_root).map_err(|_| eyre!("Failed to convert pk_root to u256s"))?,
     };
 
-    let signable_permit = PermitWitnessTransferFrom {
-        permitted,
-        spender,
-        nonce,
-        deadline,
-        witness,
-    };
+    let signable_permit =
+        PermitWitnessTransferFrom { permitted, spender, nonce, deadline, witness };
 
     // Construct the EIP712 domain
     let permit2_address = AlloyAddress::from_slice(permit2_address.as_bytes());
@@ -255,17 +247,14 @@ pub(crate) async fn gen_permit_payload(
 
 /// Mint dummy ERC20 tokens for testing
 ///
-/// Mint to both the user and the darkpool so that both are sufficiently capitalized
+/// Mint to both the user and the darkpool so that both are sufficiently
+/// capitalized
 pub async fn mint_dummy_erc20s(mint: Address, amount: U256, test_args: &TestArgs) -> Result<()> {
     let address = test_args.client.address();
     let darkpool_address = test_args.darkpool_proxy_address;
     let contract = DummyErc20Contract::new(mint, test_args.client.clone());
     contract.mint(address, amount).send().await?.await?;
-    contract
-        .mint(darkpool_address, amount)
-        .send()
-        .await?
-        .await?;
+    contract.mint(darkpool_address, amount).send().await?.await?;
 
     Ok(())
 }
@@ -276,20 +265,12 @@ pub async fn setup_external_match_token_approvals(
     match_result: &ExternalMatchResult,
     test_args: &TestArgs,
 ) -> Result<()> {
-    let mint = if buy_side {
-        &match_result.quote_mint
-    } else {
-        &match_result.base_mint
-    };
+    let mint = if buy_side { &match_result.quote_mint } else { &match_result.base_mint };
 
     let mint = biguint_to_ethers_address(mint);
     let contract = DummyErc20Contract::new(mint, test_args.client.clone());
     let amount = TEST_FUNDING_AMOUNT;
-    contract
-        .approve(test_args.darkpool_proxy_address, amount.into())
-        .send()
-        .await?
-        .await?;
+    contract.approve(test_args.darkpool_proxy_address, amount.into()).send().await?.await?;
 
     Ok(())
 }
@@ -298,10 +279,12 @@ pub async fn setup_external_match_token_approvals(
 /// which correctly encodes the data for the nested `TokenPermissions` struct.
 ///
 /// We do so by mirroring the functionality implemented in the `sol!` macro (https://github.com/alloy-rs/core/blob/v0.3.1/crates/sol-macro/src/expand/struct.rs#L56)
-/// but avoiding the (unintended) extra hash of the `TokenPermissions` struct's EIP-712 struct hash.
+/// but avoiding the (unintended) extra hash of the `TokenPermissions` struct's
+/// EIP-712 struct hash.
 ///
 /// This is fixed here: https://github.com/alloy-rs/core/pull/258
-/// But the version of `alloy` used by `stylus-sdk` is not updated to include this fix.
+/// But the version of `alloy` used by `stylus-sdk` is not updated to include
+/// this fix.
 ///
 /// TODO: Remove this function when `stylus-sdk` uses `alloy >= 0.4.0`
 fn permit_signing_hash(permit: &PermitWitnessTransferFrom, domain: &Eip712Domain) -> B256 {
@@ -347,10 +330,7 @@ pub async fn get_protocol_pubkey(
     darkpool_contract: &DarkpoolTestContract<LocalWalletHttpClient>,
 ) -> Result<EncryptionKey> {
     let [x, y] = darkpool_contract.get_pubkey().call().await?;
-    Ok(EncryptionKey {
-        x: Scalar::new(u256_to_scalar(x)?),
-        y: Scalar::new(u256_to_scalar(y)?),
-    })
+    Ok(EncryptionKey { x: Scalar::new(u256_to_scalar(x)?), y: Scalar::new(u256_to_scalar(y)?) })
 }
 
 /// Computes a commitment to the given wallet shares, inserts them
@@ -375,7 +355,8 @@ pub(crate) fn insert_shares_and_get_root(
 // | Contract Assertions |
 // -----------------------
 
-/// Asserts that the given method can only be called by the owner of the darkpool contract
+/// Asserts that the given method can only be called by the owner of the
+/// darkpool contract
 pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(
     contract: &DarkpoolTestContract<LocalWalletHttpClient>,
     contract_with_dummy_owner: &DarkpoolTestContract<LocalWalletHttpClient>,
@@ -383,11 +364,7 @@ pub async fn assert_only_owner<T: Tokenize + Clone, D: Detokenize>(
     args: T,
 ) -> Result<()> {
     assert!(
-        contract_with_dummy_owner
-            .method::<T, D>(method, args.clone())?
-            .send()
-            .await
-            .is_err(),
+        contract_with_dummy_owner.method::<T, D>(method, args.clone())?.send().await.is_err(),
         "Called {} as non-owner",
         method
     );
@@ -413,10 +390,7 @@ pub async fn assert_all_revert<'a>(
     >,
 ) -> Result<()> {
     for tx in txs {
-        assert!(
-            tx.await.is_err(),
-            "Expected transaction to revert, but it succeeded"
-        );
+        assert!(tx.await.is_err(), "Expected transaction to revert, but it succeeded");
     }
 
     Ok(())
@@ -434,10 +408,7 @@ pub async fn assert_all_succeed<'a>(
     >,
 ) -> Result<()> {
     for tx in txs {
-        assert!(
-            tx.await.is_ok(),
-            "Expected transaction to succeed, but it reverted"
-        );
+        assert!(tx.await.is_ok(), "Expected transaction to succeed, but it reverted");
     }
 
     Ok(())

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+match_block_trailing_comma = true
+max_width = 100
+normalize_comments = true
+reorder_imports = true
+use_small_heuristics = "Max"
+use_try_shorthand = true
+use_field_init_shorthand = true
+wrap_comments = true

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -38,7 +38,8 @@ pub struct Cli {
 /// The possible CLI commands
 #[derive(Subcommand)]
 pub enum Command {
-    /// Deploy all the testing contracts (includes generating testing verification keys)
+    /// Deploy all the testing contracts (includes generating testing
+    /// verification keys)
     DeployTestContracts(DeployTestContractsArgs),
     /// Deploy the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts
     DeployProxy(DeployProxyArgs),
@@ -66,24 +67,25 @@ impl Command {
         match self {
             Command::DeployTestContracts(args) => {
                 deploy_test_contracts(&args, rpc_url, priv_key, client, deployments_path).await
-            }
+            },
             Command::DeployProxy(args) => deploy_proxy(&args, client, deployments_path).await,
             Command::DeployPermit2 => deploy_permit2(client, deployments_path).await,
             Command::DeployStylus(args) => {
                 build_and_deploy_stylus_contract(&args, rpc_url, priv_key, client, deployments_path)
                     .await
                     .map(|_| ())
-            }
+            },
             Command::DeployErc20(args) => {
                 deploy_erc20(&args, rpc_url, priv_key, client, deployments_path).await
-            }
+            },
             Command::Upgrade(args) => upgrade(&args, client, deployments_path).await,
             Command::GenVkeys(args) => gen_vkeys(&args),
         }
     }
 }
 
-/// Deploy all the testing contracts (includes generating testing verification keys)
+/// Deploy all the testing contracts (includes generating testing verification
+/// keys)
 #[derive(Args)]
 pub struct DeployTestContractsArgs {
     /// Address of the owner for both the proxy admin contract
@@ -106,8 +108,9 @@ pub struct DeployTestContractsArgs {
 /// Concretely, this is a [`TransparentUpgradeableProxy`](https://docs.openzeppelin.com/contracts/5.x/api/proxy#transparent_proxy),
 /// which itself deploys a `ProxyAdmin` contract.
 ///
-/// Calls made directly to the `TransparentUpgradeableProxy` contract will be forwarded to the implementation contract.
-/// Upgrade calls can only be made to the `TransparentUpgradeableProxy` through the `ProxyAdmin`.
+/// Calls made directly to the `TransparentUpgradeableProxy` contract will be
+/// forwarded to the implementation contract. Upgrade calls can only be made to
+/// the `TransparentUpgradeableProxy` through the `ProxyAdmin`.
 #[derive(Args)]
 pub struct DeployProxyArgs {
     /// Address of the owner for both the proxy admin contract
@@ -116,11 +119,12 @@ pub struct DeployProxyArgs {
     pub owner: String,
 
     /// The initial protocol fee with which to initialize the darkpool contract.
-    /// The fee is a percentage of the trade volume, represented as a fixed-point number.
-    /// The `u64` used here should accommodate any fee we'd want to set.
+    /// The fee is a percentage of the trade volume, represented as a
+    /// fixed-point number. The `u64` used here should accommodate any fee
+    /// we'd want to set.
     ///
-    /// The default value here is the fixed-point representation of 0.0002 (2 bps),
-    /// that is 0.0002 * 2^63
+    /// The default value here is the fixed-point representation of 0.0002 (2
+    /// bps), that is 0.0002 * 2^63
     #[arg(short, long, default_value = "1844674407370955")]
     pub fee: u64,
 
@@ -152,7 +156,8 @@ pub struct DeployStylusArgs {
     pub no_verify: bool,
 }
 
-/// Deploy a dummy ERC20. Assumes the darkpool contract has already been deployed.
+/// Deploy a dummy ERC20. Assumes the darkpool contract has already been
+/// deployed.
 #[derive(Args)]
 pub struct DeployErc20Args {
     /// The symbol for the ERC20 to deploy

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -60,7 +60,8 @@ use crate::{
     },
 };
 
-/// Builds & deploys all of the contracts necessary for running the integration testing suite.
+/// Builds & deploys all of the contracts necessary for running the integration
+/// testing suite.
 ///
 /// This includes generating fresh verification keys for testing.
 pub async fn deploy_test_contracts(
@@ -71,16 +72,11 @@ pub async fn deploy_test_contracts(
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     info!("Generating testing verification keys");
-    let gen_vkeys_args = GenVkeysArgs {
-        vkeys_dir: args.vkeys_dir.clone(),
-        test: true,
-    };
+    let gen_vkeys_args = GenVkeysArgs { vkeys_dir: args.vkeys_dir.clone(), test: true };
     gen_vkeys(&gen_vkeys_args)?;
 
-    let mut deploy_stylus_args = DeployStylusArgs {
-        contract: StylusContract::TestVkeys,
-        no_verify: args.no_verify,
-    };
+    let mut deploy_stylus_args =
+        DeployStylusArgs { contract: StylusContract::TestVkeys, no_verify: args.no_verify };
 
     info!("Deploying testing verification keys");
     build_and_deploy_stylus_contract(
@@ -152,26 +148,12 @@ pub async fn deploy_test_contracts(
         funding_amount: Some(TEST_FUNDING_AMOUNT),
         account_skeys: vec![priv_key.to_string()],
     };
-    deploy_erc20(
-        &deploy_erc20_args,
-        rpc_url,
-        priv_key,
-        client.clone(),
-        deployments_path,
-    )
-    .await?;
+    deploy_erc20(&deploy_erc20_args, rpc_url, priv_key, client.clone(), deployments_path).await?;
 
     deploy_erc20_args.symbol = TEST_ERC20_TICKER2.to_string();
     deploy_erc20_args.name = TEST_ERC20_TICKER2.to_string();
     deploy_erc20_args.as_wrapper = false; // deploy the second erc20 as a normal erc20
-    deploy_erc20(
-        &deploy_erc20_args,
-        rpc_url,
-        priv_key,
-        client.clone(),
-        deployments_path,
-    )
-    .await?;
+    deploy_erc20(&deploy_erc20_args, rpc_url, priv_key, client.clone(), deployments_path).await?;
 
     info!("Deploying verifier contract");
     deploy_stylus_args.contract = StylusContract::VerifierCore;
@@ -258,21 +240,11 @@ pub async fn deploy_proxy(
 
     // Parse proxy contract constructor arguments
 
-    let darkpool_contract = if args.test {
-        StylusContract::DarkpoolTestContract
-    } else {
-        StylusContract::Darkpool
-    };
-    let merkle_contract = if args.test {
-        StylusContract::MerkleTestContract
-    } else {
-        StylusContract::Merkle
-    };
-    let vkeys_contract = if args.test {
-        StylusContract::TestVkeys
-    } else {
-        StylusContract::Vkeys
-    };
+    let darkpool_contract =
+        if args.test { StylusContract::DarkpoolTestContract } else { StylusContract::Darkpool };
+    let merkle_contract =
+        if args.test { StylusContract::MerkleTestContract } else { StylusContract::Merkle };
+    let vkeys_contract = if args.test { StylusContract::TestVkeys } else { StylusContract::Vkeys };
 
     let darkpool_address = read_stylus_deployment_address(deployments_path, &darkpool_contract)?;
     let core_wallet_ops_address =
@@ -329,10 +301,7 @@ pub async fn deploy_proxy(
 
     let proxy_address = proxy_contract.address();
 
-    info!(
-        "Proxy contract deployed at address:\n\t{:#x}",
-        proxy_address
-    );
+    info!("Proxy contract deployed at address:\n\t{:#x}", proxy_address);
 
     // Get proxy admin contract address
     // This is the recommended way to get the proxy admin address:
@@ -343,17 +312,14 @@ pub async fn deploy_proxy(
                 proxy_address,
                 // Can `unwrap` here since we know the storage slot constitutes a valid H256
                 H256::from_str(PROXY_ADMIN_STORAGE_SLOT).unwrap(),
-                None, /* block */
+                None, // block
             )
             .await
             .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
             [NUM_BYTES_STORAGE_SLOT - NUM_BYTES_ADDRESS..NUM_BYTES_STORAGE_SLOT],
     );
 
-    info!(
-        "Proxy admin contract deployed at address:\n\t{:#x}",
-        proxy_admin_address
-    );
+    info!("Proxy admin contract deployed at address:\n\t{:#x}", proxy_admin_address);
 
     // Write deployed addresses to deployments file
     write_deployment_address(deployments_path, DARKPOOL_PROXY_CONTRACT_KEY, proxy_address)?;
@@ -388,10 +354,7 @@ pub async fn deploy_permit2(
 
     let permit2_address = permit2_contract.address();
 
-    info!(
-        "Permit2 contract deployed at address:\n\t{:#x}",
-        permit2_address
-    );
+    info!("Permit2 contract deployed at address:\n\t{:#x}", permit2_address);
 
     write_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY, permit2_address)
 }
@@ -418,10 +381,7 @@ pub async fn deploy_erc20(
         StylusContract::DummyErc20(args.symbol.clone())
     };
 
-    let deploy_stylus_args = DeployStylusArgs {
-        contract,
-        no_verify: false,
-    };
+    let deploy_stylus_args = DeployStylusArgs { contract, no_verify: false };
     let erc20_address = build_and_deploy_stylus_contract(
         &deploy_stylus_args,
         rpc_url,
@@ -437,14 +397,8 @@ pub async fn deploy_erc20(
         let permit2_address = read_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY)?;
 
         for recipient_skey in &args.account_skeys {
-            fund_and_approve_erc20(
-                args,
-                rpc_url,
-                erc20_address,
-                recipient_skey,
-                permit2_address,
-            )
-            .await?;
+            fund_and_approve_erc20(args, rpc_url, erc20_address, recipient_skey, permit2_address)
+                .await?;
         }
     }
 
@@ -484,10 +438,7 @@ async fn fund_and_approve_erc20(
     let funding_amount = args.funding_amount.unwrap();
     let symbol = args.symbol.clone();
 
-    info!(
-        "Funding {:#x} with {} {} & approving Permit2",
-        account_address, funding_amount, symbol
-    );
+    info!("Funding {:#x} with {} {} & approving Permit2", account_address, funding_amount, symbol);
 
     send_contract_call(erc20.mint(account_address, EthersU256::from(funding_amount))).await?;
     send_contract_call(erc20.approve(permit2_address, EthersU256::MAX)).await?;
@@ -546,15 +497,15 @@ pub async fn upgrade(
 
 /// Computes verification keys for the protocol circuits
 fn compute_vkeys<
-    VWC: SingleProverCircuit,  /* VALID WALLET CREATE */
-    VWU: SingleProverCircuit,  /* VALID WALLET UPDATE */
-    VRFS: SingleProverCircuit, /* VALID RELAYER FEE SETTLEMENT */
-    VOFS: SingleProverCircuit, /* VALID OFFLINE FEE SETTLEMENT */
-    VFR: SingleProverCircuit,  /* VALID FEE REDEMPTION */
-    VC: SingleProverCircuit,   /* VALID COMMITMENTS */
-    VR: SingleProverCircuit,   /* VALID REBLIND */
-    VMS: SingleProverCircuit,  /* VALID MATCH SETTLE */
-    VMSA: SingleProverCircuit, /* VALID MATCH SETTLE ATOMIC */
+    VWC: SingleProverCircuit,  // VALID WALLET CREATE
+    VWU: SingleProverCircuit,  // VALID WALLET UPDATE
+    VRFS: SingleProverCircuit, // VALID RELAYER FEE SETTLEMENT
+    VOFS: SingleProverCircuit, // VALID OFFLINE FEE SETTLEMENT
+    VFR: SingleProverCircuit,  // VALID FEE REDEMPTION
+    VC: SingleProverCircuit,   // VALID COMMITMENTS
+    VR: SingleProverCircuit,   // VALID REBLIND
+    VMS: SingleProverCircuit,  // VALID MATCH SETTLE
+    VMSA: SingleProverCircuit, // VALID MATCH SETTLE ATOMIC
 >() -> Result<RenegadeVerificationKeys, ScriptError> {
     let valid_wallet_create = to_contract_vkey((*VWC::verifying_key()).clone())
         .map_err(|_| ScriptError::CircuitCreation)?;
@@ -631,20 +582,11 @@ fn write_vkeys(vkeys_dir: &str, vkeys: &RenegadeVerificationKeys) -> Result<(), 
     for (file, data) in [
         (VALID_WALLET_CREATE_VKEY_FILE, valid_wallet_create),
         (VALID_WALLET_UPDATE_VKEY_FILE, valid_wallet_update),
-        (
-            VALID_RELAYER_FEE_SETTLEMENT_VKEY_FILE,
-            valid_relayer_fee_settlement,
-        ),
-        (
-            VALID_OFFLINE_FEE_SETTLEMENT_VKEY_FILE,
-            valid_offline_fee_settlement,
-        ),
+        (VALID_RELAYER_FEE_SETTLEMENT_VKEY_FILE, valid_relayer_fee_settlement),
+        (VALID_OFFLINE_FEE_SETTLEMENT_VKEY_FILE, valid_offline_fee_settlement),
         (VALID_FEE_REDEMPTION_VKEY_FILE, valid_fee_redemption),
         (PROCESS_MATCH_SETTLE_VKEYS_FILE, process_match_settle),
-        (
-            PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE,
-            process_atomic_match_settle,
-        ),
+        (PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE, process_atomic_match_settle),
     ] {
         write_vkey_file(vkeys_dir, file, &data)?;
     }
@@ -652,8 +594,8 @@ fn write_vkeys(vkeys_dir: &str, vkeys: &RenegadeVerificationKeys) -> Result<(), 
     Ok(())
 }
 
-/// Generates and writes either the testing or production protocol verification keys
-/// to the specified directory
+/// Generates and writes either the testing or production protocol verification
+/// keys to the specified directory
 pub fn gen_vkeys(args: &GenVkeysArgs) -> Result<(), ScriptError> {
     let vkeys = if args.test {
         compute_vkeys::<

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -23,7 +23,8 @@ pub const PERMIT2_BYTECODE: &str = include_str!("../artifacts/Permit2.bin");
 /// The number of confirmations to wait for the contract deployment transaction
 pub const NUM_DEPLOY_CONFIRMATIONS: usize = 0;
 
-/// The storage slot containing the proxy admin contract address in the upgradeable proxy.
+/// The storage slot containing the proxy admin contract address in the
+/// upgradeable proxy.
 ///
 /// This is specified in EIP1967: https://eips.ethereum.org/EIPS/eip-1967#admin-address
 pub const PROXY_ADMIN_STORAGE_SLOT: &str =
@@ -75,11 +76,8 @@ pub const WASM_TARGET_TRIPLE: &str = "wasm32-unknown-unknown";
 pub const NO_VERIFY_FEATURE: &str = "no-verify";
 
 /// Nightly Z flags to add to build command
-pub const Z_FLAGS: [&str; 3] = [
-    "unstable-options",
-    "build-std=std,panic_abort",
-    "build-std-features=panic_immediate_abort",
-];
+pub const Z_FLAGS: [&str; 3] =
+    ["unstable-options", "build-std=std,panic_abort", "build-std-features=panic_immediate_abort"];
 
 /// The name of the target directory
 pub const TARGET_PATH_SEGMENT: &str = "target";
@@ -127,8 +125,9 @@ pub const PERMIT2_CONTRACT_KEY: &str = "permit2_contract";
 /// which is also its contract key in the `deployments.json` file
 pub const TEST_ERC20_TICKER1: &str = "TEST1";
 
-/// The ticker of the second ERC20 contract deployed using `deploy_test_contracts`,
-/// which is also its contract key in the `deployments.json` file
+/// The ticker of the second ERC20 contract deployed using
+/// `deploy_test_contracts`, which is also its contract key in the
+/// `deployments.json` file
 pub const TEST_ERC20_TICKER2: &str = "TEST2";
 
 /// The number of decimals for the testing ERC20 contracts

--- a/scripts/src/errors.rs
+++ b/scripts/src/errors.rs
@@ -1,11 +1,13 @@
-//! Definitions of errors that can occur during the execution of the contract management scripts
+//! Definitions of errors that can occur during the execution of the contract
+//! management scripts
 
 use std::{
     error::Error,
     fmt::{self, Display, Formatter},
 };
 
-/// Errors that can occur during the execution of the contract management scripts
+/// Errors that can occur during the execution of the contract management
+/// scripts
 #[derive(Debug)]
 pub enum ScriptError {
     /// Invalid arguments provided to a command
@@ -51,7 +53,7 @@ impl Display for ScriptError {
             ScriptError::ContractDeployment(s) => write!(f, "error deploying contract: {}", s),
             ScriptError::ContractInteraction(s) => {
                 write!(f, "error interacting with contract: {}", s)
-            }
+            },
             ScriptError::ContractCompilation(s) => write!(f, "error compiling contract: {}", s),
             ScriptError::Serde(s) => write!(f, "error de/serializing calldata: {}", s),
             ScriptError::ConversionError => write!(f, "error converting between types"),

--- a/scripts/src/main.rs
+++ b/scripts/src/main.rs
@@ -3,18 +3,11 @@ use scripts::{cli::Cli, errors::ScriptError, utils::setup_client};
 
 #[tokio::main]
 async fn main() -> Result<(), ScriptError> {
-    let Cli {
-        priv_key,
-        rpc_url,
-        command,
-        deployments_path,
-    } = Cli::parse();
+    let Cli { priv_key, rpc_url, command, deployments_path } = Cli::parse();
 
     tracing_subscriber::fmt().pretty().init();
 
     let client = setup_client(&priv_key, &rpc_url).await?;
 
-    command
-        .run(client, &rpc_url, &priv_key, &deployments_path)
-        .await
+    command.run(client, &rpc_url, &priv_key, &deployments_path).await
 }

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -48,8 +48,9 @@ use crate::{
 /// & interfaces with the RPC endpoint over HTTP
 pub type LocalWalletHttpClient = SignerMiddleware<Provider<Http>, LocalWallet>;
 
-/// Sets up the address and client with which to instantiate a contract for testing,
-/// reading in the private key, RPC url, and contract address from the environment.
+/// Sets up the address and client with which to instantiate a contract for
+/// testing, reading in the private key, RPC url, and contract address from the
+/// environment.
 pub async fn setup_client(
     priv_key: &str,
     rpc_url: &str,
@@ -64,16 +65,13 @@ pub async fn setup_client(
         .await
         .map_err(|e| ScriptError::ClientInitialization(e.to_string()))?
         .as_u64();
-    let client = Arc::new(SignerMiddleware::new(
-        provider,
-        wallet.clone().with_chain_id(chain_id),
-    ));
+    let client = Arc::new(SignerMiddleware::new(provider, wallet.clone().with_chain_id(chain_id)));
 
     Ok(client)
 }
 
-/// Sends a contract call, waiting for the transaction to go from pending to executed,
-/// and returns the transaction receipt
+/// Sends a contract call, waiting for the transaction to go from pending to
+/// executed, and returns the transaction receipt
 pub async fn send_contract_call<M: Middleware, D: Detokenize>(
     call: ContractCall<M, D>,
 ) -> Result<Option<TransactionReceipt>, ScriptError> {
@@ -106,7 +104,7 @@ pub fn read_stylus_deployment_address(
     let address_str = match contract {
         StylusContract::DummyErc20(symbol) => {
             parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol].as_str()
-        }
+        },
         _ => parsed_json[DEPLOYMENTS_KEY][contract.to_string()].as_str(),
     }
     .ok_or_else(|| {
@@ -122,11 +120,9 @@ pub fn read_deployment_address(
     deployment_key: &str,
 ) -> Result<Address, ScriptError> {
     let parsed_json = get_json_from_file(file_path)?;
-    let address_str = parsed_json[DEPLOYMENTS_KEY][deployment_key]
-        .as_str()
-        .ok_or_else(|| {
-            ScriptError::ReadFile("Could not parse address from deployments file".to_string())
-        })?;
+    let address_str = parsed_json[DEPLOYMENTS_KEY][deployment_key].as_str().ok_or_else(|| {
+        ScriptError::ReadFile("Could not parse address from deployments file".to_string())
+    })?;
 
     Address::from_str(address_str).map_err(|e| ScriptError::ReadFile(e.to_string()))
 }
@@ -148,15 +144,15 @@ pub fn write_stylus_contract_address(
         StylusContract::DummyErc20(symbol) => {
             parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol] =
                 JsonValue::String(format!("{address:#x}"));
-        }
+        },
         StylusContract::DummyWeth(symbol) => {
             parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][symbol] =
                 JsonValue::String(format!("{address:#x}"));
-        }
+        },
         _ => {
             parsed_json[DEPLOYMENTS_KEY][contract.to_string()] =
                 JsonValue::String(format!("{address:#x}"));
-        }
+        },
     }
 
     fs::write(file_path, json::stringify_pretty(parsed_json, 4))
@@ -212,10 +208,7 @@ pub fn get_public_encryption_key(
         rng.sample::<BabyJubJubProjective, _>(Standard).into()
     };
 
-    Ok(PublicEncryptionKey {
-        x: point.x.inner(),
-        y: point.y.inner(),
-    })
+    Ok(PublicEncryptionKey { x: point.x.inner(), y: point.y.inner() })
 }
 
 /// Gets the protocol external fee collection address from the given argument,
@@ -280,11 +273,7 @@ pub fn darkpool_initialize_calldata(
 
 /// Executes a command, returning an error if the command fails
 fn command_success_or(mut cmd: Command, err_msg: &str) -> Result<(), ScriptError> {
-    if !cmd
-        .output()
-        .map_err(|e| ScriptError::ContractCompilation(e.to_string()))?
-        .status
-        .success()
+    if !cmd.output().map_err(|e| ScriptError::ContractCompilation(e.to_string()))?.status.success()
     {
         Err(ScriptError::ContractCompilation(String::from(err_msg)))
     } else {
@@ -299,11 +288,8 @@ pub fn get_rustflags_for_contract(contract: &StylusContract) -> String {
         StylusContract::VerifierCore
         | StylusContract::VerifierSettlement
         | StylusContract::DarkpoolTestContract => {
-            format!(
-                "{}{} {}",
-                OPT_LEVEL_FLAG, OPT_LEVEL_Z, INLINE_THRESHOLD_FLAG
-            )
-        }
+            format!("{}{} {}", OPT_LEVEL_FLAG, OPT_LEVEL_Z, INLINE_THRESHOLD_FLAG)
+        },
         _ => format!("{}{}", OPT_LEVEL_FLAG, OPT_LEVEL_3),
     };
 
@@ -319,20 +305,19 @@ pub fn get_wasm_opt_flags_for_contract(contract: &StylusContract) -> &'static st
     }
 }
 
-/// Compiles the given Stylus contract to WASM and optimizes the resulting binary,
-/// returning the path to the optimized WASM file.
+/// Compiles the given Stylus contract to WASM and optimizes the resulting
+/// binary, returning the path to the optimized WASM file.
 ///
-/// Assumes that `cargo`, the `nightly` toolchain, and `wasm-opt` are locally available.
+/// Assumes that `cargo`, the `nightly` toolchain, and `wasm-opt` are locally
+/// available.
 pub fn build_stylus_contract(
     contract: &StylusContract,
     no_verify: bool,
 ) -> Result<PathBuf, ScriptError> {
     let current_dir = PathBuf::from(env::var(MANIFEST_DIR_ENV_VAR).unwrap());
-    let workspace_path = current_dir
-        .parent()
-        .ok_or(ScriptError::ContractCompilation(String::from(
-            "Could not find contracts directory",
-        )))?;
+    let workspace_path = current_dir.parent().ok_or(ScriptError::ContractCompilation(
+        String::from("Could not find contracts directory"),
+    ))?;
 
     let mut build_cmd = Command::new(CARGO_COMMAND);
     build_cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
@@ -361,9 +346,7 @@ pub fn build_stylus_contract(
     build_cmd.arg(WASM_TARGET_TRIPLE);
     // Set the Z flags, used to optimize the resulting binary size.
     // See constants.rs for the list of flags.
-    let z_flags = iter::repeat("-Z")
-        .take(Z_FLAGS.len())
-        .interleave_shortest(Z_FLAGS);
+    let z_flags = iter::repeat("-Z").take(Z_FLAGS.len()).interleave_shortest(Z_FLAGS);
     build_cmd.args(z_flags);
 
     env::set_var(RUSTFLAGS_ENV_VAR, get_rustflags_for_contract(contract));
@@ -380,9 +363,7 @@ pub fn build_stylus_contract(
         .map_err(|e| ScriptError::ContractCompilation(e.to_string()))?
         .find_map(|entry| {
             let path = entry.ok()?.path();
-            path.extension()
-                .is_some_and(|ext| ext == WASM_EXTENSION)
-                .then_some(path)
+            path.extension().is_some_and(|ext| ext == WASM_EXTENSION).then_some(path)
         })
         .ok_or(ScriptError::ContractCompilation(String::from(
             "Could not find contract WASM file",
@@ -414,20 +395,15 @@ pub async fn deploy_stylus_contract(
         StylusContract::DarkpoolTestContract
         | StylusContract::MerkleTestContract
         | StylusContract::DummyErc20(_) => {
-            warn!(
-                "Deploying `{}` - THIS SHOULD ONLY BE DONE FOR TESTING",
-                contract
-            );
-        }
-        _ => {}
+            warn!("Deploying `{}` - THIS SHOULD ONLY BE DONE FOR TESTING", contract);
+        },
+        _ => {},
     }
 
     // Get expected deployment address
-    let deployer_address = client
-        .default_sender()
-        .ok_or(ScriptError::ClientInitialization(
-            "client does not have sender attached".to_string(),
-        ))?;
+    let deployer_address = client.default_sender().ok_or(ScriptError::ClientInitialization(
+        "client does not have sender attached".to_string(),
+    ))?;
     let deployer_nonce = client
         .get_transaction_count(deployer_address, None /* block */)
         .await


### PR DESCRIPTION
### Purpose
This PR adds the `rustfmt.toml` file from the relayer for repo-consistency and formats the repo with `cargo fmt`
