### PR TITLE
contracts-stylus: core: core-settlement: Verify malleable match proof

### DIFF
--- a/contracts-common/src/custom_serde.rs
+++ b/contracts-common/src/custom_serde.rs
@@ -12,11 +12,12 @@ use ark_serialize::Flags;
 use crate::{
     constants::{NUM_BYTES_ADDRESS, NUM_BYTES_FELT, NUM_BYTES_U64, NUM_SCALARS_PK, NUM_U64S_FELT},
     types::{
-        BabyJubJubPoint, ExternalMatchResult, ExternalTransfer, FeeTake, G1Affine, G1BaseField,
-        G2Affine, G2BaseField, MontFp256, NoteCiphertext, OrderSettlementIndices, PublicInputs,
-        PublicSigningKey, ScalarField, ValidCommitmentsStatement, ValidFeeRedemptionStatement,
-        ValidMatchSettleAtomicStatement, ValidMatchSettleStatement,
-        ValidOfflineFeeSettlementStatement, ValidReblindStatement,
+        BabyJubJubPoint, BoundedMatchResult, ExternalMatchResult, ExternalTransfer, FeeRates,
+        FeeTake, G1Affine, G1BaseField, G2Affine, G2BaseField, MontFp256, NoteCiphertext,
+        OrderSettlementIndices, PublicInputs, PublicSigningKey, ScalarField,
+        ValidCommitmentsStatement, ValidFeeRedemptionStatement,
+        ValidMalleableMatchSettleAtomicStatement, ValidMatchSettleAtomicStatement,
+        ValidMatchSettleStatement, ValidOfflineFeeSettlementStatement, ValidReblindStatement,
         ValidRelayerFeeSettlementStatement, ValidWalletCreateStatement, ValidWalletUpdateStatement,
     },
 };
@@ -273,6 +274,20 @@ impl ScalarSerializable for ValidMatchSettleAtomicStatement {
         Ok(scalars)
     }
 }
+
+impl ScalarSerializable for ValidMalleableMatchSettleAtomicStatement {
+    fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
+        let mut scalars: Vec<ScalarField> = Vec::new();
+        scalars.extend(bounded_match_result_to_scalars(&self.match_result)?);
+        scalars.extend(fee_rates_to_scalars(&self.external_fee_rates));
+        scalars.extend(fee_rates_to_scalars(&self.internal_fee_rates));
+        scalars.extend(&self.internal_party_public_shares);
+        scalars.push(address_to_scalar(self.relayer_fee_address)?);
+
+        Ok(scalars)
+    }
+}
+
 impl ScalarSerializable for ValidRelayerFeeSettlementStatement {
     fn serialize_to_scalars(&self) -> Result<Vec<ScalarField>, SerdeError> {
         let mut scalars: Vec<ScalarField> = vec![
@@ -401,6 +416,25 @@ fn external_match_result_to_scalars(
         amount_to_scalar(external_match_result.base_amount)?,
         external_match_result.direction.into(),
     ])
+}
+
+/// Converts a [`BoundedMatchResult`] into a vector of [`ScalarField`]s
+fn bounded_match_result_to_scalars(
+    bounded_match_result: &BoundedMatchResult,
+) -> Result<Vec<ScalarField>, SerdeError> {
+    Ok(vec![
+        address_to_scalar(bounded_match_result.quote_mint)?,
+        address_to_scalar(bounded_match_result.base_mint)?,
+        bounded_match_result.price.repr,
+        amount_to_scalar(bounded_match_result.min_base_amount)?,
+        amount_to_scalar(bounded_match_result.max_base_amount)?,
+        bounded_match_result.direction.into(),
+    ])
+}
+
+/// Converts a [`FeeRates`] into a vector of [`ScalarField`]s
+fn fee_rates_to_scalars(fee_rates: &FeeRates) -> Vec<ScalarField> {
+    vec![fee_rates.relayer_fee_rate.repr, fee_rates.protocol_fee_rate.repr]
 }
 
 /// Converts a [`FeeTake`] into a vector of [`ScalarField`]s

--- a/contracts-common/src/types.rs
+++ b/contracts-common/src/types.rs
@@ -508,7 +508,6 @@ impl ExternalMatchResult {
         }
     }
 }
-
 /// A match result that specifies a range of match sizes rather than an exact
 /// base amount
 #[serde_as]
@@ -723,7 +722,7 @@ pub struct ValidMatchSettleAtomicStatement {
 
 /// Statement for the `VALID MALLEABLE MATCH SETTLE ATOMIC` circuit
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ValidMalleableMatchSettleAtomicStatement {
     /// The result of the match
     pub match_result: BoundedMatchResult,

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -19,11 +19,13 @@ use crate::{
             delegate_call_helper, deserialize_from_calldata, get_weth_address,
             is_native_eth_address, postcard_serialize,
             serialize_atomic_match_statements_for_verification,
+            serialize_malleable_match_statements_for_verification,
             serialize_match_statements_for_verification, u256_to_scalar,
         },
         solidity::{
             executeTransferBatchCall, processAtomicMatchSettleVkeysCall,
-            processMatchSettleVkeysCall, verifyAtomicMatchCall, verifyMatchCall,
+            processMalleableMatchSettleAtomicVkeysCall, processMatchSettleVkeysCall,
+            verifyAtomicMatchCall, verifyMatchCall,
         },
     },
     INVALID_TRANSACTION_VALUE_ERROR_MESSAGE,
@@ -408,8 +410,9 @@ impl CoreSettlementContract {
 
             Self::batch_verify_process_malleable_atomic_match_settle(
                 storage,
+                is_native_eth,
                 &internal_party_match_payload,
-                &malleable_match_settle_atomic_statement,
+                malleable_match_settle_atomic_statement.clone(),
                 proofs,
                 linking_proofs,
             )?;
@@ -433,6 +436,8 @@ impl CoreSettlementContract {
             match_result,
             relayer_fee_address,
         )?;
+
+        Ok(())
     }
 }
 
@@ -534,12 +539,46 @@ impl CoreSettlementContract {
         S: TopLevelStorage + BorrowMut<Self>,
     >(
         storage: &mut S,
+        is_native_eth: bool,
         internal_party_match_payload: &MatchPayload,
-        malleable_match_settle_atomic_statement: &ValidMalleableMatchSettleAtomicStatement,
+        mut malleable_match_settle_atomic_statement: ValidMalleableMatchSettleAtomicStatement,
         proofs: Bytes,
         linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
-        todo!("implement handler")
+        let process_malleable_match_settle_atomic_vkeys =
+            fetch_vkeys(storage, &processMalleableMatchSettleAtomicVkeysCall::SELECTOR)?;
+
+        if is_native_eth {
+            let weth = get_weth_address();
+            malleable_match_settle_atomic_statement.match_result.base_mint = weth;
+        }
+
+        // Serialize the statements into a set of public inputs
+        let malleable_match_public_inputs = serialize_malleable_match_statements_for_verification(
+            &internal_party_match_payload.valid_commitments_statement,
+            &internal_party_match_payload.valid_reblind_statement,
+            &malleable_match_settle_atomic_statement,
+        )?;
+
+        // The calldata to the verifier is the same as in the standard atomic match
+        // call, though the proofs and verification keys represent a different
+        // relation. We can reuse the same types here for this reason
+        let verifier_address = storage.borrow_mut().verifier_core_address();
+        let calldata = VerifyAtomicMatchCalldata {
+            verifier_address,
+            match_atomic_vkeys: process_malleable_match_settle_atomic_vkeys,
+            match_atomic_proofs: proofs.0,
+            match_atomic_public_inputs: malleable_match_public_inputs,
+            match_atomic_linking_proofs: linking_proofs.0,
+        };
+
+        let calldata_bytes = postcard_serialize(&calldata)?;
+        let result = call_settlement_verifier::<_, _, verifyAtomicMatchCall>(
+            storage,
+            (calldata_bytes.into(),),
+        )?;
+
+        assert_result!(result._0, VERIFICATION_FAILED_ERROR_MESSAGE)
     }
 
     /// Execute the transfers to/from the external party in an atomic match

--- a/contracts-stylus/src/contracts/vkeys.rs
+++ b/contracts-stylus/src/contracts/vkeys.rs
@@ -5,10 +5,10 @@ use alloc::vec::Vec;
 use stylus_sdk::{abi::Bytes, prelude::*};
 
 use crate::utils::constants::{
-    PROCESS_ATOMIC_MATCH_SETTLE_VKEYS_BYTES, PROCESS_MATCH_SETTLE_VKEYS_BYTES,
-    VALID_FEE_REDEMPTION_VKEY_BYTES, VALID_OFFLINE_FEE_SETTLEMENT_VKEY_BYTES,
-    VALID_RELAYER_FEE_SETTLEMENT_VKEY_BYTES, VALID_WALLET_CREATE_VKEY_BYTES,
-    VALID_WALLET_UPDATE_VKEY_BYTES,
+    PROCESS_ATOMIC_MATCH_SETTLE_VKEYS_BYTES, PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_BYTES,
+    PROCESS_MATCH_SETTLE_VKEYS_BYTES, VALID_FEE_REDEMPTION_VKEY_BYTES,
+    VALID_OFFLINE_FEE_SETTLEMENT_VKEY_BYTES, VALID_RELAYER_FEE_SETTLEMENT_VKEY_BYTES,
+    VALID_WALLET_CREATE_VKEY_BYTES, VALID_WALLET_UPDATE_VKEY_BYTES,
 };
 
 /// The verification keys contract, which itself is stateless
@@ -61,5 +61,14 @@ impl VkeysContract {
     /// MATCH SETTLE ATOMIC`] linking verification keys
     pub fn process_atomic_match_settle_vkeys(&self) -> Result<Bytes, Vec<u8>> {
         Ok(PROCESS_ATOMIC_MATCH_SETTLE_VKEYS_BYTES.to_vec().into())
+    }
+
+    /// Returns the serialization of the
+    /// [`VALID COMMITMENTS`, `VALID REBLIND`, `VALID MALLEABLE MATCH SETTLE
+    /// ATOMIC`] Plonk verification keys, concatenated with the serialzation
+    /// of the [`VALID REBLIND <-> VALID COMMITMENTS`, `VALID COMMITMENTS
+    /// <-> VALID MALLEABLE MATCH SETTLE ATOMIC`] linking verification keys
+    pub fn process_malleable_atomic_match_settle_vkeys(&self) -> Result<Bytes, Vec<u8>> {
+        Ok(PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_BYTES.to_vec().into())
     }
 }

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -249,6 +249,20 @@ pub const PROCESS_ATOMIC_MATCH_SETTLE_VKEYS_BYTES: &[u8] =
 pub const PROCESS_ATOMIC_MATCH_SETTLE_VKEYS_BYTES: &[u8] =
     include_bytes!("../../vkeys/test/process_match_settle_atomic");
 
+/// The serialized
+/// [VALID COMMITMENTS, VALID REBLIND, VALID MALLEABLE MATCH SETTLE ATOMIC]
+/// verification keys
+#[cfg(feature = "vkeys")]
+pub const PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_BYTES: &[u8] =
+    include_bytes!("../../vkeys/prod/process_malleable_match_settle_atomic");
+
+/// The serialized testing
+/// [VALID COMMITMENTS, VALID REBLIND, VALID MALLEABLE MATCH SETTLE ATOMIC]
+/// verification keys
+#[cfg(feature = "test-vkeys")]
+pub const PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_BYTES: &[u8] =
+    include_bytes!("../../vkeys/test/process_malleable_match_settle_atomic");
+
 /// The path of values in an empty Merkle tree of height `TEST_MERKLE_HEIGHT`,
 /// going from root to leaf
 #[cfg_attr(not(feature = "merkle-test-contract"), allow(dead_code))]

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -8,8 +8,8 @@ use contracts_common::{
     custom_serde::{bigint_from_le_bytes, statement_to_public_inputs, ScalarSerializable},
     types::{
         MatchAtomicPublicInputs, MatchPublicInputs, PublicSigningKey, ScalarField,
-        ValidCommitmentsStatement, ValidMatchSettleAtomicStatement, ValidMatchSettleStatement,
-        ValidReblindStatement,
+        ValidCommitmentsStatement, ValidMalleableMatchSettleAtomicStatement,
+        ValidMatchSettleAtomicStatement, ValidMatchSettleStatement, ValidReblindStatement,
     },
 };
 use contracts_core::crypto::ecdsa::ecdsa_verify_with_pubkey;
@@ -112,6 +112,26 @@ pub fn serialize_atomic_match_statements_for_verification(
     valid_commitments: &ValidCommitmentsStatement,
     valid_reblind: &ValidReblindStatement,
     valid_match_settle_atomic: &ValidMatchSettleAtomicStatement,
+) -> Result<Vec<u8>, Vec<u8>> {
+    let match_atomic_public_inputs = MatchAtomicPublicInputs {
+        valid_commitments: statement_to_public_inputs(valid_commitments)
+            .map_err(map_calldata_ser_error)?,
+        valid_reblind: statement_to_public_inputs(valid_reblind).map_err(map_calldata_ser_error)?,
+        valid_match_settle_atomic: statement_to_public_inputs(valid_match_settle_atomic)
+            .map_err(map_calldata_ser_error)?,
+    };
+    postcard_serialize(&match_atomic_public_inputs)
+}
+
+/// Serializes the statements used in verifying the settlement of a
+/// matched trade into scalars, builds the [`MatchPublicInputs`] struct,
+/// and then serialized it into bytes, as expected by the verifier
+/// contract.
+#[cfg_attr(not(feature = "core-settlement"), allow(dead_code))]
+pub fn serialize_malleable_match_statements_for_verification(
+    valid_commitments: &ValidCommitmentsStatement,
+    valid_reblind: &ValidReblindStatement,
+    valid_match_settle_atomic: &ValidMalleableMatchSettleAtomicStatement,
 ) -> Result<Vec<u8>, Vec<u8>> {
     let match_atomic_public_inputs = MatchAtomicPublicInputs {
         valid_commitments: statement_to_public_inputs(valid_commitments)

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -36,6 +36,7 @@ sol! {
     function validWalletUpdateVkey() external view returns (bytes);
     function processMatchSettleVkeys() external view returns (bytes);
     function processAtomicMatchSettleVkeys() external view returns (bytes);
+    function processMalleableMatchSettleAtomicVkeys() external view returns (bytes);
     function validRelayerFeeSettlementVkey() external view returns (bytes);
     function validOfflineFeeSettlementVkey() external view returns (bytes);
     function validFeeRedemptionVkey() external view returns (bytes);


### PR DESCRIPTION
### Purpose
This PR validates the proof of `VALID MALLEABLE MATCH SETTLE ATOMIC` in the malleable match handler. This handler can re-use the types and verifier calls of the standard `VALID MATCH SETTLE ATOMIC` path, as the *shape* of the proof bundles is the same; though they encode different relations.

### Testing
- Deferred until implementation complete