### PR TITLE
scripts: cli: Allow options to be set by environment vars

### DIFF
--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 ethers = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["env"] }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 alloy-sol-types = { workspace = true }

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -19,15 +19,15 @@ use crate::{
 pub struct Cli {
     /// Private key of the deployer
     // TODO: Better key management
-    #[arg(short, long)]
+    #[arg(short, long, env = "PKEY")]
     pub priv_key: String,
 
     /// Network RPC URL
-    #[arg(short, long)]
+    #[arg(short, long, env = "RPC_URL")]
     pub rpc_url: String,
 
     /// Path to a `deployments.json` file
-    #[arg(short, long)]
+    #[arg(short, long, env = "DEPLOYMENTS")]
     pub deployments_path: String,
 
     /// The command to run


### PR DESCRIPTION
### Purpose
This PR allows cli options to be set by environment variables for the contracts scripts; specifically private key, rpc url, and deployments path

### Testing
- [x] Deployed using the script with env vars.