### PR TITLE
contracts-utils: conversion: Copy conversion utils from `arbitrum-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
  "either",
  "once_cell",
  "serde",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -799,37 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
-name = "arbitrum-client"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#eda09c3c565044c2f7b92ac0c85a87efe6a28b1e"
-dependencies = [
- "alloy-primitives 0.8.25",
- "alloy-sol-types 0.8.25",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "circuit-types",
- "circuits",
- "common",
- "constants",
- "ethers",
- "itertools 0.12.1",
- "lazy_static",
- "mpc-relation",
- "num-bigint",
- "num-traits",
- "postcard",
- "renegade-crypto",
- "renegade-metrics",
- "ruint",
- "serde",
- "serde_with",
- "tokio",
- "tracing",
- "util",
-]
-
-[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,7 +859,7 @@ dependencies = [
  "blake2",
  "derivative",
  "digest 0.10.7",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -1236,21 +1205,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
-name = "atomic_float"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
-
-[[package]]
 name = "auto_impl"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,12 +1335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,15 +1399,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1491,7 +1430,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
  "tinyvec",
 ]
 
@@ -1727,6 +1666,7 @@ dependencies = [
  "circuit-macros",
  "circuit-types",
  "constants",
+ "ctor",
  "futures",
  "itertools 0.10.5",
  "jf-primitives",
@@ -1800,7 +1740,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -1816,7 +1756,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -1835,7 +1775,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.8",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -1854,44 +1794,6 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#eda09c3c565044c2f7b92ac0c85a87efe6a28b1e"
-dependencies = [
- "ark-mpc",
- "async-trait",
- "base64 0.22.1",
- "bimap",
- "circuit-types",
- "circuits",
- "constants",
- "crossbeam",
- "derivative",
- "ed25519-dalek 1.0.1",
- "ethers",
- "hmac",
- "indexmap 2.8.0",
- "itertools 0.10.5",
- "k256",
- "lazy_static",
- "libp2p",
- "libp2p-identity",
- "metrics",
- "num-bigint",
- "num-traits",
- "rand 0.8.5",
- "renegade-crypto",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "signature 2.2.0",
- "tokio",
- "tracing",
- "util",
- "uuid 1.16.0",
 ]
 
 [[package]]
@@ -1972,7 +1874,6 @@ name = "contracts-core"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.7.7",
- "arbitrum-client",
  "ark-bn254",
  "ark-crypto-primitives",
  "ark-ec",
@@ -2016,7 +1917,6 @@ name = "contracts-utils"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.7.7",
- "arbitrum-client",
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -2119,12 +2019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,9 +2110,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704722d1d929489c8528bb1882805700f1ba20f54325704973e786352320b1ed"
 dependencies = [
  "blake2",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "rand_core 0.6.4",
  "serdect",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2228,19 +2132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2445,7 +2336,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2539,18 +2430,8 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature 2.2.0",
+ "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "serde",
- "signature 1.6.4",
 ]
 
 [[package]]
@@ -2560,22 +2441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
- "serde_bytes",
- "sha2 0.9.9",
- "zeroize",
+ "signature",
 ]
 
 [[package]]
@@ -2584,11 +2450,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
+ "curve25519-dalek",
+ "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -2713,10 +2579,10 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2978,7 +2844,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -3287,17 +3153,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -3374,15 +3229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,20 +3271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version 0.4.1",
- "serde",
- "spin 0.9.8",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -3923,7 +3755,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",
- "arbitrum-client",
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -4054,7 +3885,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "sha3",
  "tagged-base64",
  "typenum",
@@ -4073,7 +3904,7 @@ dependencies = [
  "digest 0.10.7",
  "rayon",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "tagged-base64",
 ]
 
@@ -4127,8 +3958,8 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
- "signature 2.2.0",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -4293,13 +4124,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
  "bs58 0.4.0",
- "ed25519-dalek 2.1.1",
+ "ed25519-dalek",
  "log",
  "multiaddr",
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -5094,7 +4925,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac",
  "password-hash",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -5269,7 +5100,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
  "serde",
 ]
 
@@ -5548,19 +5378,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -5580,16 +5397,6 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "zerocopy 0.8.24",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5614,15 +5421,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -5637,15 +5435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5782,21 +5571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "renegade-metrics"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#eda09c3c565044c2f7b92ac0c85a87efe6a28b1e"
-dependencies = [
- "atomic_float",
- "circuit-types",
- "common",
- "lazy_static",
- "metrics",
- "num-bigint",
- "tracing",
- "util",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5896,7 +5670,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted 0.7.1",
  "web-sys",
  "winapi",
@@ -6245,7 +6019,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -6345,15 +6119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6450,19 +6215,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
@@ -6470,16 +6222,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
- "sha2-asm",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6525,12 +6267,6 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
@@ -6646,15 +6382,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -6795,7 +6522,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "thiserror 1.0.69",
  "url",
  "zip",
@@ -7636,16 +7363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
-dependencies = [
- "getrandom 0.3.2",
- "serde",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7696,12 +7413,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ circuits = { git = "https://github.com/renegade-fi/renegade.git" }
 circuit-types = { git = "https://github.com/renegade-fi/renegade.git", features = [
     "test-helpers",
 ] }
-arbitrum-client = { git = "https://github.com/renegade-fi/renegade.git" }
 itertools = "0.12"
 mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }

--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -26,5 +26,4 @@ rand = { workspace = true }
 ethers = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 circuit-types = { workspace = true, features = ["test-helpers"] }
-circuits = { workspace = true }
-arbitrum-client = { workspace = true }
+circuits = { workspace = true, features = ["test_helpers"] }

--- a/contracts-core/src/transcript/mod.rs
+++ b/contracts-core/src/transcript/mod.rs
@@ -180,7 +180,6 @@ pub fn serialize_g1s_for_transcript(points: &[G1Affine]) -> Vec<u8> {
 #[cfg(test)]
 pub mod tests {
     use alloc::vec::Vec;
-    use arbitrum_client::conversion::to_contract_proof;
     use ark_std::UniformRand;
     use circuit_types::PlonkProof;
     use constants::SystemCurve;
@@ -189,7 +188,7 @@ pub mod tests {
         types::{G1Affine, G2Affine, Proof, PublicInputs, ScalarField, VerificationKey},
     };
     use contracts_utils::{
-        conversion::to_contract_vkey,
+        conversion::{to_contract_proof, to_contract_vkey},
         crypto::NativeHasher,
         proof_system::test_data::{random_commitments, random_scalars},
     };

--- a/contracts-core/src/verifier/mod.rs
+++ b/contracts-core/src/verifier/mod.rs
@@ -697,7 +697,6 @@ impl<G: G1ArithmeticBackend, H: HashBackend> Verifier<G, H> {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    use arbitrum_client::conversion::to_contract_link_proof;
     use ark_bn254::Bn254;
     use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
     use ark_ff::One;
@@ -716,7 +715,7 @@ mod tests {
     };
     use contracts_utils::{
         constants::DUMMY_CIRCUIT_SRS_DEGREE,
-        conversion::to_linking_vkey,
+        conversion::{to_contract_link_proof, to_linking_vkey},
         crypto::NativeHasher,
         proof_system::{
             dummy_renegade_circuits::{

--- a/contracts-utils/Cargo.toml
+++ b/contracts-utils/Cargo.toml
@@ -25,4 +25,6 @@ circuit-types = { workspace = true }
 circuit-macros = { git = "https://github.com/renegade-fi/renegade.git" }
 circuits = { workspace = true }
 constants = { workspace = true }
-arbitrum-client = { workspace = true }
+
+[dev-dependencies]
+circuits = { workspace = true, features = ["test_helpers"] }

--- a/contracts-utils/src/conversion.rs
+++ b/contracts-utils/src/conversion.rs
@@ -1,17 +1,50 @@
 //! Type conversion utilities
 
-use arbitrum_client::errors::ConversionError;
+use alloy_primitives::{Address, U160, U256};
 use circuit_types::{
+    elgamal::{ElGamalCiphertext, EncryptionKey},
+    fees::FeeTake,
     keychain::{NonNativeScalar, PublicSigningKey as CircuitPublicSigningKey},
-    PolynomialCommitment,
+    note::NOTE_CIPHERTEXT_SIZE,
+    r#match::{ExternalMatchResult, OrderSettlementIndices},
+    traits::BaseType,
+    transfers::{ExternalTransfer, ExternalTransferDirection},
+    Amount, PlonkLinkProof, PlonkProof, PolynomialCommitment, SizedWalletShare,
+};
+use circuits::zk_circuits::{
+    valid_commitments::ValidCommitmentsStatement,
+    valid_fee_redemption::SizedValidFeeRedemptionStatement,
+    valid_match_settle::SizedValidMatchSettleStatement,
+    valid_match_settle_atomic::SizedValidMatchSettleAtomicStatement,
+    valid_offline_fee_settlement::SizedValidOfflineFeeSettlementStatement,
+    valid_reblind::ValidReblindStatement,
+    valid_relayer_fee_settlement::SizedValidRelayerFeeSettlementStatement,
+    valid_wallet_create::SizedValidWalletCreateStatement,
+    valid_wallet_update::SizedValidWalletUpdateStatement,
 };
 use constants::{Scalar, SystemCurve};
 use contracts_common::types::{
-    G1Affine, LinkingVerificationKey, PublicSigningKey as ContractPublicSigningKey, VerificationKey,
+    BabyJubJubPoint as ContractBabyJubJubPoint, ExternalMatchResult as ContractExternalMatchResult,
+    ExternalTransfer as ContractExternalTransfer, FeeTake as ContractFeeTake, G1Affine,
+    LinkingProof as ContractLinkingProof, LinkingVerificationKey,
+    NoteCiphertext as ContractNoteCiphertext,
+    OrderSettlementIndices as ContractOrderSettlementIndices, Proof as ContractProof,
+    PublicEncryptionKey as ContractPublicEncryptionKey,
+    PublicSigningKey as ContractPublicSigningKey, ScalarField,
+    ValidCommitmentsStatement as ContractValidCommitmentsStatement,
+    ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+    ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
+    ValidMatchSettleStatement as ContractValidMatchSettleStatement,
+    ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
+    ValidReblindStatement as ContractValidReblindStatement,
+    ValidRelayerFeeSettlementStatement as ContractValidRelayerFeeSettlementStatement,
+    ValidWalletCreateStatement as ContractValidWalletCreateStatement,
+    ValidWalletUpdateStatement as ContractValidWalletUpdateStatement, VerificationKey,
 };
-use eyre::Result;
+use eyre::{eyre, Result};
 use mpc_plonk::proof_system::structs::VerifyingKey;
 use mpc_relation::proof_linking::GroupLayout;
+use num_bigint::BigUint;
 
 /// Converts a [`GroupLayout`] (from prover-side code) to a
 /// [`LinkingVerificationKey`]
@@ -25,25 +58,15 @@ pub fn to_linking_vkey(group_layout: &GroupLayout) -> LinkingVerificationKey {
 
 /// Attempts to convert a slice of [`PolynomialCommitment`]s (from prover-side
 /// code) to a fixed-size array of [`G1Affine`]z
-fn try_unwrap_commitments<const N: usize>(
-    comms: &[PolynomialCommitment],
-) -> Result<[G1Affine; N], ConversionError> {
-    comms
-        .iter()
-        .map(|c| c.0)
-        .collect::<Vec<_>>()
-        .try_into()
-        .map_err(|_| ConversionError::InvalidLength)
+fn try_unwrap_commitments<const N: usize>(comms: &[PolynomialCommitment]) -> Result<[G1Affine; N]> {
+    comms.iter().map(|c| c.0).collect::<Vec<_>>().try_into().map_err(|_| eyre!("Invalid length"))
 }
-
 /// Converts a [`VerifyingKey`] (from prover-side code) to a [`VerificationKey`]
-pub fn to_contract_vkey(
-    jf_vkey: VerifyingKey<SystemCurve>,
-) -> Result<VerificationKey, ConversionError> {
+pub fn to_contract_vkey(jf_vkey: VerifyingKey<SystemCurve>) -> Result<VerificationKey> {
     Ok(VerificationKey {
         n: jf_vkey.domain_size as u64,
         l: jf_vkey.num_inputs as u64,
-        k: jf_vkey.k.try_into().map_err(|_| ConversionError::InvalidLength)?,
+        k: jf_vkey.k.try_into().map_err(|_| eyre!("Invalid length"))?,
         q_comms: try_unwrap_commitments(&jf_vkey.selector_comms)?,
         sigma_comms: try_unwrap_commitments(&jf_vkey.sigma_comms)?,
         g: jf_vkey.open_key.g,
@@ -76,4 +99,336 @@ pub fn to_circuit_pubkey(contract_pubkey: ContractPublicSigningKey) -> CircuitPu
     };
 
     CircuitPublicSigningKey { x, y }
+}
+
+/// Convert a [`PlonkProof`] to its corresponding smart contract type
+pub fn to_contract_proof(proof: &PlonkProof) -> Result<ContractProof> {
+    Ok(ContractProof {
+        wire_comms: try_unwrap_commitments(&proof.wires_poly_comms)?,
+        z_comm: proof.prod_perm_poly_comm.0,
+        quotient_comms: try_unwrap_commitments(&proof.split_quot_poly_comms)?,
+        w_zeta: proof.opening_proof.0,
+        w_zeta_omega: proof.shifted_opening_proof.0,
+        wire_evals: proof
+            .poly_evals
+            .wires_evals
+            .clone()
+            .try_into()
+            .map_err(|_| eyre!("Invalid length"))?,
+        sigma_evals: proof
+            .poly_evals
+            .wire_sigma_evals
+            .clone()
+            .try_into()
+            .map_err(|_| eyre!("Invalid length"))?,
+        z_bar: proof.poly_evals.perm_next_eval,
+    })
+}
+
+/// Convert a [`LinkingProof`] to its corresponding smart contract type
+pub fn to_contract_link_proof(proof: &PlonkLinkProof) -> Result<ContractLinkingProof> {
+    Ok(ContractLinkingProof {
+        linking_poly_opening: proof.opening_proof.proof,
+        linking_quotient_poly_comm: proof.quotient_commitment.0,
+    })
+}
+
+/// Convert an [`ExternalTransfer`] to its corresponding smart contract type
+fn to_contract_external_transfer(
+    external_transfer: &ExternalTransfer,
+) -> Result<ContractExternalTransfer> {
+    let account_addr = biguint_to_address(&external_transfer.account_addr)?;
+    let mint = biguint_to_address(&external_transfer.mint)?;
+    let amount = amount_to_u256(external_transfer.amount)?;
+
+    Ok(ContractExternalTransfer {
+        account_addr,
+        mint,
+        amount,
+        is_withdrawal: external_transfer.direction == ExternalTransferDirection::Withdrawal,
+    })
+}
+
+/// Convert a [`PublicSigningKey`] to its corresponding smart contract type
+pub fn to_contract_public_signing_key(
+    public_signing_key: &CircuitPublicSigningKey,
+) -> Result<ContractPublicSigningKey> {
+    let x = try_unwrap_scalars(&public_signing_key.x.to_scalars())?;
+    let y = try_unwrap_scalars(&public_signing_key.y.to_scalars())?;
+
+    Ok(ContractPublicSigningKey { x, y })
+}
+
+/// Convert a [`SizedValidWalletCreateStatement`] to its corresponding smart
+/// contract type
+pub fn to_contract_valid_wallet_create_statement(
+    statement: &SizedValidWalletCreateStatement,
+) -> ContractValidWalletCreateStatement {
+    let public_wallet_shares = wallet_shares_to_scalar_vec(&statement.public_wallet_shares);
+
+    ContractValidWalletCreateStatement {
+        private_shares_commitment: statement.private_shares_commitment.inner(),
+        public_wallet_shares,
+    }
+}
+
+/// Convert a [`SizedValidWalletUpdateStatement`] to its corresponding smart
+/// contract type
+pub fn to_contract_valid_wallet_update_statement(
+    statement: &SizedValidWalletUpdateStatement,
+) -> Result<ContractValidWalletUpdateStatement> {
+    let new_public_shares = wallet_shares_to_scalar_vec(&statement.new_public_shares);
+    let external_transfer: Option<ContractExternalTransfer> =
+        if statement.external_transfer.is_default() {
+            None
+        } else {
+            Some(to_contract_external_transfer(&statement.external_transfer)?)
+        };
+
+    let old_pk_root = to_contract_public_signing_key(&statement.old_pk_root)?;
+
+    Ok(ContractValidWalletUpdateStatement {
+        old_shares_nullifier: statement.old_shares_nullifier.inner(),
+        new_private_shares_commitment: statement.new_private_shares_commitment.inner(),
+        new_public_shares,
+        merkle_root: statement.merkle_root.inner(),
+        external_transfer,
+        old_pk_root,
+    })
+}
+
+/// Convert a [`ValidReblindStatement`] to its corresponding smart contract type
+pub fn to_contract_valid_reblind_statement(
+    statement: &ValidReblindStatement,
+) -> ContractValidReblindStatement {
+    ContractValidReblindStatement {
+        original_shares_nullifier: statement.original_shares_nullifier.inner(),
+        reblinded_private_shares_commitment: statement.reblinded_private_share_commitment.inner(),
+        merkle_root: statement.merkle_root.inner(),
+    }
+}
+
+/// Convert a [`ValidCommitmentsStatement`] to its corresponding smart contract
+/// type
+pub fn to_contract_valid_commitments_statement(
+    statement: ValidCommitmentsStatement,
+) -> ContractValidCommitmentsStatement {
+    ContractValidCommitmentsStatement {
+        indices: ContractOrderSettlementIndices {
+            balance_send: statement.indices.balance_send as u64,
+            balance_receive: statement.indices.balance_receive as u64,
+            order: statement.indices.order as u64,
+        },
+    }
+}
+
+/// Convert `OrderSettlementIndices` to its corresponding smart contract type
+pub fn to_contract_order_settlement_indices(
+    indices: &OrderSettlementIndices,
+) -> ContractOrderSettlementIndices {
+    ContractOrderSettlementIndices {
+        balance_send: indices.balance_send as u64,
+        balance_receive: indices.balance_receive as u64,
+        order: indices.order as u64,
+    }
+}
+
+/// Convert a [`SizedValidMatchSettleStatement`] to its corresponding smart
+/// contract type
+pub fn to_contract_valid_match_settle_statement(
+    statement: &SizedValidMatchSettleStatement,
+) -> ContractValidMatchSettleStatement {
+    let party0_modified_shares = wallet_shares_to_scalar_vec(&statement.party0_modified_shares);
+    let party1_modified_shares = wallet_shares_to_scalar_vec(&statement.party1_modified_shares);
+    let party0_indices = to_contract_order_settlement_indices(&statement.party0_indices);
+    let party1_indices = to_contract_order_settlement_indices(&statement.party1_indices);
+
+    ContractValidMatchSettleStatement {
+        party0_modified_shares,
+        party1_modified_shares,
+        party0_indices,
+        party1_indices,
+        protocol_fee: statement.protocol_fee.repr.inner(),
+    }
+}
+
+/// Convert a [`ExternalMatchResult`] to its corresponding smart contract type
+fn to_contract_external_match_result(
+    match_result: &ExternalMatchResult,
+) -> Result<ContractExternalMatchResult> {
+    let quote_mint = biguint_to_address(&match_result.quote_mint)?;
+    let base_mint = biguint_to_address(&match_result.base_mint)?;
+    let quote_amount = amount_to_u256(match_result.quote_amount)?;
+    let base_amount = amount_to_u256(match_result.base_amount)?;
+
+    Ok(ContractExternalMatchResult {
+        quote_mint,
+        base_mint,
+        quote_amount,
+        base_amount,
+        direction: match_result.direction,
+    })
+}
+
+/// Convert a [`FeeTake`] to its corresponding smart contract type
+fn to_contract_fee_take(fee_take: &FeeTake) -> Result<ContractFeeTake> {
+    Ok(ContractFeeTake {
+        relayer_fee: amount_to_u256(fee_take.relayer_fee)?,
+        protocol_fee: amount_to_u256(fee_take.protocol_fee)?,
+    })
+}
+
+/// Convert a [`SizedValidMatchSettleAtomicStatement`] to its corresponding
+/// smart contract type
+pub fn to_contract_valid_match_settle_atomic_statement(
+    statement: &SizedValidMatchSettleAtomicStatement,
+) -> Result<ContractValidMatchSettleAtomicStatement> {
+    let internal_party_modified_shares =
+        wallet_shares_to_scalar_vec(&statement.internal_party_modified_shares);
+    let internal_party_indices =
+        to_contract_order_settlement_indices(&statement.internal_party_indices);
+
+    Ok(ContractValidMatchSettleAtomicStatement {
+        match_result: to_contract_external_match_result(&statement.match_result)?,
+        external_party_fees: to_contract_fee_take(&statement.external_party_fees)?,
+        internal_party_modified_shares,
+        internal_party_indices,
+        protocol_fee: statement.protocol_fee.repr.inner(),
+        relayer_fee_address: biguint_to_address(&statement.relayer_fee_address)?,
+    })
+}
+
+/// Converts a [`SizedValidRelayerFeeSettlementStatement`] (from prover-side
+/// code) to a [`ContractValidRelayerFeeSettlementStatement`]
+pub fn to_contract_valid_relayer_fee_settlement_statement(
+    statement: &SizedValidRelayerFeeSettlementStatement,
+) -> Result<ContractValidRelayerFeeSettlementStatement> {
+    Ok(ContractValidRelayerFeeSettlementStatement {
+        sender_root: statement.sender_root.inner(),
+        recipient_root: statement.recipient_root.inner(),
+        sender_nullifier: statement.sender_nullifier.inner(),
+        recipient_nullifier: statement.recipient_nullifier.inner(),
+        sender_wallet_commitment: statement.sender_wallet_commitment.inner(),
+        recipient_wallet_commitment: statement.recipient_wallet_commitment.inner(),
+        sender_updated_public_shares: statement
+            .sender_updated_public_shares
+            .to_scalars()
+            .iter()
+            .map(|s| s.inner())
+            .collect(),
+        recipient_updated_public_shares: statement
+            .recipient_updated_public_shares
+            .to_scalars()
+            .iter()
+            .map(|s| s.inner())
+            .collect(),
+        recipient_pk_root: to_contract_public_signing_key(&statement.recipient_pk_root)?,
+    })
+}
+
+/// Converts a [`ElGamalCiphertext`] (from prover-side code) to a
+/// [`ContractNoteCiphertext`]
+fn to_contract_note_ciphertext(
+    note_ciphertext: &ElGamalCiphertext<NOTE_CIPHERTEXT_SIZE>,
+) -> ContractNoteCiphertext {
+    ContractNoteCiphertext(
+        ContractBabyJubJubPoint {
+            x: note_ciphertext.ephemeral_key.x.inner(),
+            y: note_ciphertext.ephemeral_key.y.inner(),
+        },
+        note_ciphertext.ciphertext[0].inner(),
+        note_ciphertext.ciphertext[1].inner(),
+        note_ciphertext.ciphertext[2].inner(),
+    )
+}
+
+/// Converts an [`EncryptionKey`] (from prover-side code) to a
+/// [`ContractPublicEncryptionKey`]
+fn to_contract_public_encryption_key(
+    public_encryption_key: &EncryptionKey,
+) -> ContractPublicEncryptionKey {
+    ContractPublicEncryptionKey {
+        x: public_encryption_key.x.inner(),
+        y: public_encryption_key.y.inner(),
+    }
+}
+
+/// Converts a [`SizedValidOfflineFeeSettlementStatement`] (from prover-side
+/// code) to a [`ContractValidOfflineFeeSettlementStatement`]
+pub fn to_contract_valid_offline_fee_settlement_statement(
+    statement: &SizedValidOfflineFeeSettlementStatement,
+) -> ContractValidOfflineFeeSettlementStatement {
+    ContractValidOfflineFeeSettlementStatement {
+        merkle_root: statement.merkle_root.inner(),
+        nullifier: statement.nullifier.inner(),
+        updated_wallet_commitment: statement.updated_wallet_commitment.inner(),
+        updated_wallet_public_shares: statement
+            .updated_wallet_public_shares
+            .to_scalars()
+            .iter()
+            .map(|s| s.inner())
+            .collect(),
+        note_ciphertext: to_contract_note_ciphertext(&statement.note_ciphertext),
+        note_commitment: statement.note_commitment.inner(),
+        protocol_key: to_contract_public_encryption_key(&statement.protocol_key),
+        is_protocol_fee: statement.is_protocol_fee,
+    }
+}
+
+/// Converts a [`SizedValidFeeRedemptionStatement`] (from prover-side code) to a
+/// [`ContractValidFeeRedemptionStatement`]
+pub fn to_contract_valid_fee_redemption_statement(
+    statement: &SizedValidFeeRedemptionStatement,
+) -> Result<ContractValidFeeRedemptionStatement> {
+    Ok(ContractValidFeeRedemptionStatement {
+        wallet_root: statement.wallet_root.inner(),
+        note_root: statement.note_root.inner(),
+        nullifier: statement.wallet_nullifier.inner(),
+        note_nullifier: statement.note_nullifier.inner(),
+        new_wallet_commitment: statement.new_wallet_commitment.inner(),
+        new_wallet_public_shares: statement
+            .new_wallet_public_shares
+            .to_scalars()
+            .iter()
+            .map(|s| s.inner())
+            .collect(),
+        old_pk_root: to_contract_public_signing_key(&statement.recipient_root_key)?,
+    })
+}
+
+// ------------------------
+// | CONVERSION UTILITIES |
+// ------------------------
+
+/// Convert a `BigUint` to an `Address`
+pub fn biguint_to_address(biguint: &BigUint) -> Result<Address> {
+    let mut buf = [0u8; U160::BYTES];
+    let be_bytes = biguint.to_bytes_be();
+    let start = buf.len().saturating_sub(be_bytes.len());
+    buf[start..].copy_from_slice(&be_bytes);
+
+    let u160 = U160::from_be_bytes(buf);
+    Ok(Address::from(u160))
+}
+
+/// Convert an `Amount` to a `U256`
+pub fn amount_to_u256(amount: Amount) -> Result<U256> {
+    amount.try_into().map_err(|_| eyre!("Invalid uint"))
+}
+
+/// Try to extract a fixed-length array of `ScalarField` elements
+/// from a slice of `Scalar`s
+fn try_unwrap_scalars<const N: usize>(scalars: &[Scalar]) -> Result<[ScalarField; N]> {
+    scalars
+        .iter()
+        .map(|s| s.inner())
+        .collect::<Vec<_>>()
+        .try_into()
+        .map_err(|_| eyre!("Invalid length"))
+}
+
+/// Convert a set of wallet secret shares into a vector of `ScalarField`
+/// elements
+fn wallet_shares_to_scalar_vec(shares: &SizedWalletShare) -> Vec<ScalarField> {
+    shares.to_scalars().into_iter().map(|s| s.inner()).collect()
 }

--- a/contracts-utils/src/crypto.rs
+++ b/contracts-utils/src/crypto.rs
@@ -1,6 +1,5 @@
 //! Helpful cryptographic utilities
 
-use arbitrum_client::conversion::to_contract_public_signing_key;
 use circuit_types::keychain::PublicSigningKey as CircuitPubkey;
 use contracts_common::{
     backends::HashBackend, constants::HASH_OUTPUT_SIZE, types::PublicSigningKey,
@@ -11,6 +10,8 @@ use ethers::{
     utils::keccak256,
 };
 use rand::{CryptoRng, RngCore};
+
+use crate::conversion::to_contract_public_signing_key;
 
 /// A hashing backend that runs natively, i.e.
 /// without using a Stylus VM-accelerated Keccak implementation

--- a/contracts-utils/src/proof_system/mod.rs
+++ b/contracts-utils/src/proof_system/mod.rs
@@ -5,7 +5,6 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
-use arbitrum_client::errors::ConversionError;
 use circuit_types::{errors::ProverError, traits::SingleProverCircuit};
 use circuits::zk_circuits::{
     VALID_COMMITMENTS_MATCH_SETTLE_LINK0, VALID_COMMITMENTS_MATCH_SETTLE_LINK1,
@@ -14,6 +13,7 @@ use circuits::zk_circuits::{
 use contracts_common::types::{
     MatchAtomicLinkingVkeys, MatchAtomicVkeys, MatchLinkingVkeys, MatchVkeys,
 };
+use eyre::Result;
 use mpc_relation::proof_linking::GroupLayout;
 
 use crate::conversion::{to_contract_vkey, to_linking_vkey};
@@ -31,7 +31,7 @@ pub mod test_data;
 /// Defined generically over the `VALID COMMITMENTS`, `VALID REBLIND`, and
 /// `VALID MATCH SETTLE` circuits, so that this can be used in both testing and
 /// production setings.
-pub fn gen_match_vkeys<C, R, M>() -> Result<MatchVkeys, ProofSystemError>
+pub fn gen_match_vkeys<C, R, M>() -> Result<MatchVkeys>
 where
     C: SingleProverCircuit,
     R: SingleProverCircuit,
@@ -46,7 +46,7 @@ where
 
 /// Generate the verification keys for the circuits involved in settling a
 /// matched trade
-pub fn gen_match_atomic_vkeys<C, R, M>() -> Result<MatchAtomicVkeys, ProofSystemError>
+pub fn gen_match_atomic_vkeys<C, R, M>() -> Result<MatchAtomicVkeys>
 where
     C: SingleProverCircuit,
     R: SingleProverCircuit,
@@ -68,7 +68,7 @@ where
 ///
 /// We use the same type here as the match atomic vkey, despite the underlying
 /// match verification key being different.
-pub fn gen_malleable_match_atomic_vkeys<C, R, M>() -> Result<MatchAtomicVkeys, ProofSystemError>
+pub fn gen_malleable_match_atomic_vkeys<C, R, M>() -> Result<MatchAtomicVkeys>
 where
     C: SingleProverCircuit,
     R: SingleProverCircuit,
@@ -102,7 +102,7 @@ pub struct MatchGroupLayouts {
 ///
 /// Defined generically over the `VALID COMMITMENTS` circuit, so that this can
 /// be used in both the testing and production setting.
-pub fn gen_match_layouts<C: SingleProverCircuit>() -> Result<MatchGroupLayouts, ProofSystemError> {
+pub fn gen_match_layouts<C: SingleProverCircuit>() -> Result<MatchGroupLayouts> {
     let valid_commitments_layout = C::get_circuit_layout()
         .map_err(|e| ProofSystemError::ProverError(ProverError::Plonk(e)))?;
 
@@ -127,8 +127,7 @@ pub fn gen_match_layouts<C: SingleProverCircuit>() -> Result<MatchGroupLayouts, 
 ///
 /// Defined generically over the `VALID COMMITMENTS` circuit, so that this can
 /// be used in both the testing and production setting.
-pub fn gen_match_linking_vkeys<C: SingleProverCircuit>(
-) -> Result<MatchLinkingVkeys, ProofSystemError> {
+pub fn gen_match_linking_vkeys<C: SingleProverCircuit>() -> Result<MatchLinkingVkeys> {
     let MatchGroupLayouts {
         valid_reblind_commitments,
         valid_commitments_match_settle_0,
@@ -144,8 +143,7 @@ pub fn gen_match_linking_vkeys<C: SingleProverCircuit>(
 
 /// Generate the linking verification keys for the circuits involved in settling
 /// an atomic match
-pub fn gen_match_atomic_linking_vkeys<C: SingleProverCircuit>(
-) -> Result<MatchAtomicLinkingVkeys, ProofSystemError> {
+pub fn gen_match_atomic_linking_vkeys<C: SingleProverCircuit>() -> Result<MatchAtomicLinkingVkeys> {
     let MatchGroupLayouts { valid_reblind_commitments, valid_commitments_match_settle_0, .. } =
         gen_match_layouts::<C>()?;
 
@@ -158,7 +156,7 @@ pub fn gen_match_atomic_linking_vkeys<C: SingleProverCircuit>(
 /// Generate the linking verification keys for the circuits involved in settling
 /// an atomic match
 pub fn gen_malleable_match_atomic_linking_vkeys<C: SingleProverCircuit>(
-) -> Result<MatchAtomicLinkingVkeys, ProofSystemError> {
+) -> Result<MatchAtomicLinkingVkeys> {
     let MatchGroupLayouts { valid_reblind_commitments, valid_commitments_match_settle_0, .. } =
         gen_match_layouts::<C>()?;
 
@@ -175,8 +173,6 @@ pub fn gen_malleable_match_atomic_linking_vkeys<C: SingleProverCircuit>(
 /// An error that occured when interacting with the proof system
 #[derive(Debug)]
 pub enum ProofSystemError {
-    /// An error that occurred when converting between prover and contract types
-    ConversionError(ConversionError),
     /// An error that occurred when computing a proof
     ProverError(ProverError),
 }
@@ -184,19 +180,12 @@ pub enum ProofSystemError {
 impl Display for ProofSystemError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ProofSystemError::ConversionError(e) => write!(f, "ConversionError: {}", e),
             ProofSystemError::ProverError(e) => write!(f, "ProverError: {}", e),
         }
     }
 }
 
 impl Error for ProofSystemError {}
-
-impl From<ConversionError> for ProofSystemError {
-    fn from(e: ConversionError) -> Self {
-        ProofSystemError::ConversionError(e)
-    }
-}
 
 impl From<ProverError> for ProofSystemError {
     fn from(e: ProverError) -> Self {

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -1,20 +1,14 @@
 //! Utilities for generating data for the proof system tests
 
 use alloy_primitives::Address as AlloyAddress;
-use arbitrum_client::conversion::{
-    to_contract_link_proof, to_contract_proof, to_contract_valid_commitments_statement,
-    to_contract_valid_fee_redemption_statement, to_contract_valid_match_settle_atomic_statement,
-    to_contract_valid_match_settle_statement, to_contract_valid_offline_fee_settlement_statement,
-    to_contract_valid_reblind_statement, to_contract_valid_relayer_fee_settlement_statement,
-    to_contract_valid_wallet_create_statement, to_contract_valid_wallet_update_statement,
-};
 use ark_ff::One;
 use ark_std::UniformRand;
 use circuit_types::{
     elgamal::EncryptionKey,
+    fees::FeeTake,
     fixed_point::FixedPoint,
     keychain::PublicSigningKey,
-    r#match::{ExternalMatchResult, FeeTake},
+    r#match::ExternalMatchResult,
     srs::SYSTEM_SRS,
     traits::{CircuitBaseType, SingleProverCircuit},
     transfers::ExternalTransfer,
@@ -59,7 +53,15 @@ use std::iter;
 
 use crate::{
     constants::DUMMY_CIRCUIT_SRS_DEGREE,
-    conversion::{to_circuit_pubkey, to_contract_vkey},
+    conversion::{
+        to_circuit_pubkey, to_contract_link_proof, to_contract_proof,
+        to_contract_valid_commitments_statement, to_contract_valid_fee_redemption_statement,
+        to_contract_valid_match_settle_atomic_statement, to_contract_valid_match_settle_statement,
+        to_contract_valid_offline_fee_settlement_statement, to_contract_valid_reblind_statement,
+        to_contract_valid_relayer_fee_settlement_statement,
+        to_contract_valid_wallet_create_statement, to_contract_valid_wallet_update_statement,
+        to_contract_vkey,
+    },
     crypto::{hash_and_sign_message, random_keypair},
     proof_system::dummy_renegade_circuits::DummyValidMatchSettleAtomic,
 };

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -23,9 +23,8 @@ alloy-primitives = { workspace = true, features = ["tiny-keccak"] }
 alloy-sol-types = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 circuit-types = { workspace = true, features = ["test-helpers"] }
-circuits = { workspace = true }
+circuits = { workspace = true, features = ["test_helpers"] }
 constants = { workspace = true }
-arbitrum-client = { workspace = true }
 jf-primitives = { workspace = true }
 itertools = { workspace = true }
 tracing = { workspace = true }

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-primitives = { workspace = true }
 itertools = { workspace = true }
-circuits = { workspace = true }
+circuits = { workspace = true, features = ["test_helpers"] }
 circuit-types = { workspace = true }
 constants = { workspace = true }
 util = { git = "https://github.com/renegade-fi/renegade.git" }


### PR DESCRIPTION
### Purpose
This PR copies over conversion utils from the `arbitrum-client` into `contract-utils` now that the underlying types are different. 

### Todo
- Fix integration tests in a follow up

### Testing
- [x] Crates build
- [x] Unit tests pass