### PR TITLE
contracts-core, contracts-utils: Remove `ethers` dependency

### DIFF
--- a/contracts-core/Cargo.toml
+++ b/contracts-core/Cargo.toml
@@ -12,8 +12,8 @@ serde = { workspace = true }
 serde_with = { workspace = true }
 ruint = { workspace = true }
 
-
 [dev-dependencies]
+alloy = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-std = { workspace = true }
@@ -23,7 +23,6 @@ mpc-plonk = { workspace = true }
 constants = { workspace = true }
 contracts-utils = { path = "../contracts-utils" }
 rand = { workspace = true }
-ethers = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 circuit-types = { workspace = true, features = ["test-helpers"] }
 circuits = { workspace = true, features = ["test_helpers"] }

--- a/contracts-core/src/crypto/ecdsa.rs
+++ b/contracts-core/src/crypto/ecdsa.rs
@@ -64,9 +64,9 @@ pub fn pubkey_to_address<H: HashBackend>(pubkey: &PublicSigningKey) -> [u8; NUM_
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::{FixedBytes, PrimitiveSignature};
     use contracts_common::constants::{HASH_OUTPUT_SIZE, NUM_BYTES_ADDRESS, NUM_BYTES_SIGNATURE};
     use contracts_utils::crypto::{hash_and_sign_message, random_keypair, NativeHasher};
-    use ethers::types::{RecoveryMessage, Signature};
     use rand::{thread_rng, RngCore};
 
     use super::{EcRecoverBackend, EcdsaError};
@@ -77,9 +77,13 @@ mod tests {
             message_hash: &[u8; HASH_OUTPUT_SIZE],
             signature: &[u8; NUM_BYTES_SIGNATURE],
         ) -> Result<[u8; NUM_BYTES_ADDRESS], EcdsaError> {
-            let signature: Signature = signature.as_slice().try_into().map_err(|_| EcdsaError)?;
-            let message_hash: RecoveryMessage = RecoveryMessage::Hash(message_hash.into());
-            Ok(signature.recover(message_hash).map_err(|_| EcdsaError)?.into())
+            let signature: PrimitiveSignature =
+                signature.as_slice().try_into().map_err(|_| EcdsaError)?;
+            let msg_bytes: FixedBytes<32> = message_hash.into();
+            let addr =
+                signature.recover_address_from_prehash(&msg_bytes).map_err(|_| EcdsaError)?;
+
+            Ok(addr.to_vec().try_into().expect("Invalid address length"))
         }
     }
 

--- a/contracts-utils/Cargo.toml
+++ b/contracts-utils/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+alloy = { workspace = true, features = ["signers"] }
 contracts-common = { path = "../contracts-common" }
 contracts-core = { path = "../contracts-core" }
 rand = { workspace = true }
@@ -15,7 +16,6 @@ alloy-primitives = { workspace = true }
 num-bigint = { workspace = true }
 eyre = { workspace = true }
 serde = { workspace = true }
-ethers = { workspace = true }
 mpc-plonk = { workspace = true, features = ["test_apis"] }
 mpc-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
 jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }

--- a/contracts-utils/src/crypto.rs
+++ b/contracts-utils/src/crypto.rs
@@ -1,13 +1,13 @@
 //! Helpful cryptographic utilities
 
+use alloy::{
+    primitives::{PrimitiveSignature, U256},
+    signers::k256::ecdsa::SigningKey,
+};
+use alloy_primitives::keccak256;
 use circuit_types::keychain::PublicSigningKey as CircuitPubkey;
 use contracts_common::{
     backends::HashBackend, constants::HASH_OUTPUT_SIZE, types::PublicSigningKey,
-};
-use ethers::{
-    core::k256::ecdsa::SigningKey,
-    types::{Signature, U256},
-    utils::keccak256,
 };
 use rand::{CryptoRng, RngCore};
 
@@ -19,7 +19,7 @@ pub struct NativeHasher;
 
 impl HashBackend for NativeHasher {
     fn hash(input: &[u8]) -> [u8; HASH_OUTPUT_SIZE] {
-        keccak256(input)
+        *keccak256(input)
     }
 }
 
@@ -37,10 +37,11 @@ pub fn random_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SigningKey, Publi
 
 /// Hashes the given message and generates a signature over it using the signing
 /// key, as expected in ECDSA
-pub fn hash_and_sign_message(signing_key: &SigningKey, msg: &[u8]) -> Signature {
+pub fn hash_and_sign_message(signing_key: &SigningKey, msg: &[u8]) -> PrimitiveSignature {
     let msg_hash = keccak256(msg);
-    let (sig, recovery_id) = signing_key.sign_prehash_recoverable(&msg_hash).unwrap();
-    let r: U256 = U256::from_big_endian(&sig.r().to_bytes());
-    let s: U256 = U256::from_big_endian(&sig.s().to_bytes());
-    Signature { r, s, v: recovery_id.to_byte() as u64 }
+    let (sig, recovery_id) = signing_key.sign_prehash_recoverable(&msg_hash.as_slice()).unwrap();
+    let r: U256 = U256::from_be_bytes(sig.r().to_bytes().into());
+    let s: U256 = U256::from_be_bytes(sig.s().to_bytes().into());
+
+    PrimitiveSignature::new(r, s, recovery_id.is_y_odd())
 }

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -1,5 +1,6 @@
 //! Utilities for generating data for the proof system tests
 
+use alloy::primitives::{Address, Bytes, U256};
 use alloy_primitives::Address as AlloyAddress;
 use ark_ff::One;
 use ark_std::UniformRand;
@@ -42,7 +43,6 @@ use contracts_common::{
     },
 };
 use contracts_core::crypto::poseidon::compute_poseidon_hash;
-use ethers::types::{Address, Bytes, U256};
 use eyre::Result;
 use jf_primitives::pcs::{prelude::Commitment, StructuredReferenceString};
 
@@ -267,7 +267,7 @@ pub fn gen_update_wallet_data<R: CryptoRng + RngCore>(
     );
 
     let wallet_commitment_signature = Bytes::from(
-        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).to_vec(),
+        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).as_bytes(),
     );
 
     Ok((proof, contract_statement, wallet_commitment_signature))
@@ -305,7 +305,7 @@ pub fn gen_settle_online_relayer_fee_data<R: CryptoRng + RngCore>(
     );
 
     let wallet_commitment_signature = Bytes::from(
-        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).to_vec(),
+        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).as_bytes(),
     );
 
     Ok((proof, contract_statement, wallet_commitment_signature))
@@ -368,7 +368,7 @@ pub fn gen_redeem_fee_data<R: CryptoRng + RngCore>(
     );
 
     let wallet_commitment_signature = Bytes::from(
-        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).to_vec(),
+        hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).as_bytes(),
     );
 
     Ok((proof, contract_statement, wallet_commitment_signature))


### PR DESCRIPTION
### Purpose
This PR removes the `ethers` dependency in `contracts-core` and `contracts-utils` in favor of `alloy`. This begins a larger transition off of `ethers` in the stack.

### Todo
- Migrate the rest of the contacts repo
- Fix integration tests once all crates are migrated

### Testing
- [x] Unit tests pass 