### PR TITLE
integration; contracts-stylus: remaining gas sponsorship tests & tweaks

### DIFF
--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -38,6 +38,10 @@ use crate::{
 /// The revert message returned when a nonce has already been used
 const ERR_NONCE_ALREADY_USED: &[u8] = b"nonce already used";
 
+/// The revert message returned when the sponsor does not have enough ETH to
+/// withdraw
+const ERR_INSUFFICIENT_BALANCE: &[u8] = b"insufficient balance";
+
 // -------------
 // | CONSTANTS |
 // -------------
@@ -55,6 +59,11 @@ const GAS_PER_CALLDATA_BYTE: u64 = 16;
 /// The cost in gas of the refund operations which take place after the final
 /// gas metering check, obtained empirically and rounded to a reasonable value
 const REFUND_OPS_GAS_COST: u64 = 10_000;
+
+/// A buffer in gas to account for empirically-observed gas overheads when
+/// selling native ETH. This may be due to some overhead in transferring ETH
+/// from the (Solidity) proxy to the (Stylus) implementation.
+const NATIVE_ETH_SELL_GAS_BUFFER: u64 = 50_000;
 
 /// The address of the ArbGasInfo precompile
 const ARB_GAS_INFO_ADDRESS: Address =
@@ -164,6 +173,15 @@ impl GasSponsorContract {
     #[payable]
     pub fn receive_eth() {}
 
+    /// Withdraws ETH from the gas sponsor contract to the given receiver
+    pub fn withdraw_eth(&mut self, receiver: Address, amount: U256) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
+        let balance = contract::balance();
+        assert_result!(balance >= amount, ERR_INSUFFICIENT_BALANCE)?;
+        call(Call::new().value(amount), receiver, &[])?;
+        Ok(())
+    }
+
     // ------------------------
     // | SPONSORED SETTLEMENT |
     // ------------------------
@@ -264,6 +282,11 @@ impl GasSponsorContract {
 
         let transfer_config = Call::new().gas(REFUND_OPS_GAS_COST);
 
+        // Check if this is a native ETH sell, for which it is sufficient to check that
+        // the message value is non-zero. If this is not a native ETH sell and the value
+        // is non-zero, there will be a revert in the darkpool.
+        let is_native_eth_sell = msg::value() > U256::ZERO;
+
         // Get the L2 gas price. On Arbitrum, this is always the basefee:
         // https://docs.arbitrum.io/how-arbitrum-works/gas-fees#l2-tips
         let gas_price = block::basefee();
@@ -278,7 +301,8 @@ impl GasSponsorContract {
             INVOCATION_BASE_GAS_COST
                 + calldata_gas
                 + (initial_gas - final_gas)
-                + REFUND_OPS_GAS_COST,
+                + REFUND_OPS_GAS_COST
+                + if is_native_eth_sell { NATIVE_ETH_SELL_GAS_BUFFER } else { 0 },
         );
 
         let gas_cost = gas_price * gas_spent + l1_gas_cost;

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -131,7 +131,10 @@ abigen!(
 abigen!(
     GasSponsorContract,
     r#"[
+        function pause() external
+        function unpause() external
         function receiveEth() external payable
+        function withdrawEth(address receiver, uint256 amount) external
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable
         function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -8,7 +8,10 @@ use test_helpers::integration_test_async;
 
 use crate::{
     abis::IAtomicMatchSettleContract,
-    utils::{serialize_to_calldata, setup_sponsored_match_test, u256_to_alloy_u256},
+    utils::{
+        alloy_u256_to_ethers_u256, serialize_to_calldata, setup_sponsored_match_test,
+        setup_sponsored_match_test_native_eth, u256_to_alloy_u256,
+    },
     TestContext,
 };
 
@@ -22,7 +25,7 @@ use super::atomic_settlement::{
 
 /// The gas cost tolerance, i.e. the margin of error in units of gas
 /// that is permissible in our gas refund accounting
-const GAS_COST_TOLERANCE: U256 = uint!(10_000U256);
+const GAS_COST_TOLERANCE: U256 = uint!(15_000U256);
 
 /// Test an unsponsored buy through the gas
 /// sponsor
@@ -76,11 +79,10 @@ pub async fn test_unsponsored_match_with_receiver(ctx: TestContext) -> Result<()
 }
 integration_test_async!(test_unsponsored_match_with_receiver);
 
-/// Test a sponsored buy through the gas sponsor.
+/// Test a sponsored match through the gas sponsor.
 ///
-/// This test only asserts that the refunded amount is ~equal to the gas paid.
-#[allow(non_snake_case)]
-pub async fn test_sponsored_match__buy_side(ctx: TestContext) -> Result<()> {
+/// Asserts that the refunded amount is ~equal to the gas paid.
+pub async fn test_sponsored_match_refund(ctx: TestContext) -> Result<()> {
     let data = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
 
     let initial_eth_balance = ctx.get_eth_balance().await?;
@@ -108,11 +110,288 @@ pub async fn test_sponsored_match__buy_side(ctx: TestContext) -> Result<()> {
         .expect("no tx receipt");
 
     let gas_price = u256_to_alloy_u256(receipt.effective_gas_price.unwrap());
-
     let final_eth_balance = ctx.get_eth_balance().await?;
+
     let gas_diff = (initial_eth_balance - final_eth_balance) / gas_price;
-    assert!(gas_diff < GAS_COST_TOLERANCE);
+    assert!(gas_diff < GAS_COST_TOLERANCE, "Unrefunded gas amount of {gas_diff} is too high");
 
     Ok(())
 }
-integration_test_async!(test_sponsored_match__buy_side);
+integration_test_async!(test_sponsored_match_refund);
+
+/// Test a sponsored match through the gas sponsor, buying the native asset.
+///
+/// Asserts that the refunded amount is ~equal to the gas paid.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_refund__native_asset_buy(ctx: TestContext) -> Result<()> {
+    let data = setup_sponsored_match_test_native_eth(true /* buy_side */, &ctx).await?;
+
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt: TransactionReceipt = ctx
+        .gas_sponsor_contract()
+        .sponsor_atomic_match_settle(
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.internal_party_match_payload,
+            )?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+            )?,
+            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
+            )?,
+            Address::zero(),
+            data.nonce,
+            data.signature,
+        )
+        .send()
+        .await?
+        .await?
+        .expect("no tx receipt");
+
+    let match_result =
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement.match_result;
+
+    let fees = &data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .external_party_fees;
+
+    let eth_received_in_match = match_result.base_amount - fees.total();
+
+    let gas_price = u256_to_alloy_u256(receipt.effective_gas_price.unwrap());
+    let final_eth_balance = ctx.get_eth_balance().await?;
+
+    let gas_diff = (initial_eth_balance - (final_eth_balance - eth_received_in_match)) / gas_price;
+    assert!(gas_diff < GAS_COST_TOLERANCE, "Unrefunded gas amount of {gas_diff} is too high");
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match_refund__native_asset_buy);
+
+/// Test a sponsored match through the gas sponsor, selling the native asset.
+///
+/// Asserts that the refunded amount is ~equal to the gas paid.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_refund__native_asset_sell(ctx: TestContext) -> Result<()> {
+    let data = setup_sponsored_match_test_native_eth(false /* buy_side */, &ctx).await?;
+
+    let base_amount = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .base_amount;
+
+    let value = alloy_u256_to_ethers_u256(base_amount);
+
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt: TransactionReceipt = ctx
+        .gas_sponsor_contract()
+        .sponsor_atomic_match_settle(
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.internal_party_match_payload,
+            )?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+            )?,
+            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
+            )?,
+            Address::zero(),
+            data.nonce,
+            data.signature,
+        )
+        .value(value)
+        .send()
+        .await?
+        .await?
+        .expect("no tx receipt");
+
+    let gas_price = u256_to_alloy_u256(receipt.effective_gas_price.unwrap());
+    let final_eth_balance = ctx.get_eth_balance().await?;
+
+    let gas_diff = (initial_eth_balance - (final_eth_balance + base_amount)) / gas_price;
+    assert!(gas_diff < GAS_COST_TOLERANCE, "Unrefunded gas amount of {gas_diff} is too high");
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match_refund__native_asset_sell);
+
+/// Test a sponsored match which reuses an existing nonce.
+///
+/// Asserts that the match w/ the duplicate nonce fails.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__duplicate_nonce(ctx: TestContext) -> Result<()> {
+    let data1 = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
+    let data2 = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
+
+    ctx.gas_sponsor_contract()
+        .sponsor_atomic_match_settle(
+            serialize_to_calldata(
+                &data1.process_atomic_match_settle_data.internal_party_match_payload,
+            )?,
+            serialize_to_calldata(
+                &data1.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+            )?,
+            serialize_to_calldata(&data1.process_atomic_match_settle_data.match_atomic_proofs)?,
+            serialize_to_calldata(
+                &data1.process_atomic_match_settle_data.match_atomic_linking_proofs,
+            )?,
+            Address::zero(),
+            data1.nonce,
+            data1.signature.clone(),
+        )
+        .send()
+        .await?
+        .await?
+        .expect("no tx receipt");
+
+    let call = ctx.gas_sponsor_contract().sponsor_atomic_match_settle(
+        serialize_to_calldata(
+            &data2.process_atomic_match_settle_data.internal_party_match_payload,
+        )?,
+        serialize_to_calldata(
+            &data2.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+        )?,
+        serialize_to_calldata(&data2.process_atomic_match_settle_data.match_atomic_proofs)?,
+        serialize_to_calldata(&data2.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
+        Address::zero(),
+        // Here, we reuse the nonce + signature from the first match
+        data1.nonce,
+        data1.signature,
+    );
+
+    let result = call.send().await;
+
+    assert!(result.is_err(), "Expected error due to duplicate nonce");
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match__duplicate_nonce);
+
+/// Test a sponsored match which provides a refund address other than the
+/// one that was signed.
+///
+/// Asserts that the match fails on account of an invalid signature.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__invalid_signature(ctx: TestContext) -> Result<()> {
+    let data = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
+
+    let call = ctx.gas_sponsor_contract().sponsor_atomic_match_settle(
+        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
+        serialize_to_calldata(
+            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+        )?,
+        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
+        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
+        Address::random(), // Incorrect refund address
+        data.nonce,
+        data.signature,
+    );
+
+    let result = call.send().await;
+
+    assert!(result.is_err(), "Expected error due to invalid signature");
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match__invalid_signature);
+
+/// Test a sponsored match when the gas sponsor is paused.
+///
+/// Asserts that the match succeeds but is not sponsored.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__paused(ctx: TestContext) -> Result<()> {
+    let data = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
+
+    // Pause the gas sponsor
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    gas_sponsor_contract.pause().send().await?.await?;
+
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt: TransactionReceipt = gas_sponsor_contract
+        .sponsor_atomic_match_settle(
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.internal_party_match_payload,
+            )?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+            )?,
+            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
+            )?,
+            Address::zero(),
+            data.nonce,
+            data.signature,
+        )
+        .send()
+        .await?
+        .await?
+        .expect("no tx receipt");
+
+    let gas_cost =
+        u256_to_alloy_u256(receipt.gas_used.unwrap() * receipt.effective_gas_price.unwrap());
+    let final_eth_balance = ctx.get_eth_balance().await?;
+
+    assert!(
+        initial_eth_balance - final_eth_balance == gas_cost,
+        "Expected full gas cost to be paid"
+    );
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match__paused);
+
+/// Test a sponsored match when the gas sponsor is underfunded.
+///
+/// Asserts that the match succeeds but is not sponsored.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
+    let data = setup_sponsored_match_test(true /* buy_side */, &ctx).await?;
+
+    // Withdraw all ETH from the gas sponsor
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let balance =
+        alloy_u256_to_ethers_u256(ctx.get_eth_balance_of(gas_sponsor_contract.address()).await?);
+    gas_sponsor_contract.withdraw_eth(ctx.client.address(), balance).send().await?.await?;
+
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt: TransactionReceipt = gas_sponsor_contract
+        .sponsor_atomic_match_settle(
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.internal_party_match_payload,
+            )?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+            )?,
+            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
+            serialize_to_calldata(
+                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
+            )?,
+            Address::zero(),
+            data.nonce,
+            data.signature,
+        )
+        .send()
+        .await?
+        .await?
+        .expect("no tx receipt");
+
+    let gas_cost =
+        u256_to_alloy_u256(receipt.gas_used.unwrap() * receipt.effective_gas_price.unwrap());
+    let final_eth_balance = ctx.get_eth_balance().await?;
+
+    assert!(
+        initial_eth_balance - final_eth_balance == gas_cost,
+        "Expected full gas cost to be paid"
+    );
+
+    Ok(())
+}
+integration_test_async!(test_sponsored_match__underfunded);

--- a/integration/src/utils.rs
+++ b/integration/src/utils.rs
@@ -398,6 +398,9 @@ pub async fn setup_sponsored_match_test(
     buy_side: bool,
     ctx: &TestContext,
 ) -> Result<SponsoredAtomicMatchSettleData> {
+    // Ensure that the gas sponsor is unpaused
+    ctx.gas_sponsor_contract().unpause().send().await?.await?;
+
     let process_atomic_match_settle_data =
         setup_atomic_match_settle_test(buy_side, true /* use_gas_sponsor */, ctx).await?;
 

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -135,7 +135,7 @@ pub const TEST_ERC20_DECIMALS: u8 = 18;
 
 /// The amount of dummy ERC20 tokens to fund the user with
 /// when deploying the testing contracts
-pub const TEST_FUNDING_AMOUNT: u128 = 1000;
+pub const TEST_FUNDING_AMOUNT: u128 = 100_000;
 
 /// The file name for the VALID WALLET CREATE verification key
 pub const VALID_WALLET_CREATE_VKEY_FILE: &str = "valid_wallet_create";


### PR DESCRIPTION
This PR implements the remaining gas sponsorship integration tests, along with any implied tweaks. Namely, these tweaks are:
1. We add a fixed refund buffer in the case of native ETH sells. This seems to imply some overhead that could do with sending Ether from the Solidity proxy to the Stylus implementation contract. We'll keep an eye on this to see if the value fluctuates.
2. We add a `withdraw_eth` method - not only is this useful for testing, but also for our own ability to manage the sponsorship funds in the contract.

All integration tests pass.