### PR TITLE
scripts: Remove `ethers` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,8 +340,10 @@ dependencies = [
  "cfg-if 1.0.0",
  "const-hex",
  "derive_more 0.99.19",
+ "getrandom 0.2.15",
  "hex-literal",
  "itoa",
+ "rand 0.8.5",
  "ruint",
  "tiny-keccak",
 ]
@@ -358,6 +360,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
+ "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "indexmap 2.8.0",
  "itoa",
@@ -1873,6 +1876,7 @@ dependencies = [
 name = "contracts-core"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-primitives 0.7.7",
  "ark-bn254",
  "ark-crypto-primitives",
@@ -1884,7 +1888,6 @@ dependencies = [
  "constants",
  "contracts-common",
  "contracts-utils",
- "ethers",
  "jf-primitives",
  "jf-utils",
  "mpc-plonk",
@@ -1916,6 +1919,7 @@ dependencies = [
 name = "contracts-utils"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-primitives 0.7.7",
  "ark-crypto-primitives",
  "ark-ec",
@@ -1927,7 +1931,6 @@ dependencies = [
  "constants",
  "contracts-common",
  "contracts-core",
- "ethers",
  "eyre",
  "jf-primitives",
  "jf-utils",
@@ -5782,6 +5785,9 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -5986,8 +5992,10 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "scripts"
 version = "0.1.0"
 dependencies = [
+ "alloy",
+ "alloy-contract",
  "alloy-primitives 0.7.7",
- "alloy-sol-types 0.7.7",
+ "alloy-sol-types 0.8.25",
  "ark-ed-on-bn254",
  "circuit-types",
  "circuits",
@@ -5995,7 +6003,6 @@ dependencies = [
  "constants",
  "contracts-common",
  "contracts-utils",
- "ethers",
  "hex",
  "itertools 0.12.1",
  "jf-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ ark-crypto-primitives = { version = "0.4", default-features = false, features = 
     "crh",
     "merkle_tree",
 ] }
+alloy = { version = "0.12", default-features = false }
+alloy-contract = { version = "=0.12", default-features = false }
 alloy-primitives = { version = "=0.7.7", default-features = false }
 alloy-sol-types = { version = "=0.7.7", default-features = false }
 serde = { version = "1.0.197", default-features = false, features = ["derive"] }

--- a/contracts-utils/src/crypto.rs
+++ b/contracts-utils/src/crypto.rs
@@ -39,7 +39,7 @@ pub fn random_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SigningKey, Publi
 /// key, as expected in ECDSA
 pub fn hash_and_sign_message(signing_key: &SigningKey, msg: &[u8]) -> PrimitiveSignature {
     let msg_hash = keccak256(msg);
-    let (sig, recovery_id) = signing_key.sign_prehash_recoverable(&msg_hash.as_slice()).unwrap();
+    let (sig, recovery_id) = signing_key.sign_prehash_recoverable(msg_hash.as_slice()).unwrap();
     let r: U256 = U256::from_be_bytes(sig.r().to_bytes().into());
     let s: U256 = U256::from_be_bytes(sig.s().to_bytes().into());
 

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -4,17 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ethers = { workspace = true }
+alloy = { workspace = true, default-features = true, features = [
+    "rlp",
+    "rand",
+] }
+alloy-contract = { workspace = true }
+# In the scripts, we use higher versions of the alloy-sol crates in line with `alloy-contract`
+alloy-sol-types = { version = "0.8" }
+alloy-primitives = { workspace = true, features = ["rand"] }
 clap = { workspace = true, features = ["env"] }
 tokio = { workspace = true }
 serde_json = { workspace = true }
-alloy-sol-types = { workspace = true }
-alloy-primitives = { workspace = true }
 itertools = { workspace = true }
 circuits = { workspace = true, features = ["test_helpers"] }
 circuit-types = { workspace = true }
 constants = { workspace = true }
-util = { git = "https://github.com/renegade-fi/renegade.git" }
+util = { git = "https://github.com/renegade-fi/renegade.git", features = [
+    "errors",
+] }
 mpc-plonk = { workspace = true }
 jf-primitives = { workspace = true }
 contracts-common = { path = "../contracts-common" }

--- a/scripts/src/cli.rs
+++ b/scripts/src/cli.rs
@@ -1,7 +1,5 @@
 //! Definitions of CLI arguments and commands for deploy scripts
 
-use std::sync::Arc;
-
 use clap::{Args, Parser, Subcommand};
 
 use crate::{
@@ -63,7 +61,7 @@ impl Command {
     /// Run the command
     pub async fn run(
         self,
-        client: Arc<LocalWalletHttpClient>,
+        client: LocalWalletHttpClient,
         rpc_url: &str,
         priv_key: &str,
         deployments_path: &str,

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -1,6 +1,9 @@
 //! Implementations of the various deploy scripts
 
-use alloy_primitives::U256;
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    providers::Provider,
+};
 use circuit_types::traits::SingleProverCircuit;
 use circuits::zk_circuits::{
     valid_commitments::SizedValidCommitments, valid_fee_redemption::SizedValidFeeRedemption,
@@ -25,15 +28,9 @@ use contracts_utils::{
         gen_match_vkeys,
     },
 };
-use ethers::{
-    abi::{Address, Contract},
-    middleware::contract::ContractFactory,
-    providers::Middleware,
-    types::{Bytes, H256, U256 as EthersU256},
-    utils::hex::FromHex,
-};
+use hex::FromHex;
 use rand::{thread_rng, Rng};
-use std::{env, str::FromStr, sync::Arc};
+use std::{env, str::FromStr};
 use tracing::log::info;
 use util::err_str;
 
@@ -43,23 +40,23 @@ use crate::{
         DeployTestContractsArgs, GenVkeysArgs, UpgradeArgs,
     },
     constants::{
-        NUM_BYTES_ADDRESS, NUM_BYTES_STORAGE_SLOT, NUM_DEPLOY_CONFIRMATIONS, PERMIT2_ABI,
-        PERMIT2_BYTECODE, PERMIT2_CONTRACT_KEY, PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_FILE,
-        PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE, PROCESS_MATCH_SETTLE_VKEYS_FILE, PROXY_ABI,
-        PROXY_ADMIN_CONTRACT_KEY, PROXY_ADMIN_STORAGE_SLOT, PROXY_BYTECODE, PROXY_CONTRACT_KEY,
+        Permit2, TransparentUpgradeableProxy, NUM_BYTES_ADDRESS, NUM_BYTES_STORAGE_SLOT,
+        PERMIT2_CONTRACT_KEY, PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_FILE,
+        PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE, PROCESS_MATCH_SETTLE_VKEYS_FILE,
+        PROXY_ADMIN_CONTRACT_KEY, PROXY_ADMIN_STORAGE_SLOT, PROXY_CONTRACT_KEY,
         TEST_ERC20_DECIMALS, TEST_ERC20_TICKER1, TEST_ERC20_TICKER2, TEST_FUNDING_AMOUNT,
         VALID_FEE_REDEMPTION_VKEY_FILE, VALID_OFFLINE_FEE_SETTLEMENT_VKEY_FILE,
         VALID_RELAYER_FEE_SETTLEMENT_VKEY_FILE, VALID_WALLET_CREATE_VKEY_FILE,
         VALID_WALLET_UPDATE_VKEY_FILE,
     },
     errors::ScriptError,
-    solidity::{DummyErc20Contract, DummyWethContract, ProxyAdminContract},
+    solidity::{DummyErc20, DummyWeth, ProxyAdmin},
     types::{RenegadeVerificationKeys, StylusContract},
     utils::{
         build_stylus_contract, darkpool_initialize_calldata, deploy_stylus_contract,
         gas_sponsor_initialize_calldata, get_protocol_external_fee_collection_address,
         get_public_encryption_key, read_deployment_address, read_stylus_deployment_address,
-        send_contract_call, setup_client, write_deployment_address, write_stylus_contract_address,
+        send_tx, setup_client, write_deployment_address, write_stylus_contract_address,
         write_vkey_file, LocalWalletHttpClient,
     },
 };
@@ -75,7 +72,7 @@ pub async fn deploy_test_contracts(
     args: &DeployTestContractsArgs,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     info!("Generating testing verification keys");
@@ -244,9 +241,8 @@ pub async fn deploy_test_contracts(
     .await?;
 
     info!("Deploying gas sponsor proxy contract");
-    let deploy_gas_sponsor_proxy_args = DeployGasSponsorProxyArgs {
-        auth_address: format!("{:#x}", client.default_sender().unwrap()),
-    };
+    let deploy_gas_sponsor_proxy_args =
+        DeployGasSponsorProxyArgs { auth_address: format!("{:#x}", client.address()) };
     deploy_gas_sponsor_proxy(&deploy_gas_sponsor_proxy_args, client, deployments_path).await?;
 
     Ok(())
@@ -255,7 +251,7 @@ pub async fn deploy_test_contracts(
 /// Deploys the proxy & proxy admin contracts for the gas sponsor
 pub async fn deploy_gas_sponsor_proxy(
     args: &DeployGasSponsorProxyArgs,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     let gas_sponsor_address =
@@ -283,7 +279,7 @@ pub async fn deploy_gas_sponsor_proxy(
 /// Deploys the proxy & proxy admin contracts for the darkpool
 pub async fn deploy_darkpool_proxy(
     args: &DeployDarkpoolProxyArgs,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     // Construct darkpool initialization calldata
@@ -348,50 +344,39 @@ pub async fn deploy_darkpool_proxy(
 /// Deploys the `TransparentUpgradeableProxy` and `ProxyAdmin` contracts for the
 /// given implementation contract
 async fn deploy_proxy(
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     implementation_address: Address,
     initialization_calldata: Bytes,
     deployment_prefix: &str,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
-    // Get proxy contract ABI and bytecode
-    let abi: Contract =
-        serde_json::from_str(PROXY_ABI).map_err(|e| ScriptError::ArtifactParsing(e.to_string()))?;
-
-    let bytecode =
-        Bytes::from_hex(PROXY_BYTECODE).map_err(|e| ScriptError::ArtifactParsing(e.to_string()))?;
-
-    let proxy_factory = ContractFactory::new(abi, bytecode, client.clone());
-
     // Deploy proxy contract
-    let owner_address = client.default_sender().unwrap();
-    let proxy_contract = proxy_factory
-        .deploy((implementation_address, owner_address, initialization_calldata))
-        .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?
-        .confirmations(NUM_DEPLOY_CONFIRMATIONS)
-        .send()
-        .await
-        .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?;
+    let owner_address = client.address();
+    let proxy_contract = TransparentUpgradeableProxy::deploy(
+        client.provider(),
+        implementation_address,
+        owner_address,
+        initialization_calldata,
+    )
+    .await
+    .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?;
 
-    let proxy_address = proxy_contract.address();
+    let proxy_address = *proxy_contract.address();
 
     info!("Proxy contract deployed at address:\n\t{:#x}", proxy_address);
 
     // Get proxy admin contract address
     // This is the recommended way to get the proxy admin address:
     // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/proxy/ERC1967/ERC1967Utils.sol#L104-L106
-    let proxy_admin_address = Address::from_slice(
-        &client
-            .get_storage_at(
-                proxy_address,
-                // Can `unwrap` here since we know the storage slot constitutes a valid H256
-                H256::from_str(PROXY_ADMIN_STORAGE_SLOT).unwrap(),
-                None, // block
-            )
-            .await
-            .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
-            [NUM_BYTES_STORAGE_SLOT - NUM_BYTES_ADDRESS..NUM_BYTES_STORAGE_SLOT],
-    );
+    let slot = U256::from_str(PROXY_ADMIN_STORAGE_SLOT).unwrap();
+    let slot_value = client
+        .provider()
+        .get_storage_at(proxy_address, slot)
+        .await
+        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?;
+    let addr_bytes = &slot_value.to_be_bytes_vec()
+        [NUM_BYTES_STORAGE_SLOT - NUM_BYTES_ADDRESS..NUM_BYTES_STORAGE_SLOT];
+    let proxy_admin_address = Address::from_slice(addr_bytes);
 
     info!("Proxy admin contract deployed at address:\n\t{:#x}", proxy_admin_address);
 
@@ -404,30 +389,16 @@ async fn deploy_proxy(
 
 /// Deploys the `Permit2` contract
 pub async fn deploy_permit2(
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     // Get Permit2 contract ABI and bytecode
-    let abi: Contract = serde_json::from_str(PERMIT2_ABI)
-        .map_err(|e| ScriptError::ArtifactParsing(e.to_string()))?;
-
-    let bytecode = Bytes::from_hex(PERMIT2_BYTECODE)
-        .map_err(|e| ScriptError::ArtifactParsing(e.to_string()))?;
-
-    let permit2_factory = ContractFactory::new(abi, bytecode, client.clone());
-
-    let permit2_contract = permit2_factory
-        .deploy(())
-        .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?
-        .confirmations(NUM_DEPLOY_CONFIRMATIONS)
-        .send()
+    let permit2 = Permit2::deploy(client.provider())
         .await
         .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?;
-
-    let permit2_address = permit2_contract.address();
+    let permit2_address = *permit2.address();
 
     info!("Permit2 contract deployed at address:\n\t{:#x}", permit2_address);
-
     write_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY, permit2_address)
 }
 
@@ -438,7 +409,7 @@ pub async fn deploy_erc20(
     args: &DeployErc20Args,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<Address, ScriptError> {
     if !args.account_skeys.is_empty() && args.funding_amount.is_none() {
@@ -465,7 +436,8 @@ pub async fn deploy_erc20(
 
     set_erc20_params(erc20_address, client.clone(), args).await?;
     if args.as_wrapper {
-        fund_wrapper_contract(erc20_address, WRAPPER_FUNDING_AMOUNT.into(), client).await?;
+        let funding_amt = U256::from(WRAPPER_FUNDING_AMOUNT);
+        fund_wrapper_contract(erc20_address, funding_amt, client).await?;
     }
 
     if !args.account_skeys.is_empty() {
@@ -483,16 +455,16 @@ pub async fn deploy_erc20(
 /// Sets the symbol, name, and decimals parameters for the ERC20 contract
 async fn set_erc20_params(
     erc20_address: Address,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     args: &DeployErc20Args,
 ) -> Result<(), ScriptError> {
-    let erc20 = DummyErc20Contract::new(erc20_address, client);
+    let erc20 = DummyErc20::new(erc20_address, client.provider());
 
     info!("Setting {} contract parameters", args.symbol);
 
-    send_contract_call(erc20.set_symbol(args.symbol.clone())).await?;
-    send_contract_call(erc20.set_name(args.name.clone())).await?;
-    send_contract_call(erc20.set_decimals(args.decimals)).await?;
+    send_tx(erc20.setSymbol(args.symbol.clone())).await?;
+    send_tx(erc20.setName(args.name.clone())).await?;
+    send_tx(erc20.setDecimals(args.decimals)).await?;
 
     Ok(())
 }
@@ -507,16 +479,16 @@ async fn fund_and_approve_erc20(
     permit2_address: Address,
 ) -> Result<(), ScriptError> {
     let account_client = setup_client(recipient_skey, rpc_url).await?;
-    let account_address = account_client.default_sender().unwrap();
-    let erc20 = DummyErc20Contract::new(erc20_address, account_client);
+    let account_address = account_client.address();
+    let erc20 = DummyErc20::new(erc20_address, account_client.provider());
 
     let funding_amount = args.funding_amount.unwrap();
     let symbol = args.symbol.clone();
 
     info!("Funding {:#x} with {} {} & approving Permit2", account_address, funding_amount, symbol);
 
-    send_contract_call(erc20.mint(account_address, EthersU256::from(funding_amount))).await?;
-    send_contract_call(erc20.approve(permit2_address, EthersU256::MAX)).await?;
+    send_tx(erc20.mint(account_address, U256::from(funding_amount))).await?;
+    send_tx(erc20.approve(permit2_address, U256::MAX)).await?;
 
     Ok(())
 }
@@ -524,12 +496,12 @@ async fn fund_and_approve_erc20(
 /// Fund a wrapper contract with ETH after it is deployed
 async fn fund_wrapper_contract(
     wrapper_address: Address,
-    value: EthersU256,
-    client: Arc<LocalWalletHttpClient>,
+    value: U256,
+    client: LocalWalletHttpClient,
 ) -> Result<(), ScriptError> {
-    let weth_contract = DummyWethContract::new(wrapper_address, client);
+    let weth_contract = DummyWeth::new(wrapper_address, client.provider());
     let call = weth_contract.deposit().value(value);
-    send_contract_call(call).await.map(|_| ())
+    send_tx(call).await.map(|_| ())
 }
 
 /// Builds and deploys a Stylus contract,
@@ -538,7 +510,7 @@ pub async fn build_and_deploy_stylus_contract(
     args: &DeployStylusArgs,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<Address, ScriptError> {
     // Build the contract to WASM
@@ -557,11 +529,11 @@ pub async fn build_and_deploy_stylus_contract(
 /// Upgrades the darkpool implementation
 pub async fn upgrade(
     args: &UpgradeArgs,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
     let proxy_admin_address = read_deployment_address(deployments_path, PROXY_ADMIN_CONTRACT_KEY)?;
-    let proxy_admin = ProxyAdminContract::new(proxy_admin_address, client);
+    let proxy_admin = ProxyAdmin::new(proxy_admin_address, client.provider());
 
     let proxy_address = read_deployment_address(deployments_path, PROXY_CONTRACT_KEY)?;
 
@@ -574,10 +546,9 @@ pub async fn upgrade(
         Bytes::new()
     };
 
-    send_contract_call(proxy_admin.upgrade_and_call(proxy_address, implementation_address, data))
-        .await?;
-
-    Ok(())
+    send_tx(proxy_admin.upgradeAndCall(proxy_address, implementation_address, data))
+        .await
+        .map(|_| ())
 }
 
 /// Computes verification keys for the protocol circuits

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -1,24 +1,28 @@
 //! Constants used in the deploy scripts
 
-/// The ABI of the `TransparentUpgradeableProxy` contract
-///
-/// Compiled from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
-pub const PROXY_ABI: &str = include_str!("../artifacts/TransparentUpgradeableProxy.abi");
+use alloy::sol;
 
-/// The bytecode of the `TransparentUpgradeableProxy` contract
-///
-/// Compiled from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
-pub const PROXY_BYTECODE: &str = include_str!("../artifacts/TransparentUpgradeableProxy.bin");
+// The ABI of the `TransparentUpgradeableProxy` contract
+//
+// Compiled from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+sol! {
+    #[allow(missing_docs)]
+    #[sol(bytecode = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts/TransparentUpgradeableProxy.bin")))]
+    #[sol(rpc)]
+    TransparentUpgradeableProxy,
+    "artifacts/TransparentUpgradeableProxy.abi"
+}
 
-/// The ABI of the `Permit2` contract
-///
-/// Compiled from https://github.com/Uniswap/permit2/blob/main/src/Permit2.sol
-pub const PERMIT2_ABI: &str = include_str!("../artifacts/Permit2.abi");
-
-/// The bytecode of the `Permit2` contract
-///
-/// Compiled from https://github.com/Uniswap/permit2/blob/main/src/Permit2.sol
-pub const PERMIT2_BYTECODE: &str = include_str!("../artifacts/Permit2.bin");
+// The ABI of the `Permit2` contract
+//
+// Compiled from https://github.com/Uniswap/permit2/blob/main/src/Permit2.sol
+sol! {
+    #[allow(missing_docs)]
+    #[sol(bytecode = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts/Permit2.bin")))]
+    #[sol(rpc)]
+    Permit2,
+    "artifacts/Permit2.abi"
+}
 
 /// The number of confirmations to wait for the contract deployment transaction
 pub const NUM_DEPLOY_CONFIRMATIONS: usize = 0;

--- a/scripts/src/main.rs
+++ b/scripts/src/main.rs
@@ -8,6 +8,5 @@ async fn main() -> Result<(), ScriptError> {
     tracing_subscriber::fmt().pretty().init();
 
     let client = setup_client(&priv_key, &rpc_url).await?;
-
     command.run(client, &rpc_url, &priv_key, &deployments_path).await
 }

--- a/scripts/src/solidity.rs
+++ b/scripts/src/solidity.rs
@@ -1,7 +1,6 @@
 //! Definitions of Solidity functions called during deployment
 
 use alloy_sol_types::sol;
-use ethers::contract::abigen;
 
 sol! {
     // Darkpool initialization ABI
@@ -10,33 +9,33 @@ sol! {
     function initialize(address memory darkpool_address, address memory auth_address) external;
 }
 
-abigen!(
-    ProxyAdminContract,
-    r#"[
+sol! {
+    #[sol(rpc)]
+    contract ProxyAdmin {
         function upgradeAndCall(address proxy, address implementation, bytes memory data) external;
-    ]"#,
-);
+    }
+}
 
-abigen!(
-    DummyErc20Contract,
-    r#"[
-        function totalSupply() external view returns (uint256)
-        function setName(string name) external
-        function setSymbol(string symbol) external
-        function setDecimals(uint8 decimals) external
-        function balanceOf(address account) external view returns (uint256)
-        function mint(address memory _address, uint256 memory value) external
-        function transfer(address to, uint256 value) external returns (bool)
-        function allowance(address owner, address spender) external view returns (uint256)
-        function approve(address spender, uint256 value) external returns (bool)
-        function transferFrom(address from, address to, uint256 value) external returns (bool)
-    ]"#
-);
+sol! {
+    #[sol(rpc)]
+    contract DummyErc20 {
+        function totalSupply() external view returns (uint256);
+        function setName(string name) external;
+        function setSymbol(string symbol) external;
+        function setDecimals(uint8 decimals) external;
+        function balanceOf(address account) external view returns (uint256);
+        function mint(address memory _address, uint256 memory value) external;
+        function transfer(address to, uint256 value) external returns (bool);
+        function allowance(address owner, address spender) external view returns (uint256);
+        function approve(address spender, uint256 value) external returns (bool);
+        function transferFrom(address from, address to, uint256 value) external returns (bool);
+    }
+}
 
-abigen!(
-    DummyWethContract,
-    r#"[
-        function deposit() external payable
-        function withdrawTo(address to, uint256 value) external
-    ]"#,
-);
+sol! {
+    #[sol(rpc)]
+    contract DummyWeth {
+        function deposit() external payable;
+        function withdrawTo(address to, uint256 value) external;
+    }
+}

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utilities for the deploy scripts.
 
 use std::{
+    borrow::Borrow,
     env,
     fs::{self, File},
     io::Read,
@@ -8,27 +9,26 @@ use std::{
     path::PathBuf,
     process::{Command, Stdio},
     str::FromStr,
-    sync::Arc,
 };
 
-use alloy_primitives::{Address as AlloyAddress, U256};
+use alloy::{
+    network::Ethereum,
+    primitives::Address,
+    providers::{DynProvider, Provider, ProviderBuilder},
+    rpc::types::TransactionReceipt,
+    signers::local::PrivateKeySigner,
+    transports::http::reqwest::Url,
+};
+use alloy_contract::{CallBuilder, CallDecoder};
+use alloy_primitives::U256;
 use alloy_sol_types::SolCall;
 use ark_ed_on_bn254::EdwardsProjective as BabyJubJubProjective;
 use contracts_common::{custom_serde::scalar_to_u256, types::PublicEncryptionKey};
-use ethers::{
-    abi::{Address, Detokenize},
-    contract::ContractCall,
-    middleware::SignerMiddleware,
-    providers::{Http, Middleware, Provider},
-    signers::{LocalWallet, Signer},
-    types::TransactionReceipt,
-    utils::get_contract_address,
-};
 use itertools::Itertools;
 use json::JsonValue;
 use rand::{distributions::Standard, thread_rng, Rng};
 use tracing::log::warn;
-use util::hex::jubjub_from_hex_string;
+use util::{err_str, hex::jubjub_from_hex_string};
 
 use crate::{
     constants::{
@@ -45,9 +45,47 @@ use crate::{
     types::StylusContract,
 };
 
+/// The call builder type used in the scripts
+pub(crate) type EthereumCall<'a, C> = CallBuilder<(), &'a DynProvider, C, Ethereum>;
+
 /// An Ethers provider that uses a `LocalWallet` to generate signatures
 /// & interfaces with the RPC endpoint over HTTP
-pub type LocalWalletHttpClient = SignerMiddleware<Provider<Http>, LocalWallet>;
+#[derive(Clone)]
+pub struct LocalWalletHttpClient {
+    /// The underlying provider
+    provider: DynProvider<Ethereum>,
+    /// The signer
+    signer: PrivateKeySigner,
+}
+
+impl Borrow<DynProvider<Ethereum>> for LocalWalletHttpClient {
+    fn borrow(&self) -> &DynProvider<Ethereum> {
+        &self.provider
+    }
+}
+
+impl LocalWalletHttpClient {
+    /// Creates a new LocalWalletHttpClient
+    pub fn new(signer: PrivateKeySigner, url: Url) -> Self {
+        let provider = ProviderBuilder::new().wallet(signer.clone()).on_http(url);
+        Self { provider: DynProvider::new(provider), signer }
+    }
+
+    /// Return a reference to the underlying provider
+    pub fn provider(&self) -> DynProvider<Ethereum> {
+        self.provider.clone()
+    }
+
+    /// Returns the signer
+    pub fn signer(&self) -> &PrivateKeySigner {
+        &self.signer
+    }
+
+    /// Returns the address of the signer
+    pub fn address(&self) -> Address {
+        self.signer.address()
+    }
+}
 
 /// Sets up the address and client with which to instantiate a contract for
 /// testing, reading in the private key, RPC url, and contract address from the
@@ -55,32 +93,24 @@ pub type LocalWalletHttpClient = SignerMiddleware<Provider<Http>, LocalWallet>;
 pub async fn setup_client(
     priv_key: &str,
     rpc_url: &str,
-) -> Result<Arc<LocalWalletHttpClient>, ScriptError> {
-    let provider = Provider::<Http>::try_from(rpc_url)
-        .map_err(|e| ScriptError::ClientInitialization(e.to_string()))?;
+) -> Result<LocalWalletHttpClient, ScriptError> {
+    let url = Url::parse(rpc_url).map_err(err_str!(ScriptError::ClientInitialization))?;
+    let signer = PrivateKeySigner::from_str(priv_key)
+        .map_err(err_str!(ScriptError::ClientInitialization))?;
 
-    let wallet = LocalWallet::from_str(priv_key)
-        .map_err(|e| ScriptError::ClientInitialization(e.to_string()))?;
-    let chain_id = provider
-        .get_chainid()
-        .await
-        .map_err(|e| ScriptError::ClientInitialization(e.to_string()))?
-        .as_u64();
-    let client = Arc::new(SignerMiddleware::new(provider, wallet.clone().with_chain_id(chain_id)));
-
-    Ok(client)
+    Ok(LocalWalletHttpClient::new(signer, url))
 }
 
 /// Sends a contract call, waiting for the transaction to go from pending to
 /// executed, and returns the transaction receipt
-pub async fn send_contract_call<M: Middleware, D: Detokenize>(
-    call: ContractCall<M, D>,
+pub async fn send_tx<C: CallDecoder + Unpin>(
+    call: EthereumCall<'_, C>,
 ) -> Result<Option<TransactionReceipt>, ScriptError> {
-    call.send()
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))?
-        .await
-        .map_err(|e| ScriptError::ContractInteraction(e.to_string()))
+    let pending_tx = call.send().await.map_err(err_str!(ScriptError::ContractInteraction))?;
+    let receipt =
+        pending_tx.get_receipt().await.map_err(err_str!(ScriptError::ContractInteraction))?;
+
+    Ok(Some(receipt))
 }
 
 /// Parses the JSON file at the given path
@@ -220,8 +250,7 @@ pub fn get_protocol_external_fee_collection_address(
     if let Some(addr_str) = arg {
         Address::from_str(&addr_str).map_err(|e| ScriptError::PubkeyParsing(e.to_string()))
     } else {
-        let mut rng = thread_rng();
-        Ok(Address::random_using(&mut rng))
+        Ok(Address::random())
     }
 }
 
@@ -240,21 +269,10 @@ pub fn darkpool_initialize_calldata(
     protocol_public_encryption_key: PublicEncryptionKey,
     protocol_external_fee_collection_address: Address,
 ) -> Result<Vec<u8>, ScriptError> {
-    let core_wallet_ops_address = AlloyAddress::from_slice(core_wallet_ops_address.as_bytes());
-    let core_settlement_address = AlloyAddress::from_slice(core_settlement_address.as_bytes());
-    let verifier_core_address = AlloyAddress::from_slice(verifier_core_address.as_bytes());
-    let verifier_settlement_address =
-        AlloyAddress::from_slice(verifier_settlement_address.as_bytes());
-    let vkeys_address = AlloyAddress::from_slice(vkeys_address.as_bytes());
-    let merkle_address = AlloyAddress::from_slice(merkle_address.as_bytes());
-    let transfer_executor_address = AlloyAddress::from_slice(transfer_executor_address.as_bytes());
-    let permit2_address = AlloyAddress::from_slice(permit2_address.as_bytes());
     let protocol_public_encryption_key = [
         scalar_to_u256(protocol_public_encryption_key.x),
         scalar_to_u256(protocol_public_encryption_key.y),
     ];
-    let protocol_external_fee_collection_address =
-        AlloyAddress::from_slice(protocol_external_fee_collection_address.as_bytes());
 
     Ok(darkpool_initialize_call::new((
         core_wallet_ops_address,
@@ -277,9 +295,6 @@ pub fn gas_sponsor_initialize_calldata(
     darkpool_address: Address,
     auth_address: Address,
 ) -> Result<Vec<u8>, ScriptError> {
-    let darkpool_address = AlloyAddress::from_slice(darkpool_address.as_bytes());
-    let auth_address = AlloyAddress::from_slice(auth_address.as_bytes());
-
     Ok(gas_sponsor_initialize_call::new((darkpool_address, auth_address)).abi_encode())
 }
 
@@ -400,7 +415,7 @@ pub async fn deploy_stylus_contract(
     wasm_file_path: PathBuf,
     rpc_url: &str,
     priv_key: &str,
-    client: Arc<LocalWalletHttpClient>,
+    client: LocalWalletHttpClient,
     contract: &StylusContract,
 ) -> Result<Address, ScriptError> {
     match contract {
@@ -412,15 +427,14 @@ pub async fn deploy_stylus_contract(
         _ => {},
     }
 
-    // Get expected deployment address
-    let deployer_address = client.default_sender().ok_or(ScriptError::ClientInitialization(
-        "client does not have sender attached".to_string(),
-    ))?;
+    // Compute the expected deployment address
+    let deployer_address = client.address();
     let deployer_nonce = client
-        .get_transaction_count(deployer_address, None /* block */)
+        .provider()
+        .get_transaction_count(deployer_address)
         .await
         .map_err(|e| ScriptError::NonceFetching(e.to_string()))?;
-    let deployed_address = get_contract_address(deployer_address, deployer_nonce);
+    let deployed_address = deployer_address.create(deployer_nonce);
 
     // Run deploy command
     let mut deploy_cmd = Command::new(CARGO_COMMAND);


### PR DESCRIPTION
### Purpose
This PR removes the `ethers` dependency from the `scripts` package, and replaces the helpers with `alloy` equivalents.

### Todo
- Remove `ethers` from the integration tests and ensure they pass

### Testing
- [x] Scripts build and run