### PR TITLE
contracts-stylus: contracts: gas_sponsor: configurable refund addr + better accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,6 +3159,7 @@ dependencies = [
  "num-bigint",
  "postcard",
  "rand 0.8.5",
+ "ruint",
  "scripts",
  "serde",
  "test-helpers",

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -145,12 +145,14 @@ impl GasSponsorContract {
     /// Sponsor the gas costs of an atomic match settlement with the caller as
     /// the receiver
     #[payable]
+    #[allow(clippy::too_many_arguments)]
     pub fn sponsor_atomic_match_settle(
         &mut self,
         internal_party_match_payload: Bytes,
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
+        refund_address: Address,
         nonce: U256,
         signature: Bytes,
     ) -> Result<(), Vec<u8>> {
@@ -161,6 +163,7 @@ impl GasSponsorContract {
             valid_match_settle_atomic_statement,
             match_proofs,
             match_linking_proofs,
+            refund_address,
             nonce,
             signature,
         )
@@ -177,6 +180,7 @@ impl GasSponsorContract {
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
+        refund_address: Address,
         nonce: U256,
         signature: Bytes,
     ) -> Result<(), Vec<u8>> {
@@ -220,7 +224,10 @@ impl GasSponsorContract {
         }
 
         // Refund the user's gas costs
-        transfer_eth(msg::sender(), gas_cost)?;
+        let refund_address =
+            if refund_address == Address::ZERO { tx::origin() } else { refund_address };
+
+        transfer_eth(refund_address, gas_cost)?;
 
         Ok(())
     }

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -2,7 +2,7 @@
 //! matches
 
 use contracts_common::{
-    constants::{NUM_BYTES_ADDRESS, NUM_BYTES_SIGNATURE},
+    constants::{NUM_BYTES_ADDRESS, NUM_BYTES_SIGNATURE, NUM_BYTES_U256},
     types::ValidMatchSettleAtomicStatement,
 };
 use contracts_core::crypto::ecdsa::ecdsa_verify;
@@ -41,6 +41,9 @@ const ERR_NONCE_ALREADY_USED: &[u8] = b"nonce already used";
 // -------------
 // | CONSTANTS |
 // -------------
+
+/// The number of bytes in a function selector
+const NUM_BYTES_SELECTOR: usize = 4;
 
 /// The base gas cost of any Ethereum transaction, including the maximum
 /// gas cost of calling a Stylus contract (https://docs.arbitrum.io/stylus/concepts/gas-metering#stylus-gas-costs)
@@ -224,19 +227,23 @@ impl GasSponsorContract {
 
         // Calculate the calldata cost of invoking this method before we consume the
         // args
-        let calldata_len = NUM_BYTES_ADDRESS
+        let calldata_len = NUM_BYTES_SELECTOR
+            + NUM_BYTES_ADDRESS
             + internal_party_match_payload.0.len()
             + valid_match_settle_atomic_statement.0.len()
             + match_proofs.0.len()
             + match_linking_proofs.0.len()
             + NUM_BYTES_ADDRESS
-            + U256::BYTES
+            + NUM_BYTES_U256
             + NUM_BYTES_SIGNATURE;
 
         let calldata_gas = (calldata_len as u64) * GAS_PER_CALLDATA_BYTE;
 
-        // Verify the nonce signature, then mark it as used
-        self.assert_valid_signature(&nonce.to_be_bytes::<32>(), &signature)?;
+        // Verify the signature over the nonce + refund address,
+        // then mark the nonce as used
+        let mut message = nonce.to_be_bytes::<NUM_BYTES_U256>().to_vec();
+        message.extend_from_slice(refund_address.as_slice());
+        self.assert_valid_signature(&message, &signature)?;
         self.mark_nonce_used(nonce)?;
 
         // Invoke the underlying atomic match settlement

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -1,13 +1,17 @@
 //! The gas sponsor contract, used to sponsor the gas costs of external (atomic)
 //! matches
 
-use contracts_common::types::ValidMatchSettleAtomicStatement;
+use contracts_common::{
+    constants::{NUM_BYTES_ADDRESS, NUM_BYTES_SIGNATURE},
+    types::ValidMatchSettleAtomicStatement,
+};
 use contracts_core::crypto::ecdsa::ecdsa_verify;
 use stylus_sdk::{
     abi::Bytes,
-    alloy_primitives::{Address, U256, U64},
-    call::{transfer_eth, Call},
-    contract, evm, msg,
+    alloy_primitives::{hex, Address, U256, U64},
+    block,
+    call::{call, Call},
+    console, contract, evm, msg,
     prelude::*,
     storage::{StorageAddress, StorageBool, StorageMap, StorageU64},
     tx,
@@ -19,8 +23,8 @@ use crate::{
         backends::{PrecompileEcRecoverBackend, StylusHasher},
         helpers::{check_address_not_zero, deserialize_from_calldata, is_native_eth_address},
         solidity::{
-            GasSponsorPausedFallback, IDarkpool, IErc20, InsufficientSponsorBalance, NonceUsed,
-            OwnershipTransferred, Paused, Unpaused,
+            GasSponsorPausedFallback, IArbGasInfo, IDarkpool, IErc20, InsufficientSponsorBalance,
+            NonceUsed, OwnershipTransferred, Paused, Unpaused,
         },
     },
     ECDSA_ERROR_MESSAGE, INVALID_ARR_LEN_ERROR_MESSAGE, INVALID_SIGNATURE_ERROR_MESSAGE,
@@ -38,8 +42,20 @@ const ERR_NONCE_ALREADY_USED: &[u8] = b"nonce already used";
 // | CONSTANTS |
 // -------------
 
-/// The cost in gas of an Ether transfer
-const TRANSFER_GAS_COST: u64 = 21000;
+/// The base gas cost of any Ethereum transaction, including the maximum
+/// gas cost of calling a Stylus contract (https://docs.arbitrum.io/stylus/concepts/gas-metering#stylus-gas-costs)
+const INVOCATION_BASE_GAS_COST: u64 = 21_000 + 2048;
+
+/// The cost in gas of a (non-zero) byte of calldata
+const GAS_PER_CALLDATA_BYTE: u64 = 16;
+
+/// The cost in gas of the refund operations which take place after the final
+/// gas metering check, obtained empirically and rounded to a reasonable value
+const REFUND_OPS_GAS_COST: u64 = 10_000;
+
+/// The address of the ArbGasInfo precompile
+const ARB_GAS_INFO_ADDRESS: Address =
+    Address::new(hex!("000000000000000000000000000000000000006C"));
 
 // -----------------------
 // | CONTRACT DEFINITION |
@@ -55,7 +71,6 @@ pub struct GasSponsorContract {
     initialized: StorageU64,
     /// Whether or not gas sponsorship is paused
     paused: StorageBool,
-
     /// The address of the darkpool proxy contract
     darkpool_address: StorageAddress,
     /// The public key used to authenticate gas sponsorship,
@@ -138,6 +153,14 @@ impl GasSponsorContract {
         Ok(())
     }
 
+    // -----------
+    // | FUNDING |
+    // -----------
+
+    /// Receives ETH from the caller.
+    #[payable]
+    pub fn receive_eth() {}
+
     // ------------------------
     // | SPONSORED SETTLEMENT |
     // ------------------------
@@ -184,6 +207,9 @@ impl GasSponsorContract {
         nonce: U256,
         signature: Bytes,
     ) -> Result<(), Vec<u8>> {
+        // Take note of the initial tx gas budget
+        let initial_gas = evm::gas_left();
+
         // If gas sponsorship is paused, follow through with naive settlement
         if self.is_paused()? {
             evm::log(GasSponsorPausedFallback { nonce });
@@ -196,8 +222,18 @@ impl GasSponsorContract {
             );
         }
 
-        // Take note of the initial tx gas budget
-        let initial_gas = evm::gas_left();
+        // Calculate the calldata cost of invoking this method before we consume the
+        // args
+        let calldata_len = NUM_BYTES_ADDRESS
+            + internal_party_match_payload.0.len()
+            + valid_match_settle_atomic_statement.0.len()
+            + match_proofs.0.len()
+            + match_linking_proofs.0.len()
+            + NUM_BYTES_ADDRESS
+            + U256::BYTES
+            + NUM_BYTES_SIGNATURE;
+
+        let calldata_gas = (calldata_len as u64) * GAS_PER_CALLDATA_BYTE;
 
         // Verify the nonce signature, then mark it as used
         self.assert_valid_signature(&nonce.to_be_bytes::<32>(), &signature)?;
@@ -212,9 +248,33 @@ impl GasSponsorContract {
             match_linking_proofs,
         )?;
 
-        // Track the total gas spent, including cost of remaining operations
-        let gas_spent = U256::from(initial_gas - evm::gas_left() + TRANSFER_GAS_COST);
-        let gas_cost = tx::gas_price() * gas_spent;
+        // Track the total gas spent, including cost of remaining operations.
+        // We frontload as many operations as possible so the final evm::gas_left()
+        // call is as accurate as possible.
+
+        let refund_address =
+            if refund_address == Address::ZERO { tx::origin() } else { refund_address };
+
+        let transfer_config = Call::new().gas(REFUND_OPS_GAS_COST);
+
+        // Get the L2 gas price. On Arbitrum, this is always the basefee:
+        // https://docs.arbitrum.io/how-arbitrum-works/gas-fees#l2-tips
+        let gas_price = block::basefee();
+
+        // Get the L1 gas cost - this is the cost in wei
+        let l1_gas_cost =
+            IArbGasInfo::new(ARB_GAS_INFO_ADDRESS).get_current_tx_l_1_gas_fees(Call::new())?;
+
+        let final_gas = evm::gas_left();
+
+        let gas_spent = U256::from(
+            INVOCATION_BASE_GAS_COST
+                + calldata_gas
+                + (initial_gas - final_gas)
+                + REFUND_OPS_GAS_COST,
+        );
+
+        let gas_cost = gas_price * gas_spent + l1_gas_cost;
 
         // If the gas sponsor doesn't have enough Ether to refund the user,
         // emit an event but don't revert.
@@ -224,10 +284,11 @@ impl GasSponsorContract {
         }
 
         // Refund the user's gas costs
-        let refund_address =
-            if refund_address == Address::ZERO { tx::origin() } else { refund_address };
-
-        transfer_eth(refund_address, gas_cost)?;
+        call(
+            transfer_config.value(gas_cost),
+            refund_address,
+            &[], // calldata
+        )?;
 
         Ok(())
     }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -108,3 +108,9 @@ sol_interface! {
         function approve(address spender, uint256 value) external returns (bool);
     }
 }
+
+sol_interface! {
+    interface IArbGasInfo {
+        function getCurrentTxL1GasFees() external view returns (uint256);
+    }
+}

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 inventory = "0.3"
 num-bigint = "0.4"
+ruint = { workspace = true }
 
 test-helpers = { git = "https://github.com/renegade-fi/renegade.git" }
 colored = "2"

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -133,7 +133,7 @@ abigen!(
     r#"[
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
-        function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, uint256 memory nonce, bytes memory signature) external payable
-        function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, uint256 memory nonce, bytes memory signature) external payable
+        function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable
+        function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable
     ]"#
 );

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -131,6 +131,7 @@ abigen!(
 abigen!(
     GasSponsorContract,
     r#"[
+        function receiveEth() external payable
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
         function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -10,7 +10,7 @@ use abis::{DarkpoolTestContract, DummyErc20Contract, GasSponsorContract};
 use alloy_primitives::U256;
 use clap::Parser;
 use cli::Cli;
-use ethers::{abi::Address, providers::Middleware};
+use ethers::{abi::Address, core::k256::ecdsa::SigningKey, providers::Middleware};
 use eyre::Result;
 use scripts::{
     constants::{
@@ -113,6 +113,11 @@ impl TestContext {
     /// Build an instance of the gas sponsor contract
     pub fn gas_sponsor_contract(&self) -> GasSponsorContract<LocalWalletHttpClient> {
         GasSponsorContract::new(self.gas_sponsor_proxy_address, self.client.clone())
+    }
+
+    /// Get the signing key for the client
+    pub fn signing_key(&self) -> &SigningKey {
+        self.client.signer().signer()
     }
 }
 

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -1,9 +1,16 @@
 //! Integration tests for gas sponsorship
 
+use alloy_primitives::U256;
+use ethers::{abi::Address, types::TransactionReceipt};
 use eyre::Result;
+use ruint::uint;
 use test_helpers::integration_test_async;
 
-use crate::{abis::IAtomicMatchSettleContract, TestContext};
+use crate::{
+    abis::IAtomicMatchSettleContract,
+    utils::{serialize_to_calldata, setup_sponsored_match_test, u256_to_alloy_u256},
+    TestContext,
+};
 
 use super::atomic_settlement::{
     _test_process_atomic_match_settle__external_party_buy_side,
@@ -12,6 +19,10 @@ use super::atomic_settlement::{
     _test_process_atomic_match_settle__native_asset_sell_side,
     _test_process_atomic_match_settle_with_receiver,
 };
+
+/// The gas cost tolerance, i.e. the margin of error in units of gas
+/// that is permissible in our gas refund accounting
+const GAS_COST_TOLERANCE: U256 = uint!(10_000U256);
 
 /// Test an unsponsored buy through the gas
 /// sponsor
@@ -64,3 +75,44 @@ pub async fn test_unsponsored_match_with_receiver(ctx: TestContext) -> Result<()
     _test_process_atomic_match_settle_with_receiver(ctx, contract).await
 }
 integration_test_async!(test_unsponsored_match_with_receiver);
+
+/// Test a sponsored buy through the gas sponsor.
+///
+/// This test only asserts that the refunded amount is ~equal to the gas paid.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__buy_side(ctx: TestContext) -> Result<()> {
+    let data = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
+
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt: TransactionReceipt = ctx
+        .gas_sponsor_contract()
+        .sponsor_atomic_match_settle(
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.internal_party_match_payload,
+            )?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+            )?,
+            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
+            )?,
+            Address::zero(),
+            data.nonce,
+            data.signature,
+        )
+        .send()
+        .await?
+        .await?
+        .expect("no tx receipt");
+
+    let gas_price = u256_to_alloy_u256(receipt.effective_gas_price.unwrap());
+
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let gas_diff = (initial_eth_balance - final_eth_balance) / gas_price;
+    assert!(gas_diff < GAS_COST_TOLERANCE);
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match__buy_side);

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -17,7 +17,7 @@ use circuit_types::{
 };
 use constants::Scalar;
 use contracts_common::{
-    constants::NUM_BYTES_FELT,
+    constants::{NUM_BYTES_ADDRESS, NUM_BYTES_FELT, NUM_BYTES_U256},
     custom_serde::{pk_to_u256s, BytesDeserializable, BytesSerializable},
     solidity::{DepositWitness, PermitWitnessTransferFrom, TokenPermissions},
     types::{
@@ -403,10 +403,11 @@ pub async fn setup_sponsored_match_test(
 
     let mut rng = thread_rng();
     let nonce = scalar_to_u256(ScalarField::rand(&mut rng));
-    let mut nonce_bytes = [0_u8; 32];
-    nonce.to_big_endian(&mut nonce_bytes);
+    let mut message = [0_u8; NUM_BYTES_U256 + NUM_BYTES_ADDRESS];
+    nonce.to_big_endian(&mut message[..NUM_BYTES_U256]);
+    message[NUM_BYTES_U256..].copy_from_slice(Address::zero().as_bytes());
 
-    let signature = Bytes::from(hash_and_sign_message(ctx.signing_key(), &nonce_bytes).to_vec());
+    let signature = Bytes::from(hash_and_sign_message(ctx.signing_key(), &message).to_vec());
 
     // Fund the gas sponsor with some ETH
     ctx.gas_sponsor_contract().receive_eth().value(parse_ether("0.1")?).send().await?.await?;

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -9,6 +9,7 @@ use alloy_sol_types::{
     Eip712Domain, SolStruct, SolType,
 };
 use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
+use ark_std::UniformRand;
 use circuit_types::{
     elgamal::EncryptionKey,
     fixed_point::FixedPoint,
@@ -32,6 +33,7 @@ use contracts_utils::{
     merkle::MerkleConfig,
     proof_system::test_data::{
         address_to_biguint, gen_atomic_match_with_match_and_fees, ProcessAtomicMatchSettleData,
+        SponsoredAtomicMatchSettleData,
     },
 };
 use ethers::{
@@ -41,6 +43,7 @@ use ethers::{
     providers::{JsonRpcClient, Middleware, PendingTransaction},
     signers::{LocalWallet, Signer},
     types::{Bytes, H256, U256},
+    utils::parse_ether,
 };
 use eyre::{eyre, Result};
 use num_bigint::BigUint;
@@ -387,6 +390,45 @@ pub async fn setup_atomic_match_settle_test_native_eth(
     // Replace the base mint with the native ETH address
     let eth_addr = native_eth_address();
     data.valid_match_settle_atomic_statement.match_result.base_mint = eth_addr;
+    Ok(data)
+}
+
+/// Setup a sponsored atomic match settle test
+pub async fn setup_sponsored_match_test(
+    buy_side: bool,
+    ctx: &TestContext,
+) -> Result<SponsoredAtomicMatchSettleData> {
+    let process_atomic_match_settle_data =
+        setup_atomic_match_settle_test(buy_side, true /* use_gas_sponsor */, ctx).await?;
+
+    let mut rng = thread_rng();
+    let nonce = scalar_to_u256(ScalarField::rand(&mut rng));
+    let mut nonce_bytes = [0_u8; 32];
+    nonce.to_big_endian(&mut nonce_bytes);
+
+    let signature = Bytes::from(hash_and_sign_message(ctx.signing_key(), &nonce_bytes).to_vec());
+
+    // Fund the gas sponsor with some ETH
+    ctx.gas_sponsor_contract().receive_eth().value(parse_ether("0.1")?).send().await?.await?;
+
+    Ok(SponsoredAtomicMatchSettleData { process_atomic_match_settle_data, nonce, signature })
+}
+
+/// Setup a sponsored atomic match settle test using native ETH as the base
+/// asset
+pub async fn setup_sponsored_match_test_native_eth(
+    buy_side: bool,
+    ctx: &TestContext,
+) -> Result<SponsoredAtomicMatchSettleData> {
+    let mut data = setup_sponsored_match_test(buy_side, ctx).await?;
+
+    // Replace the base mint with the native ETH address
+    let eth_addr = native_eth_address();
+    data.process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .base_mint = eth_addr;
+
     Ok(data)
 }
 


### PR DESCRIPTION
This PR allows for a configurable refund address to be provided to the sponsored match methods, defaulting to `tx::origin` if the zero address is provided. Additionally, we do more granular gas accounting for the refund, inclusive of L1 gas & top-level function invocation gas costs.

This is still not a perfect measure, but we typically undercount by ~7k gas, which is well within an acceptable margin.

I have included a single integration test for a sponsored buy, asserting that the refunded amount is within our tolerance bounds, which passes. The remaining tests will come in a follow-up PR.