### PR TITLE
contracts-stylus: core-settlement: Accept receiver for atomic match

### DIFF
--- a/contracts-common/src/lib.rs
+++ b/contracts-common/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
-#![no_std]
 
 extern crate alloc;
 

--- a/contracts-core/src/lib.rs
+++ b/contracts-core/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
-#![no_std]
 
 extern crate alloc;
 

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -267,6 +267,7 @@ impl CoreSettlementContract {
     #[payable]
     pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
+        receiver: Address,
         internal_party_match_payload: Bytes,
         valid_match_settle_statement: Bytes,
         match_proofs: Bytes,
@@ -329,7 +330,13 @@ impl CoreSettlementContract {
         let fees = valid_match_settle_atomic_statement.external_party_fees;
         let match_result = valid_match_settle_atomic_statement.match_result;
         let relayer_fee_address = valid_match_settle_atomic_statement.relayer_fee_address;
-        Self::execute_atomic_match_transfers(storage, fees, match_result, relayer_fee_address)?;
+        Self::execute_atomic_match_transfers(
+            storage,
+            receiver,
+            fees,
+            match_result,
+            relayer_fee_address,
+        )?;
 
         Ok(())
     }
@@ -432,6 +439,7 @@ impl CoreSettlementContract {
     /// settlement
     pub fn execute_atomic_match_transfers<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
+        receiver: Address,
         fees: FeeTake,
         match_result: ExternalMatchResult,
         relayer_fee_address: Address,
@@ -464,7 +472,7 @@ impl CoreSettlementContract {
             .checked_sub(fees.total())
             .ok_or(TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE)?;
         transfers_batch.push(SimpleErc20Transfer::new_withdraw(
-            tx_sender,
+            receiver,
             receive_mint,
             trader_take,
         ));

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -525,11 +525,40 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
+        let receiver = msg::sender();
         let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
         delegate_call_helper::<processAtomicMatchSettleCall>(
             storage,
             core_settlement_address,
             (
+                receiver,
+                internal_party_match_payload.to_vec().into(),
+                valid_match_settle_atomic_statement.to_vec().into(),
+                match_proofs.to_vec().into(),
+                match_linking_proofs.to_vec().into(),
+            ),
+        )
+        .map(|_| ())
+    }
+
+    /// Process an atomic match settle statement with a receiver specified
+    #[payable]
+    pub fn process_atomic_match_settle_with_receiver<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        receiver: Address,
+        internal_party_match_payload: Bytes,
+        valid_match_settle_atomic_statement: Bytes,
+        match_proofs: Bytes,
+        match_linking_proofs: Bytes,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_not_paused(storage)?;
+
+        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        delegate_call_helper::<processAtomicMatchSettleCall>(
+            storage,
+            core_settlement_address,
+            (
+                receiver,
                 internal_party_match_payload.to_vec().into(),
                 valid_match_settle_atomic_statement.to_vec().into(),
                 match_proofs.to_vec().into(),

--- a/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
@@ -7,7 +7,7 @@
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
 
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 use stylus_sdk::{
     alloy_primitives::{Address, Uint, U256},
     alloy_sol_types::{sol, SolError},
@@ -43,19 +43,10 @@ sol! {
     error InsufficientAllowance(address owner, address spender, uint256 have, uint256 want);
 }
 
+#[derive(SolidityError)]
 pub enum Erc20Error {
     InsufficientBalance(InsufficientBalance),
     InsufficientAllowance(InsufficientAllowance),
-}
-
-// We will soon provide a #[derive(SolidityError)] to clean this up
-impl From<Erc20Error> for Vec<u8> {
-    fn from(err: Erc20Error) -> Vec<u8> {
-        match err {
-            Erc20Error::InsufficientBalance(e) => e.abi_encode(),
-            Erc20Error::InsufficientAllowance(e) => e.abi_encode(),
-        }
-    }
 }
 
 // These methods aren't exposed to other contracts

--- a/contracts-stylus/src/lib.rs
+++ b/contracts-stylus/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![no_main]
-#![no_std]
 
 mod contracts;
 mod utils;

--- a/contracts-stylus/src/main.rs
+++ b/contracts-stylus/src/main.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(not(feature = "export-abi"), no_main)]
+
+#[cfg(feature = "export-abi")]
+fn main() {
+    use contracts_stylus::contracts::darkpool::DarkpoolContract;
+    use stylus_sdk::abi::export::print_abi;
+
+    print_abi::<DarkpoolContract>("MIT-OR-APACHE-2.0", "pragma solidity ^0.8.23;");
+}

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -19,7 +19,7 @@ sol! {
 
     // Core settlement functions
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processAtomicMatchSettle(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
 
     // Merkle functions
     function init() external;

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -34,6 +34,7 @@ abigen!(
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -1628,6 +1628,86 @@ async fn test_process_atomic_match_settle_nonzero_transaction_value(
 }
 integration_test_async!(test_process_atomic_match_settle_nonzero_transaction_value);
 
+/// Test the `process_atomic_match_settle_with_receiver` method on the darkpool
+///
+/// I.e. test an atomic settlement with a non-sender receiver specified
+async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
+    // Setup test with a random receiver address
+    let receiver = Address::random();
+    let base_addr = ctx.test_erc20_address1;
+    let quote_addr = ctx.test_erc20_address2;
+    let darkpool = ctx.darkpool_contract();
+    let data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+
+    // Get pre-balances
+    let darkpool_addr = darkpool.address();
+    let sender_pre_base_balance = ctx.get_erc20_balance(base_addr).await?;
+    let sender_pre_quote_balance = ctx.get_erc20_balance(quote_addr).await?;
+    let receiver_pre_base_balance = ctx.get_erc20_balance_of(base_addr, receiver).await?;
+    let receiver_pre_quote_balance = ctx.get_erc20_balance_of(quote_addr, receiver).await?;
+    let darkpool_pre_base_balance = ctx.get_erc20_balance_of(base_addr, darkpool_addr).await?;
+    let darkpool_pre_quote_balance = ctx.get_erc20_balance_of(quote_addr, darkpool_addr).await?;
+
+    // Execute match with specified receiver
+    darkpool
+        .process_atomic_match_settle_with_receiver(
+            receiver,
+            serialize_to_calldata(&data.internal_party_match_payload)?,
+            serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
+            serialize_to_calldata(&data.match_atomic_proofs)?,
+            serialize_to_calldata(&data.match_atomic_linking_proofs)?,
+        )
+        .send()
+        .await?;
+
+    // Get post-balances for receiver
+    let sender_post_base_balance = ctx.get_erc20_balance(base_addr).await?;
+    let sender_post_quote_balance = ctx.get_erc20_balance(quote_addr).await?;
+    let receiver_post_base_balance = ctx.get_erc20_balance_of(base_addr, receiver).await?;
+    let receiver_post_quote_balance = ctx.get_erc20_balance_of(quote_addr, receiver).await?;
+    let darkpool_post_base_balance = ctx.get_erc20_balance_of(base_addr, darkpool_addr).await?;
+    let darkpool_post_quote_balance = ctx.get_erc20_balance_of(quote_addr, darkpool_addr).await?;
+
+    // Verify receiver balances changed correctly
+    let fees = &data.valid_match_settle_atomic_statement.external_party_fees;
+    let base_amount = data.valid_match_settle_atomic_statement.match_result.base_amount;
+    let quote_amount = data.valid_match_settle_atomic_statement.match_result.quote_amount;
+    let expected_sender_base_balance = sender_pre_base_balance; // Unchanged
+    let expected_sender_quote_balance = sender_pre_quote_balance - quote_amount;
+    let expected_receiver_base_balance = receiver_pre_base_balance + base_amount - fees.total();
+    let expected_receiver_quote_balance = receiver_pre_quote_balance; // Unchanged
+    let expected_darkpool_base_balance = darkpool_pre_base_balance - base_amount;
+    let expected_darkpool_quote_balance = darkpool_pre_quote_balance + quote_amount;
+
+    assert_eq!(
+        sender_post_base_balance, expected_sender_base_balance,
+        "Sender's base balance change incorrect"
+    );
+    assert_eq!(
+        sender_post_quote_balance, expected_sender_quote_balance,
+        "Sender's quote balance change incorrect"
+    );
+    assert_eq!(
+        receiver_post_base_balance, expected_receiver_base_balance,
+        "Receiver's base balance change incorrect"
+    );
+    assert_eq!(
+        receiver_post_quote_balance, expected_receiver_quote_balance,
+        "Receiver's quote balance change incorrect"
+    );
+    assert_eq!(
+        darkpool_post_base_balance, expected_darkpool_base_balance,
+        "Darkpool's base balance change incorrect"
+    );
+    assert_eq!(
+        darkpool_post_quote_balance, expected_darkpool_quote_balance,
+        "Darkpool's quote balance change incorrect"
+    );
+
+    Ok(())
+}
+integration_test_async!(test_process_atomic_match_settle_with_receiver);
+
 /// Test the `settle_online_relayer_fee` method on the darkpool
 async fn test_settle_online_relayer_fee(ctx: TestContext) -> Result<()> {
     let contract = ctx.darkpool_contract();


### PR DESCRIPTION
### Purpose
This PR updates the `core-settlement` contract to allow a non-sender (`msg::sender()`) receiver in an external match.

### Testing
- [x] Integration tests pass
- [ ] Test against a testnet-deployed set of contracts