### PR TITLE
contracts-stylus: Upgrade `stylus-sdk` to `v0.8.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -69,24 +69,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-primitives"
-version = "0.7.7"
+name = "alloy-json-abi"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+checksum = "d62cf1b25f5a50ca2d329b0b4aeb0a0dedeaf225ad3c5099d83b1a4c4616186e"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if 1.0.0",
  "const-hex",
- "derive_more 0.99.18",
- "hex-literal",
+ "derive_more",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand 0.8.5",
  "ruint",
+ "rustc-hash 2.1.1",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -102,57 +119,69 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.7"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
+checksum = "f99b007e002f1082b28827cc47d9c72562d412a98c06f29aa438118ff3036c43"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.7"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
+checksum = "6c0a9cb9b1afbcd3325e0fff9fdf98e6d095643fae9e5584e80597f0b79b6d6e"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.7.1",
- "proc-macro-error",
+ "indexmap 2.8.0",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.7"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
+checksum = "530c4863e707b95f99b37792cdfa94d30004ec552aed41e200a1d9264d44e669"
 dependencies = [
  "const-hex",
  "dunce",
  "heck 0.5.0",
+ "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "syn-solidity",
 ]
 
 [[package]]
-name = "alloy-sol-types"
-version = "0.7.7"
+name = "alloy-sol-type-parser"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
+checksum = "74b210dd863afa9da93c488601a1f23bee1e3ce47e15519582320c205645a7a0"
 dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f306fc801b3aa2e3c4785b7b5252ec8b19f77b30e3b75babfd23849c81bd8c"
+dependencies = [
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
@@ -226,14 +255,14 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -487,7 +516,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rcgen",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "serde",
  "serde_json",
@@ -623,13 +652,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -666,7 +695,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -767,9 +796,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bech32"
@@ -800,7 +829,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -810,6 +848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,9 +861,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -862,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -890,15 +934,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -908,9 +952,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -927,12 +971,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -956,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -971,7 +1014,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -979,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -1026,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1036,7 +1079,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1053,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1064,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1095,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -1123,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1133,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1145,14 +1188,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1238,11 +1281,9 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
- "ark-ec",
  "ark-mpc",
- "ark-poly",
  "async-trait",
  "base64 0.22.1",
  "bimap",
@@ -1252,20 +1293,16 @@ dependencies = [
  "contracts-common",
  "crossbeam",
  "derivative",
- "ecdsa",
  "ed25519-dalek 1.0.1",
  "ethers",
  "hmac",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.10.5",
- "jf-primitives",
  "k256",
  "lazy_static",
  "libp2p",
  "libp2p-identity",
  "metrics",
- "mpc-plonk",
- "mpc-relation",
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
@@ -1277,7 +1314,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -1300,6 +1337,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,7 +1365,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1364,6 +1421,7 @@ dependencies = [
 name = "contracts-stylus"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
@@ -1407,12 +1465,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -1447,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1533,9 +1585,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -1618,7 +1670,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1642,7 +1694,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1653,20 +1705,20 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
+checksum = "9f9724adfcf41f45bf652b3995837669d73c4d49a1b5ac1ff82905ac7d9b5558"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1674,12 +1726,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
+checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1694,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1711,19 +1763,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -1743,7 +1782,8 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1817,19 +1857,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "dns-lookup"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "socket2 0.4.10",
- "winapi",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1852,9 +1880,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -1922,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -2001,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -2156,8 +2184,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.96",
- "toml 0.8.19",
+ "syn 2.0.100",
+ "toml 0.8.20",
  "walkdir",
 ]
 
@@ -2174,7 +2202,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2200,7 +2228,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -2216,7 +2244,7 @@ dependencies = [
  "chrono",
  "ethers-core",
  "reqwest",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2325,7 +2353,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "solang-parser",
@@ -2378,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -2412,9 +2440,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2427,19 +2455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -2533,7 +2552,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2619,6 +2638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,7 +2696,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2710,6 +2741,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "hashers"
@@ -2757,12 +2792,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"
@@ -2806,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -2864,19 +2896,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -3017,7 +3036,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3082,7 +3101,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3104,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3115,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -3170,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b31349d02fe60f80bbbab1a9402364cad7460626d6030494b08ac4a2075bf81"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
 dependencies = [
  "rustversion",
 ]
@@ -3218,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jf-primitives"
@@ -3337,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "kanal"
-version = "0.1.0-pre8"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
+checksum = "8b13526b910349296b1d3537ae62d5f83def9b6d6974e26d62b80ee2bb1b4794"
 dependencies = [
  "futures-core",
  "lock_api",
@@ -3377,7 +3396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
@@ -3408,9 +3427,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -3533,21 +3552,21 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -3567,9 +3586,20 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "matchers"
@@ -3647,7 +3677,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -3668,7 +3698,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -3695,17 +3725,18 @@ dependencies = [
 
 [[package]]
 name = "mini-alloc"
-version = "0.6.0"
-source = "git+https://github.com/joeykraut/stylus-sdk-rs#cf6352cb3007aa4d7dc9c571e19f85470d92863d"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3dc09847999e8f92fb6ff6f3e11e9ac1b1976208aed3d6a3688d94132f4298"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -3852,23 +3883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,10 +3969,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3972,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "opaque-debug"
@@ -4008,48 +4022,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-dependencies = [
- "bitflags 2.8.0",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
@@ -4059,7 +4035,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -4075,7 +4051,7 @@ checksum = "3e09667367cb509f10d7cf5960a83f9c4d96e93715f750b164b4b98d46c3cbf4"
 dependencies = [
  "futures-core",
  "http",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "once_cell",
  "opentelemetry",
@@ -4184,28 +4160,30 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4298,7 +4276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -4309,7 +4287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -4329,7 +4307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.3",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4338,7 +4316,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.5",
 ]
 
@@ -4349,19 +4327,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4370,27 +4339,27 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4417,9 +4386,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -4434,9 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "postcard"
@@ -4459,11 +4428,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4474,12 +4443,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4508,9 +4477,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -4540,23 +4509,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.93"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.8.0",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -4631,7 +4622,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "thiserror 1.0.69",
  "tokio",
@@ -4648,7 +4639,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.16.20",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "rustls-native-certs",
  "slab",
@@ -4673,12 +4664,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -4718,6 +4715,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4778,11 +4776,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.3.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4819,11 +4817,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4884,7 +4882,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -4903,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "atomic_float",
  "circuit-types",
@@ -4931,12 +4929,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4948,7 +4944,6 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -4986,15 +4981,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -5043,9 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
+checksum = "825df406ec217a8116bd7b06897c6cc8f65ffefc15d030ae2c9540acc9ed50b6"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -5086,6 +5080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,16 +5106,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5141,7 +5141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.14",
  "rustls-webpki",
  "sct",
 ]
@@ -5173,15 +5173,15 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty-fork"
@@ -5208,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
@@ -5237,7 +5237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if 1.0.0",
- "derive_more 1.0.0",
+ "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -5248,10 +5248,10 @@ version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5315,7 +5315,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -5339,7 +5339,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5367,9 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -5397,38 +5397,38 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -5467,7 +5467,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5484,7 +5484,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5610,15 +5610,9 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -5643,9 +5637,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "snafu"
@@ -5743,14 +5737,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "938d512196766101d333398efde81bc1f37b00cb42c2f8350e5df639f040bbbe"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -5779,31 +5772,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
-name = "stylus-proc"
-version = "0.6.0"
-source = "git+https://github.com/joeykraut/stylus-sdk-rs#cf6352cb3007aa4d7dc9c571e19f85470d92863d"
+name = "stylus-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2434fc6bcabf9b7f1a3d5da44cfa34609b12e98e3fde3f3d0c4709e5726474a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "cfg-if 1.0.0",
- "convert_case 0.6.0",
+ "dyn-clone",
+]
+
+[[package]]
+name = "stylus-proc"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c003efb32d59dc3f291f4a22c777e81e5dc699cdbcafeefd4a39598bd0c36e7a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "cfg-if 1.0.0",
+ "convert_case",
  "lazy_static",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
  "sha3",
- "syn 1.0.109",
+ "syn 2.0.100",
  "syn-solidity",
+ "trybuild",
 ]
 
 [[package]]
 name = "stylus-sdk"
-version = "0.6.0"
-source = "git+https://github.com/joeykraut/stylus-sdk-rs#cf6352cb3007aa4d7dc9c571e19f85470d92863d"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6cba6ce22094d368abca999750bde1eade17083d5037d036a9fb553cb04532"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5812,8 +5821,9 @@ dependencies = [
  "hex",
  "keccak-const",
  "lazy_static",
- "mini-alloc 0.6.0",
+ "mini-alloc 0.8.3",
  "regex",
+ "stylus-core",
  "stylus-proc",
 ]
 
@@ -5834,7 +5844,7 @@ dependencies = [
  "hex",
  "once_cell",
  "reqwest",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -5856,9 +5866,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5867,14 +5877,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.7"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
+checksum = "36dbbf0d465ab9fdfea3093e755ae8839bdc1263dbe18d35064d02d6060f949e"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5903,7 +5913,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5960,14 +5970,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempfile"
-version = "3.15.0"
+name = "target-triple"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if 1.0.0",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5985,34 +6000,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "arbitrum-client",
- "ark-ec",
- "ark-mpc",
- "async-trait",
- "circuit-types",
- "common",
- "constants",
- "dns-lookup",
- "ethers",
  "eyre",
  "futures",
  "itertools 0.10.5",
- "k256",
- "num-bigint",
  "rand 0.8.5",
- "renegade-crypto",
- "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "util",
 ]
 
 [[package]]
@@ -6026,11 +6034,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -6041,18 +6049,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6076,9 +6084,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -6091,15 +6099,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6126,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6141,9 +6149,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6175,17 +6183,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6226,9 +6224,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6248,9 +6246,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6269,11 +6267,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6360,7 +6358,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6469,6 +6467,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trybuild"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.8.20",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6490,9 +6503,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -6520,9 +6533,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6608,7 +6621,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#000893350337f88e812a58ad1d1928f2f6d5dbb2"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",
@@ -6655,11 +6668,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "serde",
 ]
 
@@ -6668,12 +6681,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6689,9 +6696,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -6728,6 +6735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6751,7 +6767,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -6786,7 +6802,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6826,7 +6842,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -6887,6 +6903,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"
@@ -7095,9 +7117,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -7110,6 +7132,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -7187,7 +7218,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure 0.13.1",
 ]
 
@@ -7197,8 +7228,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -7209,27 +7248,38 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure 0.13.1",
 ]
 
@@ -7250,7 +7300,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7272,7 +7322,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7316,9 +7366,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ ark-crypto-primitives = { version = "0.4", default-features = false, features = 
     "crh",
     "merkle_tree",
 ] }
-alloy-primitives = { version = "=0.7.7", default-features = false }
-alloy-sol-types = { version = "=0.7.7", default-features = false }
+alloy-primitives = { version = "0.8.20", default-features = false }
+alloy-sol-types = { version = "0.8.20", default-features = false }
 serde = { version = "1.0.197", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.4", default-features = false, features = [
@@ -45,7 +45,7 @@ arbitrum-client = { git = "https://github.com/renegade-fi/renegade.git" }
 itertools = "0.12"
 mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
-stylus-sdk = { git = "https://github.com/joeykraut/stylus-sdk-rs" }
+stylus-sdk = { version = "0.8.3" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -13,6 +13,7 @@ contracts-common = { path = "../contracts-common" }
 contracts-core = { path = "../contracts-core" }
 postcard = { workspace = true }
 alloy-sol-types = { workspace = true }
+alloy-primitives = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 

--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -10,8 +10,8 @@ use crate::{
             ROOT_NOT_IN_HISTORY_ERROR_MESSAGE,
         },
         helpers::{
-            delegate_call_helper, get_public_blinder_from_shares, map_call_error,
-            postcard_serialize, static_call_helper, u256_to_scalar,
+            delegate_call_helper, get_public_blinder_from_shares, postcard_serialize,
+            static_call_helper, u256_to_scalar,
         },
         solidity::{
             executeExternalTransferCall, insertNoteCommitmentCall, insertSharesCommitmentCall,
@@ -19,6 +19,7 @@ use crate::{
             WalletUpdated,
         },
     },
+    VKEYS_FETCH_ERROR_MESSAGE,
 };
 use alloc::{vec, vec::Vec};
 use alloy_sol_types::{SolCall, SolType};
@@ -26,7 +27,7 @@ use contracts_common::{
     custom_serde::{pk_to_u256s, scalar_to_u256},
     types::{ExternalTransfer, PublicEncryptionKey, PublicSigningKey, ScalarField},
 };
-use stylus_sdk::{abi::Bytes, alloy_primitives::U256, call::static_call, evm, prelude::*};
+use stylus_sdk::{abi::Bytes, alloy_primitives::U256, prelude::*};
 
 use super::CoreContractStorage;
 
@@ -66,13 +67,16 @@ pub fn check_root_in_history<C: CoreContractStorage, S: TopLevelStorage + Borrow
 /// Fetches the verification keys by their associated method selector on the
 /// vkeys contract. This assumes that the vkeys contract method takes no
 /// arguments and returns a single `bytes` value.
-pub fn fetch_vkeys<C: CoreContractStorage, S: TopLevelStorage + Borrow<C>>(
+pub fn fetch_vkeys<C: CoreContractStorage, S: TopLevelStorage + HostAccess + Borrow<C>>(
     s: &S,
     selector: &[u8],
 ) -> Result<Vec<u8>, Vec<u8>> {
     let storage = s.borrow();
     let vkeys_address = storage.vkeys_address();
-    let res = static_call(s, vkeys_address, selector).map_err(map_call_error)?;
+    let res = s
+        .vm()
+        .static_call(&s, vkeys_address, selector)
+        .map_err(|_| VKEYS_FETCH_ERROR_MESSAGE.to_vec())?;
     let vkey_bytes = Bytes::abi_decode(&res, false /* validate */)
         .map_err(|_| CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec())?
         .0;
@@ -116,7 +120,10 @@ where
 // -----------------------
 
 /// Marks the given nullifier as spent
-pub fn mark_nullifier_spent<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn mark_nullifier_spent<
+    C: CoreContractStorage,
+    S: TopLevelStorage + HostAccess + BorrowMut<C>,
+>(
     s: &mut S,
     nullifier: ScalarField,
 ) -> Result<(), Vec<u8>> {
@@ -130,8 +137,7 @@ pub fn mark_nullifier_spent<C: CoreContractStorage, S: TopLevelStorage + BorrowM
     )?);
 
     this.nullifier_set_mut().insert(nullifier, true);
-
-    evm::log(NullifierSpent { nullifier });
+    log(s.vm(), NullifierSpent { nullifier });
     Ok(())
 }
 
@@ -251,7 +257,7 @@ pub fn execute_external_transfer<C: CoreContractStorage, S: TopLevelStorage + Bo
 }
 
 /// Nullifies the old wallet and commits to the new wallet
-pub fn rotate_wallet<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn rotate_wallet<C: CoreContractStorage, S: TopLevelStorage + HostAccess + BorrowMut<C>>(
     s: &mut S,
     old_wallet_nullifier: ScalarField,
     merkle_root: ScalarField,
@@ -268,7 +274,10 @@ pub fn rotate_wallet<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
 
 /// Nullifies the old wallet and commits to the new wallet,
 /// verifying a signature over the commitment to the new wallet
-pub fn rotate_wallet_with_signature<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn rotate_wallet_with_signature<
+    C: CoreContractStorage,
+    S: TopLevelStorage + HostAccess + BorrowMut<C>,
+>(
     s: &mut S,
     old_wallet_nullifier: ScalarField,
     merkle_root: ScalarField,
@@ -290,7 +299,10 @@ pub fn rotate_wallet_with_signature<C: CoreContractStorage, S: TopLevelStorage +
 /// Attempts to nullify the old wallet, ensures that the given Merkle
 /// root is a valid historical root, and marks the public blinder as used.
 /// Logs the wallet update if successful.
-pub fn check_wallet_rotation<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn check_wallet_rotation<
+    C: CoreContractStorage,
+    S: TopLevelStorage + HostAccess + BorrowMut<C>,
+>(
     s: &mut S,
     old_wallet_nullifier: ScalarField,
     merkle_root: ScalarField,
@@ -304,7 +316,10 @@ pub fn check_wallet_rotation<C: CoreContractStorage, S: TopLevelStorage + Borrow
 
 /// Checks that the given Merkle root is a valid historical root,
 /// and marks the nullifier as spent.
-pub fn check_root_and_nullify<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn check_root_and_nullify<
+    C: CoreContractStorage,
+    S: TopLevelStorage + HostAccess + BorrowMut<C>,
+>(
     s: &mut S,
     nullifier: ScalarField,
     merkle_root: ScalarField,
@@ -317,7 +332,7 @@ pub fn check_root_and_nullify<C: CoreContractStorage, S: TopLevelStorage + Borro
 }
 
 /// Commits the given note commitment in the Merkle tree
-pub fn commit_note<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn commit_note<C: CoreContractStorage, S: TopLevelStorage + HostAccess + BorrowMut<C>>(
     s: &mut S,
     note_commitment: ScalarField,
 ) -> Result<(), Vec<u8>> {
@@ -325,8 +340,7 @@ pub fn commit_note<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
     let merkle_address = s.borrow_mut().merkle_address();
     delegate_call_helper::<insertNoteCommitmentCall>(s, merkle_address, (note_commitment_u256,))?;
 
-    evm::log(NotePosted { note_commitment: note_commitment_u256 });
-
+    log(s.vm(), NotePosted { note_commitment: note_commitment_u256 });
     Ok(())
 }
 
@@ -335,7 +349,7 @@ pub fn commit_note<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
 // -----------
 
 /// Emits a `WalletUpdated` event with the wallet's public blinder share
-pub fn log_blinder_used<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn log_blinder_used<C: CoreContractStorage, S: TopLevelStorage + HostAccess + BorrowMut<C>>(
     s: &mut S,
     public_wallet_shares: &[ScalarField],
 ) -> Result<(), Vec<u8>> {
@@ -345,7 +359,6 @@ pub fn log_blinder_used<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C
 
     // Log the wallet update
     let blinder_u256 = scalar_to_u256(wallet_blinder_share);
-    evm::log(WalletUpdated { wallet_blinder_share: blinder_u256 });
-
+    log(s.vm(), WalletUpdated { wallet_blinder_share: blinder_u256 });
     Ok(())
 }

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -3,8 +3,6 @@
 //! contract and that certain storage elements are set by the outer contract. As
 //! such, its storage layout must exactly align with that of the outer contract.
 
-use core::borrow::BorrowMut;
-
 use crate::{
     assert_result,
     contracts::core::core_helpers::{call_settlement_verifier, fetch_vkeys, rotate_wallet},
@@ -38,7 +36,6 @@ use contracts_common::types::{
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{Address, U256},
-    msg,
     prelude::*,
     storage::{StorageAddress, StorageArray, StorageBool, StorageMap, StorageU256, StorageU64},
 };
@@ -202,8 +199,8 @@ impl CoreSettlementContract {
     /// [`contracts_common::types::MatchProofs`] struct, and the
     /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::MatchLinkingProofs`] struct
-    pub fn process_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn process_match_settle(
+        &mut self,
         party_0_match_payload: Bytes,
         party_1_match_payload: Bytes,
         valid_match_settle_statement: Bytes,
@@ -233,14 +230,13 @@ impl CoreSettlementContract {
             // We convert the protocol fee directly to a scalar as it is already kept
             // in storage as fixed-point number, no manipulation is needed to coerce it
             // to the form expected in the statement / circuit.
-            let protocol_fee = u256_to_scalar(storage.borrow_mut().protocol_fee())?;
+            let protocol_fee = u256_to_scalar(self.protocol_fee())?;
             assert_result!(
                 valid_match_settle_statement.protocol_fee == protocol_fee,
                 INVALID_PROTOCOL_FEE_ERROR_MESSAGE
             )?;
 
-            Self::batch_verify_process_match_settle(
-                storage,
+            self.batch_verify_process_match_settle(
                 &party_0_match_payload,
                 &party_1_match_payload,
                 &valid_match_settle_statement,
@@ -250,7 +246,7 @@ impl CoreSettlementContract {
         });
 
         rotate_wallet(
-            storage,
+            self,
             party_0_match_payload.valid_reblind_statement.original_shares_nullifier,
             party_0_match_payload.valid_reblind_statement.merkle_root,
             party_0_match_payload.valid_reblind_statement.reblinded_private_shares_commitment,
@@ -258,7 +254,7 @@ impl CoreSettlementContract {
         )?;
 
         rotate_wallet(
-            storage,
+            self,
             party_1_match_payload.valid_reblind_statement.original_shares_nullifier,
             party_1_match_payload.valid_reblind_statement.merkle_root,
             party_1_match_payload.valid_reblind_statement.reblinded_private_shares_commitment,
@@ -280,8 +276,8 @@ impl CoreSettlementContract {
     /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::ExternalMatchLinkingProofs`] struct
     #[payable]
-    pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn process_atomic_match_settle(
+        &mut self,
         receiver: Address,
         internal_party_match_payload: Bytes,
         valid_match_settle_statement: Bytes,
@@ -300,7 +296,7 @@ impl CoreSettlementContract {
         let is_native_eth = is_native_eth_address(match_result.base_mint);
         let is_external_party_sell = match_result.is_external_party_sell();
         let native_eth_sell = is_native_eth && is_external_party_sell;
-        if !native_eth_sell && msg::value() > U256::ZERO {
+        if !native_eth_sell && self.vm().msg_value() > U256::ZERO {
             return Err(INVALID_TRANSACTION_VALUE_ERROR_MESSAGE.into());
         }
 
@@ -315,16 +311,14 @@ impl CoreSettlementContract {
             // We convert the protocol fee directly to a scalar as it is already kept
             // in storage as fixed-point number, no manipulation is needed to coerce it
             // to the form expected in the statement / circuit.
-            let protocol_fee =
-                storage.borrow_mut().external_match_protocol_fee(match_result.base_mint);
+            let protocol_fee = self.external_match_protocol_fee(match_result.base_mint);
             let protocol_fee = u256_to_scalar(protocol_fee)?;
             assert_result!(
                 valid_match_settle_atomic_statement.protocol_fee == protocol_fee,
                 INVALID_PROTOCOL_FEE_ERROR_MESSAGE
             )?;
 
-            Self::batch_verify_process_atomic_match_settle(
-                storage,
+            self.batch_verify_process_atomic_match_settle(
                 is_native_eth,
                 &internal_party_match_payload,
                 valid_match_settle_atomic_statement.clone(),
@@ -334,7 +328,7 @@ impl CoreSettlementContract {
         });
 
         rotate_wallet(
-            storage,
+            self,
             internal_party_match_payload.valid_reblind_statement.original_shares_nullifier,
             internal_party_match_payload.valid_reblind_statement.merkle_root,
             internal_party_match_payload
@@ -348,7 +342,7 @@ impl CoreSettlementContract {
         let match_result = valid_match_settle_atomic_statement.match_result;
         let relayer_fee_address = valid_match_settle_atomic_statement.relayer_fee_address;
         Self::execute_atomic_match_transfers(
-            storage,
+            self,
             receiver,
             fees,
             match_result,
@@ -368,8 +362,8 @@ impl CoreSettlementContract {
     ///
     /// TODO: Optimize the (re)serialization of the match statements if need be
     #[allow(clippy::too_many_arguments)]
-    pub fn batch_verify_process_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn batch_verify_process_match_settle(
+        &self,
         party_0_match_payload: &MatchPayload,
         party_1_match_payload: &MatchPayload,
         valid_match_settle_statement: &ValidMatchSettleStatement,
@@ -378,8 +372,7 @@ impl CoreSettlementContract {
     ) -> Result<(), Vec<u8>> {
         // Fetch the Plonk & linking verification keys used in verifying the matching of
         // a trade
-        let process_match_settle_vkeys =
-            fetch_vkeys(storage, &processMatchSettleVkeysCall::SELECTOR)?;
+        let process_match_settle_vkeys = fetch_vkeys(self, &processMatchSettleVkeysCall::SELECTOR)?;
 
         let match_public_inputs = serialize_match_statements_for_verification(
             &party_0_match_payload.valid_commitments_statement,
@@ -389,7 +382,7 @@ impl CoreSettlementContract {
             valid_match_settle_statement,
         )?;
 
-        let verifier_address = storage.borrow_mut().verifier_core_address();
+        let verifier_address = self.verifier_core_address();
         let calldata = VerifyMatchCalldata {
             verifier_address,
             match_vkeys: process_match_settle_vkeys,
@@ -400,15 +393,15 @@ impl CoreSettlementContract {
 
         let calldata_bytes = postcard_serialize(&calldata)?;
         let result =
-            call_settlement_verifier::<_, _, verifyMatchCall>(storage, (calldata_bytes.into(),))?;
+            call_settlement_verifier::<_, _, verifyMatchCall>(self, (calldata_bytes.into(),))?;
         assert_result!(result._0, VERIFICATION_FAILED_ERROR_MESSAGE)
     }
 
     /// Batch-verifies all of the `process_atomic_match_settle` proofs
     ///
     /// TODO: Optimize the (re)serialization of the match statements if need be
-    pub fn batch_verify_process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn batch_verify_process_atomic_match_settle(
+        &self,
         is_native_eth: bool,
         internal_party_match_payload: &MatchPayload,
         mut valid_match_settle_atomic_statement: ValidMatchSettleAtomicStatement,
@@ -418,7 +411,7 @@ impl CoreSettlementContract {
         // Fetch the Plonk & linking verification keys used in verifying the matching of
         // a trade
         let process_atomic_match_settle_vkeys =
-            fetch_vkeys(storage, &processAtomicMatchSettleVkeysCall::SELECTOR)?;
+            fetch_vkeys(self, &processAtomicMatchSettleVkeysCall::SELECTOR)?;
 
         // We allow native ETH transfers on external matches, but the verifier will
         // expect WETH to be compatible with internal orders, so we change it
@@ -434,7 +427,7 @@ impl CoreSettlementContract {
             &valid_match_settle_atomic_statement,
         )?;
 
-        let verifier_address = storage.borrow_mut().verifier_core_address();
+        let verifier_address = self.verifier_core_address();
         let calldata = VerifyAtomicMatchCalldata {
             verifier_address,
             match_atomic_vkeys: process_atomic_match_settle_vkeys,
@@ -445,7 +438,7 @@ impl CoreSettlementContract {
 
         let calldata_bytes = postcard_serialize(&calldata)?;
         let result = call_settlement_verifier::<_, _, verifyAtomicMatchCall>(
-            storage,
+            self,
             (calldata_bytes.into(),),
         )?;
 
@@ -454,8 +447,8 @@ impl CoreSettlementContract {
 
     /// Execute the transfers to/from the external party in an atomic match
     /// settlement
-    pub fn execute_atomic_match_transfers<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn execute_atomic_match_transfers(
+        &mut self,
         receiver: Address,
         fees: FeeTake,
         match_result: ExternalMatchResult,
@@ -463,7 +456,7 @@ impl CoreSettlementContract {
     ) -> Result<(), Vec<u8>> {
         /// The number of transfers to execute in an atomic match settlement
         const N_TRANSFERS: usize = 4;
-        let tx_sender = msg::sender();
+        let tx_sender = self.vm().msg_sender();
 
         let mut transfers_batch = Vec::with_capacity(N_TRANSFERS);
         let (send_mint, send_amount) = match_result.external_party_sell_mint_amount();
@@ -477,7 +470,7 @@ impl CoreSettlementContract {
         ));
 
         // The fee charged by the protocol to the external party
-        let protocol_fee_address = storage.borrow_mut().protocol_external_fee_collection_address();
+        let protocol_fee_address = self.protocol_external_fee_collection_address();
         transfers_batch.push(SimpleErc20Transfer::new_withdraw(
             protocol_fee_address,
             receive_mint,
@@ -496,19 +489,15 @@ impl CoreSettlementContract {
 
         // The amount sent by the external party to the darkpool
         transfers_batch.push(SimpleErc20Transfer::new_deposit(tx_sender, send_mint, send_amount));
-
-        Self::execute_transfers(storage, transfers_batch)
+        self.execute_transfers(transfers_batch)
     }
 
     /// Call the transfer executor to execute the transfers
-    fn execute_transfers<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        transfers: Vec<SimpleErc20Transfer>,
-    ) -> Result<(), Vec<u8>> {
-        let transfer_executor_address = storage.borrow_mut().transfer_executor_address();
+    fn execute_transfers(&mut self, transfers: Vec<SimpleErc20Transfer>) -> Result<(), Vec<u8>> {
+        let transfer_executor_address = self.transfer_executor_address();
         let calldata = postcard_serialize(&transfers)?;
         delegate_call_helper::<executeTransferBatchCall>(
-            storage,
+            self,
             transfer_executor_address,
             (calldata.into(),),
         )

--- a/contracts-stylus/src/contracts/core/core_wallet_ops.rs
+++ b/contracts-stylus/src/contracts/core/core_wallet_ops.rs
@@ -4,8 +4,6 @@
 //! outer contract. As such, its storage layout must exactly align with that of
 //! the outer contract.
 
-use core::borrow::BorrowMut;
-
 use crate::{
     assert_result,
     contracts::core::core_helpers::{
@@ -196,8 +194,8 @@ impl CoreContractStorage for CoreWalletOpsContract {
 #[public]
 impl CoreWalletOpsContract {
     /// Adds a new wallet to the commitment tree
-    pub fn new_wallet<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn new_wallet(
+        &mut self,
         proof: Bytes,
         valid_wallet_create_statement_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
@@ -206,11 +204,11 @@ impl CoreWalletOpsContract {
 
         if_verifying!({
             let valid_wallet_create_vkey_bytes =
-                fetch_vkeys(storage, &validWalletCreateVkeyCall::SELECTOR)?;
+                fetch_vkeys(self, &validWalletCreateVkeyCall::SELECTOR)?;
 
             assert_result!(
                 verify(
-                    storage,
+                    self,
                     valid_wallet_create_vkey_bytes,
                     proof.0,
                     serialize_statement_for_verification(&valid_wallet_create_statement)?,
@@ -220,18 +218,18 @@ impl CoreWalletOpsContract {
         });
 
         insert_wallet_commitment_to_merkle_tree(
-            storage,
+            self,
             valid_wallet_create_statement.private_shares_commitment,
             &valid_wallet_create_statement.public_wallet_shares,
         )?;
 
-        log_blinder_used(storage, &valid_wallet_create_statement.public_wallet_shares)?;
+        log_blinder_used(self, &valid_wallet_create_statement.public_wallet_shares)?;
         Ok(())
     }
 
     /// Update a wallet in the commitment tree
-    pub fn update_wallet<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn update_wallet(
+        &mut self,
         proof: Bytes,
         valid_wallet_update_statement_bytes: Bytes,
         wallet_commitment_signature: Bytes,
@@ -242,11 +240,11 @@ impl CoreWalletOpsContract {
 
         if_verifying!({
             let valid_wallet_update_vkey_bytes =
-                fetch_vkeys(storage, &validWalletUpdateVkeyCall::SELECTOR)?;
+                fetch_vkeys(self, &validWalletUpdateVkeyCall::SELECTOR)?;
 
             assert_result!(
                 verify(
-                    storage,
+                    self,
                     valid_wallet_update_vkey_bytes,
                     proof.0,
                     serialize_statement_for_verification(&valid_wallet_update_statement)?,
@@ -256,7 +254,7 @@ impl CoreWalletOpsContract {
         });
 
         rotate_wallet_with_signature(
-            storage,
+            self,
             valid_wallet_update_statement.old_shares_nullifier,
             valid_wallet_update_statement.merkle_root,
             valid_wallet_update_statement.new_private_shares_commitment,
@@ -267,7 +265,7 @@ impl CoreWalletOpsContract {
 
         if let Some(external_transfer) = valid_wallet_update_statement.external_transfer {
             execute_external_transfer(
-                storage,
+                self,
                 valid_wallet_update_statement.old_pk_root,
                 external_transfer,
                 transfer_aux_data_bytes,
@@ -279,8 +277,8 @@ impl CoreWalletOpsContract {
 
     /// Settles the fee accumulated by a relayer for a given balance in a
     /// managed wallet into the relayer's wallet
-    pub fn settle_online_relayer_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn settle_online_relayer_fee(
+        &mut self,
         proof: Bytes,
         valid_relayer_fee_settlement_statement: Bytes,
         relayer_wallet_commitment_signature: Bytes,
@@ -290,11 +288,11 @@ impl CoreWalletOpsContract {
 
         if_verifying!({
             let valid_relayer_fee_settlement_vkey_bytes =
-                fetch_vkeys(storage, &validRelayerFeeSettlementVkeyCall::SELECTOR)?;
+                fetch_vkeys(self, &validRelayerFeeSettlementVkeyCall::SELECTOR)?;
 
             assert_result!(
                 verify(
-                    storage,
+                    self,
                     valid_relayer_fee_settlement_vkey_bytes,
                     proof.0,
                     serialize_statement_for_verification(&valid_relayer_fee_settlement_statement)?,
@@ -304,7 +302,7 @@ impl CoreWalletOpsContract {
         });
 
         rotate_wallet(
-            storage,
+            self,
             valid_relayer_fee_settlement_statement.sender_nullifier,
             valid_relayer_fee_settlement_statement.sender_root,
             valid_relayer_fee_settlement_statement.sender_wallet_commitment,
@@ -312,7 +310,7 @@ impl CoreWalletOpsContract {
         )?;
 
         rotate_wallet_with_signature(
-            storage,
+            self,
             valid_relayer_fee_settlement_statement.recipient_nullifier,
             valid_relayer_fee_settlement_statement.recipient_root,
             valid_relayer_fee_settlement_statement.recipient_wallet_commitment,
@@ -324,8 +322,8 @@ impl CoreWalletOpsContract {
 
     /// Settles the fee accumulated either by a relayer or the protocol
     /// into an encrypted note which is committed to the Merkle tree
-    pub fn settle_offline_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn settle_offline_fee(
+        &mut self,
         proof: Bytes,
         valid_offline_fee_settlement_statement: Bytes,
     ) -> Result<(), Vec<u8>> {
@@ -333,18 +331,18 @@ impl CoreWalletOpsContract {
             deserialize_from_calldata(&valid_offline_fee_settlement_statement)?;
 
         if_verifying!({
-            let protocol_pubkey = get_protocol_public_encryption_key(storage)?;
+            let protocol_pubkey = get_protocol_public_encryption_key(self)?;
             assert_result!(
                 valid_offline_fee_settlement_statement.protocol_key == protocol_pubkey,
                 INVALID_PROTOCOL_PUBKEY_ERROR_MESSAGE
             )?;
 
             let valid_offline_fee_settlement_vkey_bytes =
-                fetch_vkeys(storage, &validOfflineFeeSettlementVkeyCall::SELECTOR)?;
+                fetch_vkeys(self, &validOfflineFeeSettlementVkeyCall::SELECTOR)?;
 
             assert_result!(
                 verify(
-                    storage,
+                    self,
                     valid_offline_fee_settlement_vkey_bytes,
                     proof.0,
                     serialize_statement_for_verification(&valid_offline_fee_settlement_statement)?,
@@ -354,19 +352,19 @@ impl CoreWalletOpsContract {
         });
 
         rotate_wallet(
-            storage,
+            self,
             valid_offline_fee_settlement_statement.nullifier,
             valid_offline_fee_settlement_statement.merkle_root,
             valid_offline_fee_settlement_statement.updated_wallet_commitment,
             &valid_offline_fee_settlement_statement.updated_wallet_public_shares,
         )?;
 
-        commit_note(storage, valid_offline_fee_settlement_statement.note_commitment)
+        commit_note(self, valid_offline_fee_settlement_statement.note_commitment)
     }
 
     /// Redeems a fee note into the recipient's wallet, nullifying the note
-    pub fn redeem_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn redeem_fee(
+        &mut self,
         proof: Bytes,
         valid_fee_redemption_statement: Bytes,
         recipient_wallet_commitment_signature: Bytes,
@@ -376,11 +374,11 @@ impl CoreWalletOpsContract {
 
         if_verifying!({
             let valid_fee_redemption_vkey_bytes =
-                fetch_vkeys(storage, &validFeeRedemptionVkeyCall::SELECTOR)?;
+                fetch_vkeys(self, &validFeeRedemptionVkeyCall::SELECTOR)?;
 
             assert_result!(
                 verify(
-                    storage,
+                    self,
                     valid_fee_redemption_vkey_bytes,
                     proof.0,
                     serialize_statement_for_verification(&valid_fee_redemption_statement)?,
@@ -390,7 +388,7 @@ impl CoreWalletOpsContract {
         });
 
         rotate_wallet_with_signature(
-            storage,
+            self,
             valid_fee_redemption_statement.nullifier,
             valid_fee_redemption_statement.wallet_root,
             valid_fee_redemption_statement.new_wallet_commitment,
@@ -400,7 +398,7 @@ impl CoreWalletOpsContract {
         )?;
 
         check_root_and_nullify(
-            storage,
+            self,
             valid_fee_redemption_statement.note_nullifier,
             valid_fee_redemption_statement.note_root,
         )

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -3,11 +3,9 @@
 //! and handling deposits / withdrawals.
 
 use alloc::{vec, vec::Vec};
-use core::borrow::{Borrow, BorrowMut};
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{Address, U256, U64},
-    evm, msg,
     prelude::*,
     storage::{StorageAddress, StorageArray, StorageBool, StorageMap, StorageU256, StorageU64},
 };
@@ -128,8 +126,8 @@ impl DarkpoolContract {
 
     /// Initializes the Darkpool
     #[allow(clippy::too_many_arguments)]
-    pub fn initialize<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn initialize(
+        &mut self,
         core_wallet_ops_address: Address,
         core_settlement_address: Address,
         verifier_core_address: Address,
@@ -143,39 +141,39 @@ impl DarkpoolContract {
         protocol_external_fee_collection_address: Address,
     ) -> Result<(), Vec<u8>> {
         // Initialize the Merkle tree
-        delegate_call_helper::<initMerkleCall>(storage, merkle_address, ())?;
+        delegate_call_helper::<initMerkleCall>(self, merkle_address, ())?;
 
         // Initialize the transfer executor
         delegate_call_helper::<initTransferExecutorCall>(
-            storage,
+            self,
             transfer_executor_address,
             (permit2_address,),
         )?;
 
         // Set the stored addresses
-        DarkpoolContract::_transfer_ownership(storage, msg::sender());
-        DarkpoolContract::set_core_wallet_ops_address(storage, core_wallet_ops_address)?;
-        DarkpoolContract::set_core_settlement_address(storage, core_settlement_address)?;
-        DarkpoolContract::set_verifier_core_address(storage, verifier_core_address)?;
-        DarkpoolContract::set_verifier_settlement_address(storage, verifier_settlement_address)?;
-        DarkpoolContract::set_vkeys_address(storage, vkeys_address)?;
-        DarkpoolContract::set_merkle_address(storage, merkle_address)?;
-        DarkpoolContract::set_transfer_executor_address(storage, transfer_executor_address)?;
+        let sender = self.vm().msg_sender();
+        self._transfer_ownership(sender);
+        self.set_core_wallet_ops_address(core_wallet_ops_address)?;
+        self.set_core_settlement_address(core_settlement_address)?;
+        self.set_verifier_core_address(verifier_core_address)?;
+        self.set_verifier_settlement_address(verifier_settlement_address)?;
+        self.set_vkeys_address(vkeys_address)?;
+        self.set_merkle_address(merkle_address)?;
+        self.set_transfer_executor_address(transfer_executor_address)?;
 
         // Set the protocol fee
-        DarkpoolContract::set_fee(storage, protocol_fee)?;
+        self.set_fee(protocol_fee)?;
 
         // Set the protocol public encryption key
-        DarkpoolContract::set_public_encryption_key(storage, protocol_public_encryption_key)?;
+        self.set_public_encryption_key(protocol_public_encryption_key)?;
 
         // Set the protocol external fee collection address
-        DarkpoolContract::set_protocol_external_fee_collection_address(
-            storage,
+        self.set_protocol_external_fee_collection_address(
             protocol_external_fee_collection_address,
         )?;
 
         // Mark the darkpool as initialized
-        DarkpoolContract::_initialize(storage, 1)?;
+        self._initialize(1)?;
 
         Ok(())
     }
@@ -185,19 +183,15 @@ impl DarkpoolContract {
     // -----------
 
     /// Returns the current owner of the darkpool
-    pub fn owner<S: TopLevelStorage + Borrow<Self>>(storage: &S) -> Result<Address, Vec<u8>> {
-        Ok(storage.borrow().owner.get())
+    pub fn owner(&self) -> Result<Address, Vec<u8>> {
+        Ok(self.owner.get())
     }
 
     /// Transfers ownership of the darkpool to the provided address
-    pub fn transfer_ownership<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        new_owner: Address,
-    ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-
+    pub fn transfer_ownership(&mut self, new_owner: Address) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
         check_address_not_zero(new_owner)?;
-        DarkpoolContract::_transfer_ownership(storage, new_owner);
+        self._transfer_ownership(new_owner);
 
         Ok(())
     }
@@ -207,25 +201,27 @@ impl DarkpoolContract {
     // ------------
 
     /// Returns whether or not the darkpool is paused
-    pub fn paused<S: TopLevelStorage + Borrow<Self>>(storage: &S) -> Result<bool, Vec<u8>> {
-        Ok(storage.borrow().paused.get())
+    pub fn paused(&self) -> Result<bool, Vec<u8>> {
+        Ok(self.paused.get())
     }
 
     /// Pauses the darkpool
-    pub fn pause<S: TopLevelStorage + BorrowMut<Self>>(storage: &mut S) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        DarkpoolContract::_check_not_paused(storage)?;
-        storage.borrow_mut().paused.set(true);
-        evm::log(Paused {});
+    pub fn pause(&mut self) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
+        self._check_not_paused()?;
+        self.paused.set(true);
+
+        log(self.vm(), Paused {});
         Ok(())
     }
 
     /// Unpauses the darkpool
-    pub fn unpause<S: TopLevelStorage + BorrowMut<Self>>(storage: &mut S) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        DarkpoolContract::_check_paused(storage)?;
-        storage.borrow_mut().paused.set(false);
-        evm::log(Unpaused {});
+    pub fn unpause(&mut self) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
+        self._check_paused()?;
+        self.paused.set(false);
+
+        log(self.vm(), Unpaused {});
         Ok(())
     }
 
@@ -234,40 +230,27 @@ impl DarkpoolContract {
     // -----------
 
     /// Checks whether the given nullifier is spent
-    pub fn is_nullifier_spent<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-        nullifier: U256,
-    ) -> Result<bool, Vec<u8>> {
-        let this = storage.borrow();
-        Ok(this.nullifier_set.get(nullifier))
+    pub fn is_nullifier_spent(&self, nullifier: U256) -> Result<bool, Vec<u8>> {
+        Ok(self.nullifier_set.get(nullifier))
     }
 
     /// Checks whether the given public blinder share has been used
-    pub fn is_public_blinder_used<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-        blinder: U256,
-    ) -> Result<bool, Vec<u8>> {
-        let this = storage.borrow();
-        Ok(this.public_blinder_set.get(blinder))
+    pub fn is_public_blinder_used(&self, blinder: U256) -> Result<bool, Vec<u8>> {
+        Ok(self.public_blinder_set.get(blinder))
     }
 
     /// Returns the current root of the Merkle tree
-    pub fn get_root<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-    ) -> Result<U256, Vec<u8>> {
-        let merkle_address = storage.borrow_mut().merkle_address.get();
-        let (res,) = delegate_call_helper::<rootCall>(storage, merkle_address, ())?.into();
+    pub fn get_root(&mut self) -> Result<U256, Vec<u8>> {
+        let merkle_address = self.merkle_address.get();
+        let (res,) = delegate_call_helper::<rootCall>(self, merkle_address, ())?.into();
         Ok(res)
     }
 
     /// Returns whether or not the given root is a valid historical Merkle root
-    pub fn root_in_history<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        root: U256,
-    ) -> Result<bool, Vec<u8>> {
-        let merkle_address = storage.borrow_mut().merkle_address.get();
+    pub fn root_in_history(&mut self, root: U256) -> Result<bool, Vec<u8>> {
+        let merkle_address = self.merkle_address.get();
         let (res,) =
-            delegate_call_helper::<rootInHistoryCall>(storage, merkle_address, (root,))?.into();
+            delegate_call_helper::<rootInHistoryCall>(self, merkle_address, (root,))?.into();
 
         Ok(res)
     }
@@ -275,35 +258,28 @@ impl DarkpoolContract {
     // --- Fees --- //
 
     /// Returns the protocol fee
-    pub fn get_fee<S: TopLevelStorage + Borrow<Self>>(storage: &S) -> Result<U256, Vec<u8>> {
-        Ok(storage.borrow().protocol_fee.get())
+    pub fn get_fee(&self) -> Result<U256, Vec<u8>> {
+        Ok(self.protocol_fee.get())
     }
 
     /// Returns the asset-specific protocol fee for an external match
-    pub fn get_external_match_fee_for_asset<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-        asset: Address,
-    ) -> Result<U256, Vec<u8>> {
-        let fee_override = storage.borrow().external_match_fee_overrides.get(asset);
+    pub fn get_external_match_fee_for_asset(&self, asset: Address) -> Result<U256, Vec<u8>> {
+        let fee_override = self.external_match_fee_overrides.get(asset);
         if fee_override > U256::ZERO {
             return Ok(fee_override);
         }
 
-        Ok(storage.borrow().protocol_fee.get())
+        Ok(self.protocol_fee.get())
     }
 
     /// Returns the protocol public encryption key
-    pub fn get_pubkey<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-    ) -> Result<[U256; 2], Vec<u8>> {
-        Ok(DarkpoolContract::_get_protocol_pubkey_coords(storage))
+    pub fn get_pubkey(&self) -> Result<[U256; 2], Vec<u8>> {
+        Ok(self._get_protocol_pubkey_coords())
     }
 
     /// Returns the protocol external fee collection address
-    pub fn get_protocol_external_fee_collection_address<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-    ) -> Result<Address, Vec<u8>> {
-        Ok(storage.borrow().protocol_external_fee_collection_address.get())
+    pub fn get_protocol_external_fee_collection_address(&self) -> Result<Address, Vec<u8>> {
+        Ok(self.protocol_external_fee_collection_address.get())
     }
 
     // -----------
@@ -313,170 +289,182 @@ impl DarkpoolContract {
     // --- Fees --- //
 
     /// Set the protocol fee
-    pub fn set_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        new_fee: U256,
-    ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+    pub fn set_fee(&mut self, new_fee: U256) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
         assert_result!(new_fee != U256::ZERO, ZERO_FEE_ERROR_MESSAGE)?;
-        storage.borrow_mut().protocol_fee.set(new_fee);
-        evm::log(FeeChanged { new_fee });
+        self.protocol_fee.set(new_fee);
+
+        log(self.vm(), FeeChanged { new_fee });
         Ok(())
     }
 
     /// Set the fee override for an asset
-    pub fn set_external_match_fee_override<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_external_match_fee_override(
+        &mut self,
         asset: Address,
         new_fee: U256,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         assert_result!(new_fee != U256::ZERO, ZERO_FEE_ERROR_MESSAGE)?;
-        let mut fee_override = storage.borrow_mut().external_match_fee_overrides.setter(asset);
+        let mut fee_override = self.external_match_fee_overrides.setter(asset);
         fee_override.set(new_fee);
-        evm::log(ExternalMatchFeeChanged { asset, new_fee });
+
+        log(self.vm(), ExternalMatchFeeChanged { asset, new_fee });
         Ok(())
     }
 
     /// Remove the fee override for an asset
-    pub fn remove_external_match_fee_override<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        asset: Address,
-    ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        storage.borrow_mut().external_match_fee_overrides.delete(asset);
-        let default_fee = storage.borrow_mut().protocol_fee.get();
-        evm::log(ExternalMatchFeeChanged { asset, new_fee: default_fee });
+    pub fn remove_external_match_fee_override(&mut self, asset: Address) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
+        self.external_match_fee_overrides.delete(asset);
+        let default_fee = self.protocol_fee.get();
+
+        log(self.vm(), ExternalMatchFeeChanged { asset, new_fee: default_fee });
         Ok(())
     }
 
     /// Set the protocol public encryption key
-    pub fn set_public_encryption_key<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_public_encryption_key(
+        &mut self,
         new_public_encryption_key: [U256; 2],
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        let mut pubkey_x = storage.borrow_mut().protocol_public_encryption_key.setter(0).unwrap();
+        self._check_owner()?;
+        let mut pubkey_x = self.protocol_public_encryption_key.setter(0).unwrap();
         pubkey_x.set(new_public_encryption_key[0]);
 
-        let mut pubkey_y = storage.borrow_mut().protocol_public_encryption_key.setter(1).unwrap();
+        let mut pubkey_y = self.protocol_public_encryption_key.setter(1).unwrap();
         pubkey_y.set(new_public_encryption_key[1]);
 
-        evm::log(PubkeyRotated {
+        let key_rotated_log = PubkeyRotated {
             new_pubkey_x: new_public_encryption_key[0],
             new_pubkey_y: new_public_encryption_key[1],
-        });
+        };
+        log(self.vm(), key_rotated_log);
 
         Ok(())
     }
 
     /// Sets the protocol external fee collection address
-    pub fn set_protocol_external_fee_collection_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_protocol_external_fee_collection_address(
+        &mut self,
         new_protocol_external_fee_collection_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         check_address_not_zero(new_protocol_external_fee_collection_address)?;
-        storage
-            .borrow_mut()
-            .protocol_external_fee_collection_address
+        self.protocol_external_fee_collection_address
             .set(new_protocol_external_fee_collection_address);
 
-        evm::log(ExternalFeeCollectionAddressChanged {
+        let fee_changed_log = ExternalFeeCollectionAddressChanged {
             new_address: new_protocol_external_fee_collection_address,
-        });
+        };
+        log(self.vm(), fee_changed_log);
+
         Ok(())
     }
 
     // --- Implementation Addresses --- //
 
     /// Sets the darkpool core address
-    pub fn set_core_wallet_ops_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_core_wallet_ops_address(
+        &mut self,
         core_wallet_ops_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         check_address_not_zero(core_wallet_ops_address)?;
-        storage.borrow_mut().core_wallet_ops_address.set(core_wallet_ops_address);
+        self.core_wallet_ops_address.set(core_wallet_ops_address);
 
-        evm::log(CoreWalletOpsAddressChanged { new_address: core_wallet_ops_address });
+        let core_wallet_ops_changed_log =
+            CoreWalletOpsAddressChanged { new_address: core_wallet_ops_address };
+        log(self.vm(), core_wallet_ops_changed_log);
 
         Ok(())
     }
 
     /// Sets the core settlement address
-    pub fn set_core_settlement_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_core_settlement_address(
+        &mut self,
         core_settlement_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         check_address_not_zero(core_settlement_address)?;
-        storage.borrow_mut().core_settlement_address.set(core_settlement_address);
+        self.core_settlement_address.set(core_settlement_address);
 
-        evm::log(CoreSettlementAddressChanged { new_address: core_settlement_address });
+        let core_settlement_changed_log =
+            CoreSettlementAddressChanged { new_address: core_settlement_address };
+        log(self.vm(), core_settlement_changed_log);
+
         Ok(())
     }
 
     /// Sets the verifier address
-    pub fn set_verifier_core_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_verifier_core_address(
+        &mut self,
         verifier_core_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         check_address_not_zero(verifier_core_address)?;
-        storage.borrow_mut().verifier_core_address.set(verifier_core_address);
-        evm::log(VerifierCoreAddressChanged { new_address: verifier_core_address });
+        self.verifier_core_address.set(verifier_core_address);
+
+        let verifier_core_changed_log =
+            VerifierCoreAddressChanged { new_address: verifier_core_address };
+        log(self.vm(), verifier_core_changed_log);
+
         Ok(())
     }
 
     /// Sets the verifier settlement address
-    pub fn set_verifier_settlement_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_verifier_settlement_address(
+        &mut self,
         verifier_settlement_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         check_address_not_zero(verifier_settlement_address)?;
-        storage.borrow_mut().verifier_settlement_address.set(verifier_settlement_address);
+        self.verifier_settlement_address.set(verifier_settlement_address);
 
-        evm::log(VerifierSettlementAddressChanged { new_address: verifier_settlement_address });
+        let verifier_settlement_changed_log =
+            VerifierSettlementAddressChanged { new_address: verifier_settlement_address };
+        log(self.vm(), verifier_settlement_changed_log);
+
         Ok(())
     }
 
     /// Sets the vkeys address
-    pub fn set_vkeys_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        vkeys_address: Address,
-    ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+    pub fn set_vkeys_address(&mut self, vkeys_address: Address) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
         check_address_not_zero(vkeys_address)?;
-        storage.borrow_mut().vkeys_address.set(vkeys_address);
-        evm::log(VkeysAddressChanged { new_address: vkeys_address });
+        self.vkeys_address.set(vkeys_address);
+
+        let vkeys_address_changed_log = VkeysAddressChanged { new_address: vkeys_address };
+        log(self.vm(), vkeys_address_changed_log);
+
         Ok(())
     }
 
     /// Sets the Merkle address
-    pub fn set_merkle_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        merkle_address: Address,
-    ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+    pub fn set_merkle_address(&mut self, merkle_address: Address) -> Result<(), Vec<u8>> {
+        self._check_owner()?;
         check_address_not_zero(merkle_address)?;
-        storage.borrow_mut().merkle_address.set(merkle_address);
-        evm::log(MerkleAddressChanged { new_address: merkle_address });
+        self.merkle_address.set(merkle_address);
+
+        let merkle_address_changed_log = MerkleAddressChanged { new_address: merkle_address };
+        log(self.vm(), merkle_address_changed_log);
+
         Ok(())
     }
 
     /// Sets the transfer executor address
-    pub fn set_transfer_executor_address<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn set_transfer_executor_address(
+        &mut self,
         transfer_executor_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
+        self._check_owner()?;
         check_address_not_zero(transfer_executor_address)?;
+        self.transfer_executor_address.set(transfer_executor_address);
 
-        storage.borrow_mut().transfer_executor_address.set(transfer_executor_address);
+        let transfer_executor_address_changed_log =
+            TransferExecutorAddressChanged { new_address: transfer_executor_address };
+        log(self.vm(), transfer_executor_address_changed_log);
 
-        evm::log(TransferExecutorAddressChanged { new_address: transfer_executor_address });
         Ok(())
     }
 
@@ -485,16 +473,16 @@ impl DarkpoolContract {
     // ----------------
 
     /// Adds a new wallet to the commitment tree
-    pub fn new_wallet<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn new_wallet(
+        &mut self,
         proof: Bytes,
         valid_wallet_create_statement_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let core_wallet_ops_address = self.get_core_wallet_ops_address();
         delegate_call_helper::<newWalletCall>(
-            storage,
+            self,
             core_wallet_ops_address,
             (proof.to_vec().into(), valid_wallet_create_statement_bytes.to_vec().into()),
         )
@@ -502,18 +490,18 @@ impl DarkpoolContract {
     }
 
     /// Update a wallet in the commitment tree
-    pub fn update_wallet<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn update_wallet(
+        &mut self,
         proof: Bytes,
         valid_wallet_update_statement_bytes: Bytes,
         wallet_commitment_signature: Bytes,
         transfer_aux_data_bytes: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let core_wallet_ops_address = self.get_core_wallet_ops_address();
         delegate_call_helper::<updateWalletCall>(
-            storage,
+            self,
             core_wallet_ops_address,
             (
                 proof.to_vec().into(),
@@ -532,19 +520,19 @@ impl DarkpoolContract {
     /// [`contracts_common::types::MatchProofs`] struct, and the
     /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::MatchLinkingProofs`] struct
-    pub fn process_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn process_match_settle(
+        &mut self,
         party_0_match_payload: Bytes,
         party_1_match_payload: Bytes,
         valid_match_settle_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let core_settlement_address = self.get_core_settlement_address();
         delegate_call_helper::<processMatchSettleCall>(
-            storage,
+            self,
             core_settlement_address,
             (
                 party_0_match_payload.to_vec().into(),
@@ -573,19 +561,19 @@ impl DarkpoolContract {
     /// as payable to allow for the darkpool to delegate call them. This can be
     /// seen in the merkle and transfer executor contracts.
     #[payable]
-    pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn process_atomic_match_settle(
+        &mut self,
         internal_party_match_payload: Bytes,
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let receiver = msg::sender();
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let receiver = self.vm().msg_sender();
+        let core_settlement_address = self.get_core_settlement_address();
         delegate_call_helper::<processAtomicMatchSettleCall>(
-            storage,
+            self,
             core_settlement_address,
             (
                 receiver,
@@ -600,19 +588,19 @@ impl DarkpoolContract {
 
     /// Process an atomic match settle statement with a receiver specified
     #[payable]
-    pub fn process_atomic_match_settle_with_receiver<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn process_atomic_match_settle_with_receiver(
+        &mut self,
         receiver: Address,
         internal_party_match_payload: Bytes,
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let core_settlement_address = self.get_core_settlement_address();
         delegate_call_helper::<processAtomicMatchSettleCall>(
-            storage,
+            self,
             core_settlement_address,
             (
                 receiver,
@@ -627,17 +615,17 @@ impl DarkpoolContract {
 
     /// Settles the fee accumulated by a relayer for a given balance in a
     /// managed wallet into the relayer's wallet
-    pub fn settle_online_relayer_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn settle_online_relayer_fee(
+        &mut self,
         proof: Bytes,
         valid_relayer_fee_settlement_statement: Bytes,
         relayer_wallet_commitment_signature: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let core_wallet_ops_address = self.get_core_wallet_ops_address();
         delegate_call_helper::<settleOnlineRelayerFeeCall>(
-            storage,
+            self,
             core_wallet_ops_address,
             (
                 proof.to_vec().into(),
@@ -650,16 +638,16 @@ impl DarkpoolContract {
 
     /// Settles the fee accumulated either by a relayer or the protocol
     /// into an encrypted note which is committed to the Merkle tree
-    pub fn settle_offline_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn settle_offline_fee(
+        &mut self,
         proof: Bytes,
         valid_offline_fee_settlement_statement: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let core_wallet_ops_address = self.get_core_wallet_ops_address();
         delegate_call_helper::<settleOfflineFeeCall>(
-            storage,
+            self,
             core_wallet_ops_address,
             (proof.to_vec().into(), valid_offline_fee_settlement_statement.to_vec().into()),
         )
@@ -667,17 +655,17 @@ impl DarkpoolContract {
     }
 
     /// Redeems a fee note into the recipient's wallet, nullifying the note
-    pub fn redeem_fee<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn redeem_fee(
+        &mut self,
         proof: Bytes,
         valid_fee_redemption_statement: Bytes,
         recipient_wallet_commitment_signature: Bytes,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_not_paused(storage)?;
+        self._check_not_paused()?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let core_wallet_ops_address = self.get_core_wallet_ops_address();
         delegate_call_helper::<redeemFeeCall>(
-            storage,
+            self,
             core_wallet_ops_address,
             (
                 proof.to_vec().into(),
@@ -696,14 +684,10 @@ impl DarkpoolContract {
     // -----------------
 
     /// Initializes this contract with the given version.
-    pub fn _initialize<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        version: u64,
-    ) -> Result<(), Vec<u8>> {
+    pub fn _initialize(&mut self, version: u64) -> Result<(), Vec<u8>> {
         let version_uint64 = U64::from_limbs([version]);
-        let this = storage.borrow_mut();
-        assert_result!(this.initialized.get() < version_uint64, INVALID_VERSION_ERROR_MESSAGE)?;
-        this.initialized.set(version_uint64);
+        assert_result!(self.initialized.get() < version_uint64, INVALID_VERSION_ERROR_MESSAGE)?;
+        self.initialized.set(version_uint64);
         Ok(())
     }
 
@@ -712,17 +696,15 @@ impl DarkpoolContract {
     // -----------
 
     /// Updates the stored owner address to `new_owner`
-    pub fn _transfer_ownership<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        new_owner: Address,
-    ) {
-        storage.borrow_mut().owner.set(new_owner);
-        evm::log(OwnershipTransferred { new_owner })
+    pub fn _transfer_ownership(&mut self, new_owner: Address) {
+        self.owner.set(new_owner);
+        log(self.vm(), OwnershipTransferred { new_owner });
     }
 
     /// Checks that the sender is the owner
-    pub fn _check_owner<S: TopLevelStorage + Borrow<Self>>(storage: &S) -> Result<(), Vec<u8>> {
-        assert_result!(storage.borrow().owner.get() == msg::sender(), NOT_OWNER_ERROR_MESSAGE)
+    pub fn _check_owner(&self) -> Result<(), Vec<u8>> {
+        let sender = self.vm().msg_sender();
+        assert_result!(self.owner.get() == sender, NOT_OWNER_ERROR_MESSAGE)
     }
 
     // ------------
@@ -730,15 +712,13 @@ impl DarkpoolContract {
     // ------------
 
     /// Checks that the darkpool is paused
-    pub fn _check_paused<S: TopLevelStorage + Borrow<Self>>(storage: &S) -> Result<(), Vec<u8>> {
-        assert_result!(storage.borrow().paused.get(), PAUSED_ERROR_MESSAGE)
+    pub fn _check_paused(&self) -> Result<(), Vec<u8>> {
+        assert_result!(self.paused.get(), PAUSED_ERROR_MESSAGE)
     }
 
     /// Checks that the darkpool is not paused
-    pub fn _check_not_paused<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-    ) -> Result<(), Vec<u8>> {
-        assert_result!(!storage.borrow().paused.get(), UNPAUSED_ERROR_MESSAGE)
+    pub fn _check_not_paused(&self) -> Result<(), Vec<u8>> {
+        assert_result!(!self.paused.get(), UNPAUSED_ERROR_MESSAGE)
     }
 
     // ----------------
@@ -757,12 +737,9 @@ impl DarkpoolContract {
 
     /// Gets the affine coordinates of the protocol public encryption key
     /// as U256s
-    pub fn _get_protocol_pubkey_coords<S: TopLevelStorage + Borrow<Self>>(
-        storage: &S,
-    ) -> [U256; 2] {
-        let protocol_pubkey_x = storage.borrow().protocol_public_encryption_key.get(0).unwrap();
-
-        let protocol_pubkey_y = storage.borrow().protocol_public_encryption_key.get(1).unwrap();
+    pub fn _get_protocol_pubkey_coords(&self) -> [U256; 2] {
+        let protocol_pubkey_x = self.protocol_public_encryption_key.get(0).unwrap();
+        let protocol_pubkey_y = self.protocol_public_encryption_key.get(1).unwrap();
 
         [protocol_pubkey_x, protocol_pubkey_y]
     }

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -6,15 +6,13 @@ use contracts_common::{
     types::ValidMatchSettleAtomicStatement,
 };
 use contracts_core::crypto::ecdsa::ecdsa_verify;
+#[allow(deprecated)]
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{hex, Address, U256, U64},
-    block,
-    call::{call, Call},
-    console, contract, evm, msg,
-    prelude::*,
+    call::Call as CallWithValue,
+    prelude::{calls::context::Call, *},
     storage::{StorageAddress, StorageBool, StorageMap, StorageU64},
-    tx,
 };
 
 use crate::{
@@ -112,8 +110,7 @@ impl GasSponsorContract {
         self.darkpool_address.set(darkpool_address);
         self.auth_address.set(auth_address);
 
-        self._transfer_ownership(msg::sender());
-
+        self._transfer_ownership(self.vm().msg_sender());
         self._initialize(1)?;
         Ok(())
     }
@@ -137,7 +134,7 @@ impl GasSponsorContract {
     pub fn pause(&mut self) -> Result<(), Vec<u8>> {
         self._check_owner()?;
         self.paused.set(true);
-        evm::log(Paused {});
+        log(self.vm(), Paused {});
         Ok(())
     }
 
@@ -145,7 +142,7 @@ impl GasSponsorContract {
     pub fn unpause(&mut self) -> Result<(), Vec<u8>> {
         self._check_owner()?;
         self.paused.set(false);
-        evm::log(Unpaused {});
+        log(self.vm(), Unpaused {});
         Ok(())
     }
 
@@ -176,9 +173,12 @@ impl GasSponsorContract {
     /// Withdraws ETH from the gas sponsor contract to the given receiver
     pub fn withdraw_eth(&mut self, receiver: Address, amount: U256) -> Result<(), Vec<u8>> {
         self._check_owner()?;
-        let balance = contract::balance();
+        let this_addr = self.vm().contract_address();
+        let balance = self.vm().balance(this_addr);
         assert_result!(balance >= amount, ERR_INSUFFICIENT_BALANCE)?;
-        call(Call::new().value(amount), receiver, &[])?;
+
+        let ctx = Call::new().value(amount);
+        self.vm().call(&ctx, receiver, &[])?;
         Ok(())
     }
 
@@ -200,7 +200,7 @@ impl GasSponsorContract {
         nonce: U256,
         signature: Bytes,
     ) -> Result<(), Vec<u8>> {
-        let receiver = msg::sender();
+        let receiver = self.vm().msg_sender();
         self.sponsor_atomic_match_settle_with_receiver(
             receiver,
             internal_party_match_payload,
@@ -229,11 +229,11 @@ impl GasSponsorContract {
         signature: Bytes,
     ) -> Result<(), Vec<u8>> {
         // Take note of the initial tx gas budget
-        let initial_gas = evm::gas_left();
+        let initial_gas = self.vm().evm_gas_left();
 
         // If gas sponsorship is paused, follow through with naive settlement
         if self.is_paused()? {
-            evm::log(GasSponsorPausedFallback { nonce });
+            log(self.vm(), GasSponsorPausedFallback { nonce });
             return self.process_atomic_match_settle_with_receiver(
                 receiver,
                 internal_party_match_payload,
@@ -277,25 +277,25 @@ impl GasSponsorContract {
         // We frontload as many operations as possible so the final evm::gas_left()
         // call is as accurate as possible.
 
-        let refund_address =
-            if refund_address == Address::ZERO { tx::origin() } else { refund_address };
+        let origin = self.vm().tx_origin();
+        let refund_address = if refund_address == Address::ZERO { origin } else { refund_address };
 
         let transfer_config = Call::new().gas(REFUND_OPS_GAS_COST);
 
         // Check if this is a native ETH sell, for which it is sufficient to check that
         // the message value is non-zero. If this is not a native ETH sell and the value
         // is non-zero, there will be a revert in the darkpool.
-        let is_native_eth_sell = msg::value() > U256::ZERO;
+        let is_native_eth_sell = self.vm().msg_value() > U256::ZERO;
 
         // Get the L2 gas price. On Arbitrum, this is always the basefee:
         // https://docs.arbitrum.io/how-arbitrum-works/gas-fees#l2-tips
-        let gas_price = block::basefee();
+        let gas_price = self.vm().block_basefee();
 
         // Get the L1 gas cost - this is the cost in wei
         let l1_gas_cost =
-            IArbGasInfo::new(ARB_GAS_INFO_ADDRESS).get_current_tx_l_1_gas_fees(Call::new())?;
+            IArbGasInfo::new(ARB_GAS_INFO_ADDRESS).get_current_tx_l_1_gas_fees(&*self)?;
 
-        let final_gas = evm::gas_left();
+        let final_gas = self.vm().evm_gas_left();
 
         let gas_spent = U256::from(
             INVOCATION_BASE_GAS_COST
@@ -309,20 +309,20 @@ impl GasSponsorContract {
 
         // If the gas sponsor doesn't have enough Ether to refund the user,
         // emit an event but don't revert.
-        if contract::balance() < gas_cost {
-            evm::log(InsufficientSponsorBalance { nonce });
+        let this_addr = self.vm().contract_address();
+        if self.vm().balance(this_addr) < gas_cost {
+            log(self.vm(), InsufficientSponsorBalance { nonce });
             return Ok(());
         }
 
         // Refund the user's gas costs
-        call(
-            transfer_config.value(gas_cost),
+        self.vm().call(
+            &transfer_config.value(gas_cost),
             refund_address,
             &[], // calldata
         )?;
 
-        evm::log(SponsoredExternalMatch { amount: gas_cost, nonce });
-
+        log(self.vm(), SponsoredExternalMatch { amount: gas_cost, nonce });
         Ok(())
     }
 
@@ -339,7 +339,7 @@ impl GasSponsorContract {
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        let receiver = msg::sender();
+        let receiver = self.vm().msg_sender();
         self.process_atomic_match_settle_with_receiver(
             receiver,
             internal_party_match_payload,
@@ -361,8 +361,8 @@ impl GasSponsorContract {
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        let sender = msg::sender();
-        let sponsor = contract::address();
+        let sender = self.vm().msg_sender();
+        let sponsor = self.vm().contract_address();
         let darkpool_address = self.darkpool_address.get();
 
         // Transfer the input tokens from the caller to the gas sponsor
@@ -375,16 +375,18 @@ impl GasSponsorContract {
         // Only execute an ERC20 transfer if the input token is not the native asset
         if !is_native_eth_address(send_mint) {
             let send_token = IErc20::new(send_mint);
-            send_token.approve(Call::new(), darkpool_address, send_amount)?;
-            send_token.transfer_from(Call::new(), sender, sponsor, send_amount)?;
+            send_token.approve(&mut *self, darkpool_address, send_amount)?;
+            send_token.transfer_from(&mut *self, sender, sponsor, send_amount)?;
         }
 
         // Call the darkpool contract's `process_atomic_match_settle_with_receiver`
         // method. We pass along the message value in case the input token is
         // the native asset
         let darkpool = IDarkpool::new(darkpool_address);
+        #[allow(deprecated)]
+        let ctx = CallWithValue::new().value(self.vm().msg_value());
         darkpool.process_atomic_match_settle_with_receiver(
-            Call::new().value(msg::value()),
+            ctx,
             receiver,
             internal_party_match_payload.0.into(),
             valid_match_settle_atomic_statement.0.into(),
@@ -411,13 +413,14 @@ impl GasSponsorContract {
 
     /// Checks that the sender is the owner
     pub fn _check_owner(&self) -> Result<(), Vec<u8>> {
-        assert_result!(self.owner.get() == msg::sender(), NOT_OWNER_ERROR_MESSAGE)
+        let sender = self.vm().msg_sender();
+        assert_result!(self.owner.get() == sender, NOT_OWNER_ERROR_MESSAGE)
     }
 
     /// Updates the stored owner address to `new_owner`
     pub fn _transfer_ownership(&mut self, new_owner: Address) {
         self.owner.set(new_owner);
-        evm::log(OwnershipTransferred { new_owner })
+        log(self.vm(), OwnershipTransferred { new_owner })
     }
 
     /// Asserts the validity of the given signature using the auth address
@@ -439,7 +442,7 @@ impl GasSponsorContract {
     fn mark_nonce_used(&mut self, nonce: U256) -> Result<(), Vec<u8>> {
         assert_result!(!self.used_nonces.get(nonce), ERR_NONCE_ALREADY_USED)?;
         self.used_nonces.insert(nonce, true);
-        evm::log(NonceUsed { nonce });
+        log(self.vm(), NonceUsed { nonce });
 
         Ok(())
     }

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -20,7 +20,6 @@ use contracts_core::crypto::poseidon::compute_poseidon_hash;
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{U128, U256},
-    evm,
     prelude::*,
     storage::{StorageBool, StorageMap, StorageU128, StorageU256},
 };
@@ -204,7 +203,9 @@ where
         subtree_filled: bool,
     ) -> Result<(), Vec<u8>> {
         self.insert_recursive(value, height, insert_index, subtree_filled)?;
-        evm::log(MerkleInsertion { index: insert_index, value: scalar_to_u256(value) });
+
+        let insert_log = MerkleInsertion { index: insert_index, value: scalar_to_u256(value) };
+        log(self.vm(), insert_log);
 
         Ok(())
     }
@@ -267,11 +268,12 @@ where
         // Emit the sibling coordinates and value
         let sibling_idx = if is_left { insert_index + 1 } else { insert_index - 1 };
 
-        evm::log(MerkleOpeningNode {
+        let sibling_log = MerkleOpeningNode {
             height,
             index: sibling_idx,
             new_value: scalar_to_u256(current_sibling_value),
-        });
+        };
+        log(self.vm(), sibling_log);
 
         Ok(())
     }

--- a/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_erc20.rs
@@ -11,7 +11,6 @@ use alloc::string::String;
 use stylus_sdk::{
     alloy_primitives::{Address, Uint, U256},
     alloy_sol_types::sol,
-    evm, msg,
     prelude::*,
 };
 
@@ -71,7 +70,7 @@ impl Erc20 {
         let mut to_balance = self.balances.setter(to);
         let new_to_balance = to_balance.get() + value;
         to_balance.set(new_to_balance);
-        evm::log(Transfer { from, to, value });
+        log(self.vm(), Transfer { from, to, value });
         Ok(())
     }
 }
@@ -112,7 +111,7 @@ impl Erc20 {
         let new_balance = balance.get() + value;
         balance.set(new_balance);
         self.total_supply.set(self.total_supply.get() + value);
-        evm::log(Transfer { from: Address::ZERO, to: address, value });
+        log(self.vm(), Transfer { from: Address::ZERO, to: address, value });
     }
 
     pub fn burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
@@ -127,7 +126,7 @@ impl Erc20 {
         }
         balance.set(old_balance - value);
         self.total_supply.set(self.total_supply.get() - value);
-        evm::log(Transfer { from: address, to: Address::ZERO, value });
+        log(self.vm(), Transfer { from: address, to: Address::ZERO, value });
         Ok(())
     }
 
@@ -136,12 +135,12 @@ impl Erc20 {
     }
 
     pub fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Erc20Error> {
-        self.transfer_impl(msg::sender(), to, value)?;
+        self.transfer_impl(self.vm().msg_sender(), to, value)?;
         Ok(true)
     }
 
     pub fn approve(&mut self, spender: Address, value: U256) -> Result<bool, Erc20Error> {
-        self.allowances.setter(msg::sender()).insert(spender, value);
+        self.allowances.setter(self.vm().msg_sender()).insert(spender, value);
         Ok(true)
     }
 
@@ -152,14 +151,15 @@ impl Erc20 {
         value: U256,
     ) -> Result<bool, Erc20Error> {
         // Update allowance if not self-transfer
-        if from != msg::sender() {
+        let sender = self.vm().msg_sender();
+        if from != sender {
             let mut sender_allowances = self.allowances.setter(from);
-            let mut allowance = sender_allowances.setter(msg::sender());
+            let mut allowance = sender_allowances.setter(sender);
             let old_allowance = allowance.get();
             if old_allowance < value {
                 return Err(Erc20Error::InsufficientAllowance(InsufficientAllowance {
                     owner: from,
-                    spender: msg::sender(),
+                    spender: self.vm().msg_sender(),
                     have: old_allowance,
                     want: value,
                 }));

--- a/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
@@ -10,9 +10,7 @@ use alloc::vec::Vec;
 use alloy_sol_types::sol;
 use stylus_sdk::{
     alloy_primitives::{Address, U256},
-    call::transfer_eth,
-    evm, msg,
-    prelude::{entrypoint, public, sol_storage},
+    prelude::*,
 };
 
 use super::dummy_erc20::Erc20;
@@ -40,7 +38,7 @@ sol! {
 impl DummyWeth {
     /// Withdraw weth from the contract to a specified address
     fn withdraw_impl(&mut self, to: Address, amount: U256) -> Result<(), Vec<u8>> {
-        let sender = msg::sender();
+        let sender = self.vm().msg_sender();
         let mut bal = self.erc20.balances.setter(sender);
         let old_bal = bal.get();
         if old_bal < amount {
@@ -49,8 +47,8 @@ impl DummyWeth {
         bal.set(old_bal - amount);
 
         // Transfer the ETH and log the withdrawal
-        transfer_eth(to, amount)?;
-        evm::log(Withdrawal { to, value: amount });
+        self.vm().transfer_eth(to, amount)?;
+        log(self.vm(), Withdrawal { to, value: amount });
         Ok(())
     }
 }
@@ -62,20 +60,20 @@ impl DummyWeth {
     #[payable]
     pub fn deposit(&mut self) -> Result<(), Vec<u8>> {
         // Update the sender's balance
-        let sender = msg::sender();
-        let amount = msg::value();
+        let sender = self.vm().msg_sender();
+        let amount = self.vm().msg_value();
         let mut bal = self.erc20.balances.setter(sender);
         let new_bal = bal.get() + amount;
         bal.set(new_bal);
 
         // Emit a deposit event
-        evm::log(Deposit { from: sender, value: amount });
+        log(self.vm(), Deposit { from: sender, value: amount });
         Ok(())
     }
 
     /// Withdraw ETH from the contract
     pub fn withdraw(&mut self, amount: U256) -> Result<(), Vec<u8>> {
-        self.withdraw_impl(msg::sender(), amount)
+        self.withdraw_impl(self.vm().msg_sender(), amount)
     }
 
     /// Withdraw ETH from the contract to a specified address

--- a/contracts-stylus/src/contracts/test_contracts/precompile_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/precompile_test_contract.rs
@@ -7,7 +7,7 @@ use contracts_common::{
     backends::{EcRecoverBackend, G1ArithmeticBackend},
     serde_def_types::{SerdeG1Affine, SerdeG2Affine, SerdeScalarField},
 };
-use stylus_sdk::{abi::Bytes, console, prelude::*};
+use stylus_sdk::{abi::Bytes, prelude::*};
 
 use crate::utils::backends::{PrecompileEcRecoverBackend, PrecompileG1ArithmeticBackend};
 

--- a/contracts-stylus/src/contracts/transfer_executor.rs
+++ b/contracts-stylus/src/contracts/transfer_executor.rs
@@ -28,11 +28,11 @@ use contracts_common::{
     },
     types::{ExternalTransfer, PublicSigningKey, SimpleErc20Transfer, TransferAuxData},
 };
+#[allow(deprecated)]
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{Address, U256},
-    call::Call,
-    contract, evm, msg,
+    call::Call as CallWithValue,
     prelude::*,
     storage::{StorageAddress, StorageArray, StorageU256},
 };
@@ -96,7 +96,7 @@ impl TransferExecutorContract {
             )?);
 
             call_helper::<transferCall>(
-                self,
+                &mut *self,
                 mint, // address
                 (account_addr /* to */, amount),
             )?;
@@ -104,7 +104,7 @@ impl TransferExecutorContract {
             // In the case of a deposit, we make a `permitTransferFrom` call through
             // the `Permit2` contract using the calldata-serialized `PermitPayload`
 
-            let contract_address = contract::address();
+            let contract_address = self.vm().contract_address();
             let permit2_address = self.permit2_address.get();
 
             let permit = CalldataPermitWitnessTransferFrom {
@@ -128,7 +128,7 @@ impl TransferExecutorContract {
             let deposit_witness_hash = deposit_witness.eip712_hash_struct().0;
 
             call_helper::<permitWitnessTransferFromCall>(
-                self,
+                &mut *self,
                 permit2_address, // address
                 (
                     permit,
@@ -144,7 +144,9 @@ impl TransferExecutorContract {
             )?;
         };
 
-        evm::log(ExternalTransferEvent { account: account_addr, mint, is_withdrawal, amount });
+        let transfer_log =
+            ExternalTransferEvent { account: account_addr, mint, is_withdrawal, amount };
+        log(self.vm(), transfer_log);
 
         Ok(())
     }
@@ -191,7 +193,7 @@ impl TransferExecutorContract {
         }
 
         // Otherwise, deposit the ERC20
-        let contract_address = contract::address();
+        let contract_address = self.vm().contract_address();
         let res = call_helper::<transferFromCall>(
             self,
             erc20_address,
@@ -230,14 +232,15 @@ impl TransferExecutorContract {
     /// Deposit native ETH into the contract by wrapping the transaction payable
     /// amount
     fn handle_native_eth_deposit(&mut self, transfer: SimpleErc20Transfer) -> Result<(), Vec<u8>> {
-        let payable = msg::value();
+        let payable = self.vm().msg_value();
         if transfer.amount != payable {
             return Err(INVALID_TRANSACTION_PAYABLE_AMOUNT_ERROR_MESSAGE.to_vec());
         }
 
         // Wrap the native asset
         let weth_address = get_weth_address();
-        let call_ctx = Call::new_in(self).value(payable);
+        #[allow(deprecated)]
+        let call_ctx = CallWithValue::new_in(self).value(payable);
         call_helper::<depositCall>(call_ctx, weth_address, ())?;
         Ok(())
     }
@@ -249,9 +252,8 @@ impl TransferExecutorContract {
         transfer: SimpleErc20Transfer,
     ) -> Result<(), Vec<u8>> {
         let weth_address = get_weth_address();
-        let call_ctx = Call::new_in(self);
         call_helper::<withdrawToCall>(
-            call_ctx,
+            self,
             weth_address,
             (transfer.account_addr, transfer.amount),
         )?;

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -21,6 +21,10 @@ pub const ZERO_ADDRESS_ERROR_MESSAGE: &[u8] = b"zero address";
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract"))]
 pub const ZERO_FEE_ERROR_MESSAGE: &[u8] = b"zero fee";
 
+/// The revert message when the vkeys cannot be fetched
+#[cfg(feature = "darkpool-core")]
+pub const VKEYS_FETCH_ERROR_MESSAGE: &[u8] = b"vkey fetch failed";
+
 /// The revert message when verification fails
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
 pub const VERIFICATION_FAILED_ERROR_MESSAGE: &[u8] = b"verification failed";

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -15,12 +15,13 @@ use contracts_common::{
 use contracts_core::crypto::ecdsa::ecdsa_verify_with_pubkey;
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};
+#[allow(deprecated)]
 use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::{Address, U256},
-    call::{call, delegate_call, static_call, MutatingCallContext},
-    storage::TopLevelStorage,
+    call::{call, delegate_call, static_call},
 };
+use stylus_sdk::{call::MutatingCallContext, prelude::TopLevelStorage};
 
 use crate::{
     utils::{
@@ -133,6 +134,7 @@ pub fn get_public_blinder_from_shares(shares: &[ScalarField]) -> ScalarField {
 
 /// Maps an error returned from an external contract call to a `Vec<u8>`,
 /// which is the expected return type of external contract methods.
+#[allow(deprecated)]
 pub fn map_call_error(e: stylus_sdk::call::Error) -> Vec<u8> {
     match e {
         stylus_sdk::call::Error::Revert(msg) => msg,
@@ -155,6 +157,7 @@ pub fn map_calldata_ser_error<E>(_e: E) -> Vec<u8> {
     not(any(feature = "darkpool-core", feature = "darkpool-test-contract")),
     allow(dead_code)
 )]
+#[allow(deprecated)]
 pub fn static_call_helper<C: SolCall>(
     storage: &impl TopLevelStorage,
     address: Address,
@@ -172,6 +175,7 @@ pub fn static_call_helper<C: SolCall>(
     not(any(feature = "darkpool-core", feature = "darkpool", feature = "darkpool-test-contract")),
     allow(dead_code)
 )]
+#[allow(deprecated)]
 pub fn delegate_call_helper<C: SolCall>(
     storage: &mut impl TopLevelStorage,
     address: Address,
@@ -186,6 +190,7 @@ pub fn delegate_call_helper<C: SolCall>(
 /// Performs a `call` to the given address, calling the function
 /// defined as a `SolCall` with the given arguments.
 #[cfg_attr(not(feature = "transfer-executor"), allow(dead_code))]
+#[allow(deprecated)]
 pub fn call_helper<C: SolCall>(
     storage: impl MutatingCallContext,
     address: Address,
@@ -263,6 +268,7 @@ macro_rules! if_verifying {
             use contracts_common::constants::DEVNET_CHAINID;
             use $crate::{assert_result, utils::constants::VERIFICATION_DISABLED_ERROR_MESSAGE};
 
+            #[allow(deprecated)]
             assert_result!(block::chainid() == DEVNET_CHAINID, VERIFICATION_DISABLED_ERROR_MESSAGE)?;
         }
     };

--- a/contracts-utils/Cargo.toml
+++ b/contracts-utils/Cargo.toml
@@ -21,7 +21,7 @@ mpc-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", defau
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { workspace = true }
 renegade-crypto = { workspace = true }
-circuit-types = { workspace = true }
+circuit-types = { workspace = true, features = ["proof-system-types"] }
 circuit-macros = { git = "https://github.com/renegade-fi/renegade.git" }
 circuits = { workspace = true }
 constants = { workspace = true }

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -12,9 +12,10 @@ use ark_ff::One;
 use ark_std::UniformRand;
 use circuit_types::{
     elgamal::EncryptionKey,
+    fees::FeeTake,
     fixed_point::FixedPoint,
     keychain::PublicSigningKey,
-    r#match::{ExternalMatchResult, FeeTake},
+    r#match::ExternalMatchResult,
     srs::SYSTEM_SRS,
     traits::{CircuitBaseType, SingleProverCircuit},
     transfers::ExternalTransfer,


### PR DESCRIPTION
### Purpose
This PR upgrades the `stylus-sdk` version to `v0.8.3` and makes all necessary changes. These largely involve changing method signatures and receiver types on contract methods.

### Testing
- Deferred until the nitro devnode is working again