### PR TITLE
contracts-stylus: contracts: gas_sponsor: emit amount sponsored event

### DIFF
--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -24,7 +24,7 @@ use crate::{
         helpers::{check_address_not_zero, deserialize_from_calldata, is_native_eth_address},
         solidity::{
             GasSponsorPausedFallback, IArbGasInfo, IDarkpool, IErc20, InsufficientSponsorBalance,
-            NonceUsed, OwnershipTransferred, Paused, Unpaused,
+            NonceUsed, OwnershipTransferred, Paused, SponsoredExternalMatch, Unpaused,
         },
     },
     ECDSA_ERROR_MESSAGE, INVALID_ARR_LEN_ERROR_MESSAGE, INVALID_SIGNATURE_ERROR_MESSAGE,
@@ -320,6 +320,8 @@ impl GasSponsorContract {
             refund_address,
             &[], // calldata
         )?;
+
+        evm::log(SponsoredExternalMatch { amount: gas_cost, nonce });
 
         Ok(())
     }

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -96,6 +96,7 @@ sol! {
     event InsufficientSponsorBalance(uint256 indexed nonce);
     event NonceUsed(uint256 indexed nonce);
     event GasSponsorPausedFallback(uint256 indexed nonce);
+    event SponsoredExternalMatch(uint256 indexed amount, uint256 indexed nonce);
 }
 
 sol_interface! {


### PR DESCRIPTION
This PR adds an `AmountSponsored` event to be emitted after successful gas sponsorship, indicating how much was refunded along with the nonce used. This can be used for accurate tracking of gas sponsorship expenditures by the sponsor.