### PR TITLE
integration: tests: gas_sponsorship: unsponsored match tests

### DIFF
--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -14,7 +14,6 @@ pub const VERIFICATION_DISABLED_ERROR_MESSAGE: &[u8] = b"verification disabled o
 
 /// The revert message when a contract/owner address
 /// is attempted to be set to the zero address
-#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "gas-sponsor"))]
 pub const ZERO_ADDRESS_ERROR_MESSAGE: &[u8] = b"zero address";
 
 /// The revert message when the protocol fee

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -48,7 +48,7 @@ use contracts_common::{
     },
 };
 use contracts_core::crypto::poseidon::compute_poseidon_hash;
-use ethers::types::Bytes;
+use ethers::types::{Bytes, U256};
 use eyre::Result;
 use jf_primitives::pcs::{prelude::Commitment, StructuredReferenceString};
 
@@ -653,6 +653,16 @@ pub fn generate_match_bundle<R: CryptoRng + RngCore>(
         match_linking_proofs,
         match_linking_wire_poly_comms,
     ))
+}
+
+/// The inputs for the `sponsor_atomic_match_settle` darkpool method
+pub struct SponsoredAtomicMatchSettleData {
+    /// The data used to call `process_atomic_match_settle`
+    pub process_atomic_match_settle_data: ProcessAtomicMatchSettleData,
+    /// The sponsorship nonce
+    pub nonce: U256,
+    /// The signature over the nonce
+    pub signature: Bytes,
 }
 
 /// The inputs for the `process_atomic_match_settle` darkpool method

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -19,7 +19,7 @@ rand = { workspace = true }
 clap = { workspace = true }
 postcard = { workspace = true }
 serde = { workspace = true }
-alloy-primitives = { workspace = true }
+alloy-primitives = { workspace = true, features = ["tiny-keccak"] }
 alloy-sol-types = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 circuit-types = { workspace = true, features = ["test-helpers"] }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -119,3 +119,21 @@ abigen!(
         function isDummyUpgradeTarget() external view returns (bool)
     ]"#
 );
+
+abigen!(
+    IAtomicMatchSettleContract,
+    r#"[
+        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
+    ]"#
+);
+
+abigen!(
+    GasSponsorContract,
+    r#"[
+        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
+        function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, uint256 memory nonce, bytes memory signature) external payable
+        function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, uint256 memory nonce, bytes memory signature) external payable
+    ]"#
+);

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use abis::{DarkpoolTestContract, DummyErc20Contract};
+use abis::{DarkpoolTestContract, DummyErc20Contract, GasSponsorContract};
 use alloy_primitives::U256;
 use clap::Parser;
 use cli::Cli;
@@ -70,6 +70,8 @@ pub struct TestContext {
     pub test_upgrade_target_address: Address,
     /// The address of the precompiles testing contract
     pub precompiles_contract_address: Address,
+    /// The address of the gas sponsor proxy contract
+    pub gas_sponsor_proxy_address: Address,
 }
 
 impl TestContext {
@@ -107,6 +109,11 @@ impl TestContext {
     pub fn darkpool_contract(&self) -> DarkpoolTestContract<LocalWalletHttpClient> {
         DarkpoolTestContract::new(self.darkpool_proxy_address, self.client.clone())
     }
+
+    /// Build an instance of the gas sponsor contract
+    pub fn gas_sponsor_contract(&self) -> GasSponsorContract<LocalWalletHttpClient> {
+        GasSponsorContract::new(self.gas_sponsor_proxy_address, self.client.clone())
+    }
 }
 
 impl From<Cli> for TestContext {
@@ -114,11 +121,14 @@ impl From<Cli> for TestContext {
         let client =
             Handle::current().block_on(setup_client(&value.priv_key, &value.rpc_url)).unwrap();
 
+        let darkpool_proxy_key = format!("{}_{}", StylusContract::Darkpool, PROXY_CONTRACT_KEY);
         let darkpool_proxy_address =
-            read_deployment_address(&value.deployments_file, PROXY_CONTRACT_KEY).unwrap();
+            read_deployment_address(&value.deployments_file, &darkpool_proxy_key).unwrap();
 
+        let darkpool_proxy_admin_key =
+            format!("{}_{}", StylusContract::Darkpool, PROXY_ADMIN_CONTRACT_KEY);
         let proxy_admin_address =
-            read_deployment_address(&value.deployments_file, PROXY_ADMIN_CONTRACT_KEY).unwrap();
+            read_deployment_address(&value.deployments_file, &darkpool_proxy_admin_key).unwrap();
 
         let darkpool_impl_address = read_stylus_deployment_address(
             &value.deployments_file,
@@ -188,6 +198,11 @@ impl From<Cli> for TestContext {
         )
         .unwrap();
 
+        let gas_sponsor_proxy_key =
+            format!("{}_{}", StylusContract::GasSponsor, PROXY_CONTRACT_KEY);
+        let gas_sponsor_proxy_address =
+            read_deployment_address(&value.deployments_file, &gas_sponsor_proxy_key).unwrap();
+
         TestContext {
             client,
             darkpool_proxy_address,
@@ -205,6 +220,7 @@ impl From<Cli> for TestContext {
             test_erc20_address2,
             test_upgrade_target_address,
             precompiles_contract_address,
+            gas_sponsor_proxy_address,
         }
     }
 }

--- a/integration/src/tests/atomic_settlement.rs
+++ b/integration/src/tests/atomic_settlement.rs
@@ -1,110 +1,25 @@
 //! Integration tests for atomic settlement
 
 use ark_ff::One;
-use circuit_types::{
-    fixed_point::FixedPoint,
-    r#match::{ExternalMatchResult, FeeTake},
-};
-use constants::Scalar;
 use contracts_common::{constants::TEST_MERKLE_HEIGHT, types::ScalarField};
-use contracts_utils::{
-    merkle::new_ark_merkle_tree,
-    proof_system::test_data::{gen_atomic_match_with_match_and_fees, ProcessAtomicMatchSettleData},
-};
+use contracts_utils::merkle::new_ark_merkle_tree;
 use ethers::{
     abi::Address,
     types::{TransactionReceipt, U256},
 };
 use eyre::Result;
-use rand::thread_rng;
-use scripts::constants::TEST_FUNDING_AMOUNT;
+use scripts::utils::LocalWalletHttpClient;
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
+    abis::IAtomicMatchSettleContract,
     utils::{
-        alloy_address_to_ethers_address, alloy_u256_to_ethers_u256, biguint_to_ethers_address,
-        ethers_address_to_biguint, insert_shares_and_get_root, mint_dummy_erc20s,
-        native_eth_address, scalar_to_u256, serialize_to_calldata,
-        setup_external_match_token_approvals, u256_to_alloy_u256, u256_to_scalar,
+        alloy_address_to_ethers_address, alloy_u256_to_ethers_u256, insert_shares_and_get_root,
+        scalar_to_u256, serialize_to_calldata, setup_atomic_match_settle_test,
+        setup_atomic_match_settle_test_native_eth, u256_to_alloy_u256, u256_to_scalar,
     },
     TestContext,
 };
-
-/// Get a dummy `ExternalMatchResult` and `FeeTake` for an atomic match
-async fn dummy_external_match_result_and_fees(
-    buy_side: bool,
-    ctx: &TestContext,
-) -> Result<(ExternalMatchResult, FeeTake)> {
-    let base_mint = ctx.test_erc20_address1;
-    let quote_mint = ctx.test_erc20_address2;
-    let base_amount = TEST_FUNDING_AMOUNT;
-    let quote_amount = TEST_FUNDING_AMOUNT;
-
-    // Ensure that the client has sufficient balances and approvals
-    mint_dummy_erc20s(base_mint, base_amount.into(), ctx).await?;
-    mint_dummy_erc20s(quote_mint, quote_amount.into(), ctx).await?;
-
-    // The price here does not matter for testing, so we just trade the default
-    // funding amount
-    let match_result = ExternalMatchResult {
-        base_mint: ethers_address_to_biguint(&base_mint),
-        quote_mint: ethers_address_to_biguint(&quote_mint),
-        base_amount,
-        quote_amount,
-        direction: buy_side,
-    };
-    setup_external_match_token_approvals(buy_side, &match_result, ctx).await?;
-
-    // Values here don't matter, but importantly are different to ensure the
-    // correct fee ends in the correct address
-    let fees = FeeTake {
-        relayer_fee: TEST_FUNDING_AMOUNT / 100,  // 1%
-        protocol_fee: TEST_FUNDING_AMOUNT / 200, // 0.5%
-    };
-
-    Ok((match_result, fees))
-}
-
-/// Setup an atomic match settle test using native ETH as the base asset
-async fn setup_atomic_match_settle_test_native_eth(
-    buy_side: bool,
-    ctx: &TestContext,
-) -> Result<ProcessAtomicMatchSettleData> {
-    let mut data = setup_atomic_match_settle_test(buy_side, ctx).await?;
-
-    // Replace the base mint with the native ETH address
-    let eth_addr = native_eth_address();
-    data.valid_match_settle_atomic_statement.match_result.base_mint = eth_addr;
-    Ok(data)
-}
-
-/// Setup an atomic match settle test
-async fn setup_atomic_match_settle_test(
-    buy_side: bool,
-    ctx: &TestContext,
-) -> Result<ProcessAtomicMatchSettleData> {
-    let contract = ctx.darkpool_contract();
-
-    // Clear merkle state
-    contract.clear_merkle().send().await?.await?;
-
-    let mut rng = thread_rng();
-    let contract_root = Scalar::new(u256_to_scalar(contract.get_root().call().await?)?);
-    let (match_result, fees) = dummy_external_match_result_and_fees(buy_side, ctx).await?;
-    let base = biguint_to_ethers_address(&match_result.base_mint);
-    let fee = contract.get_external_match_fee_for_asset(base).call().await?;
-    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(fee)?));
-
-    let data = gen_atomic_match_with_match_and_fees(
-        &mut rng,
-        contract_root,
-        protocol_fee,
-        match_result,
-        fees,
-    )?;
-
-    Ok(data)
-}
 
 /// Test a successful call to `process_atomic_match_settle`
 ///
@@ -112,7 +27,12 @@ async fn setup_atomic_match_settle_test(
 #[allow(non_snake_case)]
 async fn test_process_atomic_match_settle__internal_party(ctx: TestContext) -> Result<()> {
     let contract = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
 
     // Call process_atomic_match_settle
     contract
@@ -153,12 +73,21 @@ integration_test_async!(test_process_atomic_match_settle__internal_party);
 /// Test `process_atomic_match_settle` and verify the external party's state
 /// after update. That is, the erc20 transfers that result from the atomic match
 #[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__external_party_buy_side(ctx: TestContext) -> Result<()> {
+pub async fn _test_process_atomic_match_settle__external_party_buy_side(
+    ctx: TestContext,
+    contract: IAtomicMatchSettleContract<LocalWalletHttpClient>,
+) -> Result<()> {
     // Setup test data
+    let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test(
+        true, // buy_side
+        use_gas_sponsor,
+        &ctx,
+    )
+    .await?;
 
     let relayer_fee_addr = alloy_address_to_ethers_address(
         &data.valid_match_settle_atomic_statement.relayer_fee_address,
@@ -172,7 +101,7 @@ async fn test_process_atomic_match_settle__external_party_buy_side(ctx: TestCont
     let initial_protocol_balance = ctx.get_erc20_balance_of(base_addr, protocol_fee_addr).await?;
 
     // Call process_atomic_match_settle
-    darkpool
+    contract
         .process_atomic_match_settle(
             serialize_to_calldata(&data.internal_party_match_payload)?,
             serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
@@ -215,19 +144,34 @@ async fn test_process_atomic_match_settle__external_party_buy_side(ctx: TestCont
 
     Ok(())
 }
+
+/// Run the `test_process_atomic_match_settle__external_party_buy_side` test
+/// through the darkpool contract
+#[allow(non_snake_case)]
+async fn test_process_atomic_match_settle__external_party_buy_side(ctx: TestContext) -> Result<()> {
+    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.client.clone());
+    _test_process_atomic_match_settle__external_party_buy_side(ctx, contract).await
+}
 integration_test_async!(test_process_atomic_match_settle__external_party_buy_side);
 
 /// Test `process_atomic_match_settle` and verify the external party's state
 /// after update. That is, the erc20 transfers that result from the atomic match
 #[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__external_party_sell_side(
+pub async fn _test_process_atomic_match_settle__external_party_sell_side(
     ctx: TestContext,
+    contract: IAtomicMatchSettleContract<LocalWalletHttpClient>,
 ) -> Result<()> {
     // Setup test data
+    let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test(false /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test(
+        false, // buy_side
+        use_gas_sponsor,
+        &ctx,
+    )
+    .await?;
 
     let relayer_fee_addr = alloy_address_to_ethers_address(
         &data.valid_match_settle_atomic_statement.relayer_fee_address,
@@ -241,7 +185,7 @@ async fn test_process_atomic_match_settle__external_party_sell_side(
     let initial_protocol_balance = ctx.get_erc20_balance_of(quote_addr, protocol_fee_addr).await?;
 
     // Call process_atomic_match_settle
-    darkpool
+    contract
         .process_atomic_match_settle(
             serialize_to_calldata(&data.internal_party_match_payload)?,
             serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
@@ -284,15 +228,34 @@ async fn test_process_atomic_match_settle__external_party_sell_side(
 
     Ok(())
 }
+
+/// Run the `test_process_atomic_match_settle__external_party_sell_side` test
+/// through the darkpool contract
+#[allow(non_snake_case)]
+async fn test_process_atomic_match_settle__external_party_sell_side(
+    ctx: TestContext,
+) -> Result<()> {
+    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.client.clone());
+    _test_process_atomic_match_settle__external_party_sell_side(ctx, contract).await
+}
 integration_test_async!(test_process_atomic_match_settle__external_party_sell_side);
 
 /// Test `process_atomic_match_settle` with the native asset
 #[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__native_asset_sell_side(ctx: TestContext) -> Result<()> {
+pub async fn _test_process_atomic_match_settle__native_asset_sell_side(
+    ctx: TestContext,
+    contract: IAtomicMatchSettleContract<LocalWalletHttpClient>,
+) -> Result<()> {
     // Setup test data
+    let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test_native_eth(false /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test_native_eth(
+        false, // buy_side
+        use_gas_sponsor,
+        &ctx,
+    )
+    .await?;
 
     let relayer_fee_addr = alloy_address_to_ethers_address(
         &data.valid_match_settle_atomic_statement.relayer_fee_address,
@@ -354,14 +317,31 @@ async fn test_process_atomic_match_settle__native_asset_sell_side(ctx: TestConte
 
     Ok(())
 }
+
+/// Run the `test_process_atomic_match_settle__native_asset_sell_side` test
+/// through the darkpool contract
+#[allow(non_snake_case)]
+async fn test_process_atomic_match_settle__native_asset_sell_side(ctx: TestContext) -> Result<()> {
+    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.client.clone());
+    _test_process_atomic_match_settle__native_asset_sell_side(ctx, contract).await
+}
 integration_test_async!(test_process_atomic_match_settle__native_asset_sell_side);
 
 /// Test `process_atomic_match_settle` with native asset on buy side
 #[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__native_asset_buy_side(ctx: TestContext) -> Result<()> {
+pub async fn _test_process_atomic_match_settle__native_asset_buy_side(
+    ctx: TestContext,
+    contract: IAtomicMatchSettleContract<LocalWalletHttpClient>,
+) -> Result<()> {
+    let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test_native_eth(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test_native_eth(
+        true, // buy_side
+        use_gas_sponsor,
+        &ctx,
+    )
+    .await?;
 
     let relayer_fee_addr = alloy_address_to_ethers_address(
         &data.valid_match_settle_atomic_statement.relayer_fee_address,
@@ -374,7 +354,7 @@ async fn test_process_atomic_match_settle__native_asset_buy_side(ctx: TestContex
     let initial_relayer_balance = ctx.get_eth_balance_of(relayer_fee_addr).await?;
     let initial_protocol_balance = ctx.get_eth_balance_of(protocol_fee_addr).await?;
 
-    let receipt: TransactionReceipt = darkpool
+    let receipt: TransactionReceipt = contract
         .process_atomic_match_settle(
             serialize_to_calldata(&data.internal_party_match_payload)?,
             serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
@@ -420,12 +400,25 @@ async fn test_process_atomic_match_settle__native_asset_buy_side(ctx: TestContex
 
     Ok(())
 }
+
+/// Run the `test_process_atomic_match_settle__native_asset_buy_side` test
+/// through the darkpool contract
+#[allow(non_snake_case)]
+async fn test_process_atomic_match_settle__native_asset_buy_side(ctx: TestContext) -> Result<()> {
+    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.client.clone());
+    _test_process_atomic_match_settle__native_asset_buy_side(ctx, contract).await
+}
 integration_test_async!(test_process_atomic_match_settle__native_asset_buy_side);
 
 /// Test `process_atomic_match_settle` with inconsistent indices
 async fn test_process_atomic_match_settle_inconsistent_indices(ctx: TestContext) -> Result<()> {
     let contract = ctx.darkpool_contract();
-    let mut data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let mut data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
 
     // Modify the index to make it inconsistent
     data.valid_match_settle_atomic_statement.internal_party_indices.balance_receive += 1;
@@ -450,7 +443,12 @@ async fn test_process_atomic_match_settle_inconsistent_protocol_fee(
     ctx: TestContext,
 ) -> Result<()> {
     let contract = ctx.darkpool_contract();
-    let mut data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let mut data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
 
     // Modify the protocol fee to make it inconsistent
     data.valid_match_settle_atomic_statement.protocol_fee += ScalarField::one();
@@ -475,7 +473,12 @@ async fn test_process_atomic_match_settle_invalid_transaction_value(
     ctx: TestContext,
 ) -> Result<()> {
     let contract = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test_native_eth(false /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test_native_eth(
+        false, // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
 
     // Try to execute with insufficient ETH value
     let required_eth_value = data.valid_match_settle_atomic_statement.match_result.base_amount;
@@ -501,7 +504,12 @@ async fn test_process_atomic_match_settle_nonzero_transaction_value(
     ctx: TestContext,
 ) -> Result<()> {
     let contract = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test_native_eth(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test_native_eth(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
 
     // Try to execute with non-zero ETH value when it should be zero for buy-side
     let call = contract
@@ -522,16 +530,24 @@ integration_test_async!(test_process_atomic_match_settle_nonzero_transaction_val
 /// Test the `process_atomic_match_settle_with_receiver` method on the darkpool
 ///
 /// I.e. test an atomic settlement with a non-sender receiver specified
-async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
+pub async fn _test_process_atomic_match_settle_with_receiver(
+    ctx: TestContext,
+    contract: IAtomicMatchSettleContract<LocalWalletHttpClient>,
+) -> Result<()> {
     // Setup test with a random receiver address
+    let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let receiver = Address::random();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
-    let darkpool = ctx.darkpool_contract();
-    let data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test(
+        true, // buy_side
+        use_gas_sponsor,
+        &ctx,
+    )
+    .await?;
 
     // Get pre-balances
-    let darkpool_addr = darkpool.address();
+    let darkpool_addr = ctx.darkpool_contract().address();
     let sender_pre_base_balance = ctx.get_erc20_balance(base_addr).await?;
     let sender_pre_quote_balance = ctx.get_erc20_balance(quote_addr).await?;
     let receiver_pre_base_balance = ctx.get_erc20_balance_of(base_addr, receiver).await?;
@@ -540,7 +556,7 @@ async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Res
     let darkpool_pre_quote_balance = ctx.get_erc20_balance_of(quote_addr, darkpool_addr).await?;
 
     // Execute match with specified receiver
-    darkpool
+    contract
         .process_atomic_match_settle_with_receiver(
             receiver,
             serialize_to_calldata(&data.internal_party_match_payload)?,
@@ -597,6 +613,14 @@ async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Res
 
     Ok(())
 }
+
+/// Run the `test_process_atomic_match_settle_with_receiver` test
+/// through the darkpool contract
+#[allow(non_snake_case)]
+async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
+    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.client.clone());
+    _test_process_atomic_match_settle_with_receiver(ctx, contract).await
+}
 integration_test_async!(test_process_atomic_match_settle_with_receiver);
 
 /// Test the `process_atomic_match_settle` method with a fee override
@@ -615,7 +639,12 @@ async fn test_atomic_match_settle__fee_override(ctx: TestContext) -> Result<()> 
     assert_eq_result!(fee, new_fee)?;
 
     // Call process_atomic_match_settle with the new fee
-    let data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
     let expected_fee = u256_to_scalar(new_fee)?;
     assert_eq_result!(data.valid_match_settle_atomic_statement.protocol_fee, expected_fee)?;
 
@@ -636,7 +665,12 @@ async fn test_atomic_match_settle__fee_override(ctx: TestContext) -> Result<()> 
     assert_eq_result!(base_fee, default_fee)?;
 
     // Call process_atomic_match_settle again with the default fee
-    let data = setup_atomic_match_settle_test(true /* buy_side */, &ctx).await?;
+    let data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
     let expected_fee = u256_to_scalar(default_fee)?;
     assert_eq_result!(data.valid_match_settle_atomic_statement.protocol_fee, expected_fee)?;
 

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -1,0 +1,66 @@
+//! Integration tests for gas sponsorship
+
+use eyre::Result;
+use test_helpers::integration_test_async;
+
+use crate::{abis::IAtomicMatchSettleContract, TestContext};
+
+use super::atomic_settlement::{
+    _test_process_atomic_match_settle__external_party_buy_side,
+    _test_process_atomic_match_settle__external_party_sell_side,
+    _test_process_atomic_match_settle__native_asset_buy_side,
+    _test_process_atomic_match_settle__native_asset_sell_side,
+    _test_process_atomic_match_settle_with_receiver,
+};
+
+/// Test an unsponsored buy through the gas
+/// sponsor
+#[allow(non_snake_case)]
+pub async fn test_unsponsored_match__buy_side(ctx: TestContext) -> Result<()> {
+    let contract =
+        IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.client.clone());
+
+    _test_process_atomic_match_settle__external_party_buy_side(ctx, contract).await
+}
+integration_test_async!(test_unsponsored_match__buy_side);
+
+/// Test an unsponsored sell through the gas
+/// sponsor
+#[allow(non_snake_case)]
+pub async fn test_unsponsored_match__sell_side(ctx: TestContext) -> Result<()> {
+    let contract =
+        IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.client.clone());
+
+    _test_process_atomic_match_settle__external_party_sell_side(ctx, contract).await
+}
+integration_test_async!(test_unsponsored_match__sell_side);
+
+/// Test an unsponsored buy through the gas sponsor with the native asset
+#[allow(non_snake_case)]
+pub async fn test_unsponsored_match__native_asset_buy_side(ctx: TestContext) -> Result<()> {
+    let contract =
+        IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.client.clone());
+
+    _test_process_atomic_match_settle__native_asset_buy_side(ctx, contract).await
+}
+integration_test_async!(test_unsponsored_match__native_asset_buy_side);
+
+/// Test an unsponsored sell through the gas sponsor with the native asset
+#[allow(non_snake_case)]
+pub async fn test_unsponsored_match__native_asset_sell_side(ctx: TestContext) -> Result<()> {
+    let contract =
+        IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.client.clone());
+
+    _test_process_atomic_match_settle__native_asset_sell_side(ctx, contract).await
+}
+integration_test_async!(test_unsponsored_match__native_asset_sell_side);
+
+/// Test an unsponsored match with a receiver through the gas sponsor
+#[allow(non_snake_case)]
+pub async fn test_unsponsored_match_with_receiver(ctx: TestContext) -> Result<()> {
+    let contract =
+        IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.client.clone());
+
+    _test_process_atomic_match_settle_with_receiver(ctx, contract).await
+}
+integration_test_async!(test_unsponsored_match_with_receiver);

--- a/integration/src/tests/mod.rs
+++ b/integration/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod basic_darkpool_interaction;
 mod darkpool_components;
 mod external_transfer;
 mod fees;
+mod gas_sponsorship;
 mod precompile;
 
 // TODO: Add test cases covering invalid historical Merkle roots,

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -9,7 +9,11 @@ use alloy_sol_types::{
     Eip712Domain, SolStruct, SolType,
 };
 use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
-use circuit_types::{elgamal::EncryptionKey, r#match::ExternalMatchResult};
+use circuit_types::{
+    elgamal::EncryptionKey,
+    fixed_point::FixedPoint,
+    r#match::{ExternalMatchResult, FeeTake},
+};
 use constants::Scalar;
 use contracts_common::{
     constants::NUM_BYTES_FELT,
@@ -24,8 +28,11 @@ use contracts_common::{
 use contracts_core::crypto::poseidon::compute_poseidon_hash;
 use contracts_stylus::NATIVE_ETH_ADDRESS;
 use contracts_utils::{
-    crypto::hash_and_sign_message, merkle::MerkleConfig,
-    proof_system::test_data::address_to_biguint,
+    crypto::hash_and_sign_message,
+    merkle::MerkleConfig,
+    proof_system::test_data::{
+        address_to_biguint, gen_atomic_match_with_match_and_fees, ProcessAtomicMatchSettleData,
+    },
 };
 use ethers::{
     abi::{Address, Detokenize, Tokenize},
@@ -273,6 +280,7 @@ pub async fn mint_dummy_erc20s(mint: Address, amount: U256, test_args: &TestCont
 /// Setup the token approvals for an atomic match
 pub async fn setup_external_match_token_approvals(
     buy_side: bool,
+    use_gas_sponsor: bool,
     match_result: &ExternalMatchResult,
     test_args: &TestContext,
 ) -> Result<()> {
@@ -281,7 +289,14 @@ pub async fn setup_external_match_token_approvals(
     let mint = biguint_to_ethers_address(mint);
     let contract = DummyErc20Contract::new(mint, test_args.client.clone());
     let amount = TEST_FUNDING_AMOUNT;
-    contract.approve(test_args.darkpool_proxy_address, amount.into()).send().await?.await?;
+
+    let spender = if use_gas_sponsor {
+        test_args.gas_sponsor_proxy_address
+    } else {
+        test_args.darkpool_proxy_address
+    };
+
+    contract.approve(spender, amount.into()).send().await?.await?;
 
     Ok(())
 }
@@ -319,6 +334,90 @@ fn permit_signing_hash(permit: &PermitWitnessTransferFrom, domain: &Eip712Domain
     digest_input[2..34].copy_from_slice(&domain_separator[..]);
     digest_input[34..66].copy_from_slice(&struct_hash[..]);
     keccak256(digest_input)
+}
+
+// ------------------------
+// | External Match Setup |
+// ------------------------
+
+/// Get a dummy `ExternalMatchResult` and `FeeTake` for an atomic match
+pub async fn dummy_external_match_result_and_fees(
+    buy_side: bool,
+    use_gas_sponsor: bool,
+    ctx: &TestContext,
+) -> Result<(ExternalMatchResult, FeeTake)> {
+    let base_mint = ctx.test_erc20_address1;
+    let quote_mint = ctx.test_erc20_address2;
+    let base_amount = TEST_FUNDING_AMOUNT;
+    let quote_amount = TEST_FUNDING_AMOUNT;
+
+    // Ensure that the client has sufficient balances and approvals
+    mint_dummy_erc20s(base_mint, base_amount.into(), ctx).await?;
+    mint_dummy_erc20s(quote_mint, quote_amount.into(), ctx).await?;
+
+    // The price here does not matter for testing, so we just trade the default
+    // funding amount
+    let match_result = ExternalMatchResult {
+        base_mint: ethers_address_to_biguint(&base_mint),
+        quote_mint: ethers_address_to_biguint(&quote_mint),
+        base_amount,
+        quote_amount,
+        direction: buy_side,
+    };
+    setup_external_match_token_approvals(buy_side, use_gas_sponsor, &match_result, ctx).await?;
+
+    // Values here don't matter, but importantly are different to ensure the
+    // correct fee ends in the correct address
+    let fees = FeeTake {
+        relayer_fee: TEST_FUNDING_AMOUNT / 100,  // 1%
+        protocol_fee: TEST_FUNDING_AMOUNT / 200, // 0.5%
+    };
+
+    Ok((match_result, fees))
+}
+
+/// Setup an atomic match settle test using native ETH as the base asset
+pub async fn setup_atomic_match_settle_test_native_eth(
+    buy_side: bool,
+    use_gas_sponsor: bool,
+    ctx: &TestContext,
+) -> Result<ProcessAtomicMatchSettleData> {
+    let mut data = setup_atomic_match_settle_test(buy_side, use_gas_sponsor, ctx).await?;
+
+    // Replace the base mint with the native ETH address
+    let eth_addr = native_eth_address();
+    data.valid_match_settle_atomic_statement.match_result.base_mint = eth_addr;
+    Ok(data)
+}
+
+/// Setup an atomic match settle test
+pub async fn setup_atomic_match_settle_test(
+    buy_side: bool,
+    use_gas_sponsor: bool,
+    ctx: &TestContext,
+) -> Result<ProcessAtomicMatchSettleData> {
+    let darkpool_contract = ctx.darkpool_contract();
+
+    // Clear merkle state
+    darkpool_contract.clear_merkle().send().await?.await?;
+
+    let mut rng = thread_rng();
+    let contract_root = Scalar::new(u256_to_scalar(darkpool_contract.get_root().call().await?)?);
+    let (match_result, fees) =
+        dummy_external_match_result_and_fees(buy_side, use_gas_sponsor, ctx).await?;
+    let base = biguint_to_ethers_address(&match_result.base_mint);
+    let fee = darkpool_contract.get_external_match_fee_for_asset(base).call().await?;
+    let protocol_fee = FixedPoint::from(Scalar::new(u256_to_scalar(fee)?));
+
+    let data = gen_atomic_match_with_match_and_fees(
+        &mut rng,
+        contract_root,
+        protocol_fee,
+        match_result,
+        fees,
+    )?;
+
+    Ok(data)
 }
 
 // ---------------------------------------

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -97,11 +97,6 @@ impl Command {
 /// keys)
 #[derive(Args)]
 pub struct DeployTestContractsArgs {
-    /// Address of the owner for both the proxy admin contract
-    /// and the underlying darkpool contract
-    #[arg(short, long)]
-    pub owner: String,
-
     /// Whether or not to enable proof & ECDSA verification.
     /// This only applies to the darkpool & Merkle contracts.
     #[arg(long)]

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -220,14 +220,31 @@ pub async fn deploy_test_contracts(
     )
     .await?;
 
-    info!("Deploying proxy contract");
-    let deploy_proxy_args = DeployDarkpoolProxyArgs {
+    info!("Deploying darkpool proxy contract");
+    let deploy_darkpool_proxy_args = DeployDarkpoolProxyArgs {
         fee: thread_rng().gen(),
         protocol_public_encryption_key: None,
         protocol_external_fee_collection_address: None,
         test: true,
     };
-    deploy_darkpool_proxy(&deploy_proxy_args, client, deployments_path).await?;
+    deploy_darkpool_proxy(&deploy_darkpool_proxy_args, client.clone(), deployments_path).await?;
+
+    info!("Deploying gas sponsor contract");
+    deploy_stylus_args.contract = StylusContract::GasSponsor;
+    build_and_deploy_stylus_contract(
+        &deploy_stylus_args,
+        rpc_url,
+        priv_key,
+        client.clone(),
+        deployments_path,
+    )
+    .await?;
+
+    info!("Deploying gas sponsor proxy contract");
+    let deploy_gas_sponsor_proxy_args = DeployGasSponsorProxyArgs {
+        auth_address: format!("{:#x}", client.default_sender().unwrap()),
+    };
+    deploy_gas_sponsor_proxy(&deploy_gas_sponsor_proxy_args, client, deployments_path).await?;
 
     Ok(())
 }

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -47,7 +47,7 @@ pub const RUSTFLAGS_ENV_VAR: &str = "RUSTFLAGS";
 pub const DEFAULT_RUSTFLAGS: &str = "-Clink-arg=-zstack-size=131072 -Zlocation-detail=none";
 
 /// The inline threshold flag for the Rust compiler
-pub const INLINE_THRESHOLD_FLAG: &str = "-Cinline-threshold=0";
+pub const INLINE_THRESHOLD_FLAG: &str = "-Cllvm-args=--inline-threshold=0";
 
 /// The optimization level flag for the Rust compiler
 pub const OPT_LEVEL_FLAG: &str = "-C opt-level=";


### PR DESCRIPTION
This PR adds the first set of integration tests for the gas sponsor contract. So far, these only test the unsponsored match paths through the gas sponsor, which are a thin wrapper around the darkpool's atomic match settlement methods, handling any necessary transfers/approvals to the gas sponsor.

### Testing
- [x] All integration tests pass