### PR TITLE
contracts-stylus: transfer-executor: Handle zero-valued transfer

### DIFF
--- a/contracts-stylus/src/contracts/transfer_executor.rs
+++ b/contracts-stylus/src/contracts/transfer_executor.rs
@@ -30,7 +30,7 @@ use contracts_common::{
 };
 use stylus_sdk::{
     abi::Bytes,
-    alloy_primitives::Address,
+    alloy_primitives::{Address, U256},
     call::Call,
     contract, evm, msg,
     prelude::*,
@@ -167,6 +167,11 @@ impl TransferExecutorContract {
         &mut self,
         transfer: SimpleErc20Transfer,
     ) -> Result<(), Vec<u8>> {
+        // Do nothing if the transfer is zero
+        if transfer.amount == U256::ZERO {
+            return Ok(());
+        }
+
         if transfer.is_withdrawal {
             self.execute_simple_erc20_withdrawal(transfer)
         } else {

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -129,9 +129,8 @@ pub const NATIVE_ETH_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
 /// deployer.
 ///
 /// For convenience, the addresses of WETH on Arbitrum chains are below:
-/// - Sepolia: 0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 // TODO: replace with
-///   dummy WETH address
-/// - Arbitrum One: 0x82aF49447D8a07e3bd95BD0d56f35241523fBabb
+/// - Sepolia: 0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a
+/// - Arbitrum One: 0x82af49447d8a07e3bd95bd0d56f35241523fbab1
 #[cfg(any(feature = "transfer-executor", feature = "core-settlement"))]
 pub const WETH_ADDRESS: &str = env!("WETH_ADDRESS");
 

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -422,6 +422,8 @@ pub async fn deploy_stylus_contract(
     deploy_cmd.arg("--private-key");
     deploy_cmd.arg(priv_key);
     deploy_cmd.arg("--no-verify");
+    deploy_cmd.arg("--max-fee-per-gas-gwei");
+    deploy_cmd.arg("1");
 
     command_success_or(deploy_cmd, "Failed to deploy Stylus contract")?;
 


### PR DESCRIPTION
### Purpose
This PR adds a case to handle zero-valued transfers in the `transfer-executor`

### Testing
- [x] Tested in testnet