### PR TITLE
contracts-stylus: core-settlement: Apply malleable match to wallet shares

### DIFF
--- a/contracts-common/src/types/keys.rs
+++ b/contracts-common/src/types/keys.rs
@@ -36,3 +36,39 @@ pub struct BabyJubJubPoint {
 
 /// A BabyJubJub EC-ElGamal public encryption key
 pub type PublicEncryptionKey = BabyJubJubPoint;
+
+/// A public identification key used for proving knowledge of preimages
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct PublicIdentificationKey {
+    /// The public key - this is the image under hash of its corresponding
+    /// secret key
+    #[serde_as(as = "ScalarFieldDef")]
+    pub key: ScalarField,
+}
+
+/// A public root key, which is a scalar field representation of a secp256k1
+/// public key
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct PublicRootKey {
+    /// The x coordinate of the public key
+    #[serde_as(as = "[ScalarFieldDef; 2]")]
+    pub x: [ScalarField; 2],
+    /// The y coordinate of the public key  
+    #[serde_as(as = "[ScalarFieldDef; 2]")]
+    pub y: [ScalarField; 2],
+}
+
+/// A public keychain containing public keys for various wallet operations
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct PublicKeychain {
+    /// The public root key
+    pub pk_root: PublicRootKey,
+    /// The public match key used by relayers to authorize matches
+    pub pk_match: PublicIdentificationKey,
+    /// The nonce of the keychain, allowing rotation and recovery
+    #[serde_as(as = "ScalarFieldDef")]
+    pub nonce: ScalarField,
+}

--- a/contracts-common/src/types/mod.rs
+++ b/contracts-common/src/types/mod.rs
@@ -1,6 +1,8 @@
 //! Types common to all contracts
+use ark_ff::PrimeField;
 
 mod proof_system;
+use alloy_primitives::U256;
 pub use proof_system::*;
 mod transfers;
 pub use transfers::*;
@@ -12,3 +14,17 @@ mod keys;
 pub use keys::*;
 mod statements;
 pub use statements::*;
+mod wallet;
+pub use wallet::*;
+
+use crate::{
+    constants::{NUM_BYTES_U256, SCALAR_CONVERSION_ERROR_MESSAGE},
+    custom_serde::bigint_from_le_bytes,
+};
+
+/// Converts a U256 to a scalar
+pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, Vec<u8>> {
+    let bigint = bigint_from_le_bytes(&u256.to_le_bytes::<NUM_BYTES_U256>())
+        .map_err(|_| SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())?;
+    ScalarField::from_bigint(bigint).ok_or(SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())
+}

--- a/contracts-common/src/types/statements.rs
+++ b/contracts-common/src/types/statements.rs
@@ -65,7 +65,7 @@ pub struct ValidReblindStatement {
 
 /// The indices that specify where settlement logic should modify the wallet
 /// shares
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderSettlementIndices {
     /// The index of the balance that holds the mint that the wallet will
     /// send if a successful match occurs

--- a/contracts-common/src/types/wallet.rs
+++ b/contracts-common/src/types/wallet.rs
@@ -1,0 +1,234 @@
+//! Types related to darkpool wallets
+
+use super::{
+    u256_to_scalar, ExternalMatchResult, FeeRates, FixedPoint, OrderSettlementIndices,
+    PublicEncryptionKey, PublicKeychain, ScalarField,
+};
+use crate::types::{BabyJubJubPoint, PublicIdentificationKey, PublicRootKey};
+use alloc::vec::Vec;
+
+/// Error message for when a vector cannot be sized into an array
+pub const VEC_SIZE_ERROR: &[u8] = b"Vector length does not match array size";
+
+/// The maximum number of balances in a wallet
+pub const MAX_BALANCES: usize = 10;
+/// The maximum number of orders in a wallet
+pub const MAX_ORDERS: usize = 4;
+/// The number of scalars in a serialized wallet share
+pub const NUM_WALLET_SCALARS: usize = 70;
+
+/// Helper function to size a vector into an array
+pub fn size_vec<T, const N: usize>(vec: Vec<T>) -> Result<[T; N], Vec<u8>> {
+    vec.try_into().map_err(|_| VEC_SIZE_ERROR.to_vec())
+}
+
+/// A secret share of a darkpool wallet
+#[cfg(feature = "core-settlement")]
+pub struct WalletShare {
+    /// The list of balances in the wallet
+    pub balances: [BalanceShare; MAX_BALANCES],
+    /// The list of orders in the wallet
+    pub orders: [OrderShare; MAX_ORDERS],
+    /// The keychain of the wallet
+    pub keychain: PublicKeychain,
+    /// The maximum match fee that the user is willing to pay for a match
+    pub max_match_fee: FixedPoint,
+    /// The public key of the cluster that the wallet has authorized to collect
+    /// match fees
+    pub managing_cluster: PublicEncryptionKey,
+    /// The public share of the wallet's blinder
+    pub blinder: ScalarField,
+}
+
+#[cfg(feature = "core-settlement")]
+impl WalletShare {
+    /// Apply an external match to a wallet's shares
+    ///
+    /// SAFETY: It is assumed that all balance increment/decrements have been
+    /// checked for overflow elsewhere, e.g. in-circuit
+    pub fn apply_external_match_to_shares(
+        &mut self,
+        internal_party_fee_rate: FeeRates,
+        match_result: &ExternalMatchResult,
+        indices: OrderSettlementIndices,
+    ) {
+        // Deduct the matched amount from the order's volume
+        let base_amt_scalar = u256_to_scalar(match_result.base_amount).unwrap();
+        self.orders[indices.order as usize].amount -= base_amt_scalar;
+
+        // Compute the fees owed by the internal party
+        let (_, recv_amount) = match_result.external_party_sell_mint_amount();
+        let (_, send_amount) = match_result.external_party_buy_mint_amount();
+        let internal_party_fees = internal_party_fee_rate.get_fee_take(recv_amount);
+
+        // Add the receive amount to the wallet's balances
+        let net_receive_amount = recv_amount - internal_party_fees.total();
+        let recv_bal = &mut self.balances[indices.balance_receive as usize];
+
+        recv_bal.amount += u256_to_scalar(net_receive_amount).unwrap();
+        recv_bal.relayer_fee_balance += u256_to_scalar(internal_party_fees.relayer_fee).unwrap();
+        recv_bal.protocol_fee_balance += u256_to_scalar(internal_party_fees.protocol_fee).unwrap();
+
+        // Deduct the send amount from the wallet's balances
+        let send_bal = &mut self.balances[indices.balance_send as usize];
+        send_bal.amount -= u256_to_scalar(send_amount).unwrap();
+    }
+
+    /// Serialize a wallet share into a list of scalars
+    pub fn scalar_serialize(&self) -> [ScalarField; NUM_WALLET_SCALARS] {
+        let mut scalars = [ScalarField::default(); NUM_WALLET_SCALARS];
+        let mut offset = 0;
+
+        // Serialize the balances
+        for balance in &self.balances {
+            scalars[offset] = balance.token;
+            scalars[offset + 1] = balance.amount;
+            scalars[offset + 2] = balance.relayer_fee_balance;
+            scalars[offset + 3] = balance.protocol_fee_balance;
+            offset += 4;
+        }
+
+        // Serialize the orders
+        for order in &self.orders {
+            scalars[offset] = order.quote_mint;
+            scalars[offset + 1] = order.base_mint;
+            scalars[offset + 2] = order.side;
+            scalars[offset + 3] = order.amount;
+            scalars[offset + 4] = order.worst_case_price;
+            offset += 5;
+        }
+
+        // Serialize the keychain
+        scalars[offset] = self.keychain.pk_root.x[0];
+        scalars[offset + 1] = self.keychain.pk_root.x[1];
+        scalars[offset + 2] = self.keychain.pk_root.y[0];
+        scalars[offset + 3] = self.keychain.pk_root.y[1];
+        scalars[offset + 4] = self.keychain.pk_match.key;
+        scalars[offset + 5] = self.keychain.nonce;
+        offset += 6;
+
+        // Serialize the max match fee
+        scalars[offset] = self.max_match_fee.repr;
+        offset += 1;
+
+        // Serialize the managing cluster
+        scalars[offset] = self.managing_cluster.x;
+        scalars[offset + 1] = self.managing_cluster.y;
+        offset += 2;
+
+        // Serialize the blinder
+        scalars[offset] = self.blinder;
+
+        scalars
+    }
+
+    /// Deserialize a wallet share from a list of scalars
+    pub fn scalar_deserialize(scalars: &[ScalarField]) -> Self {
+        assert_eq!(scalars.len(), NUM_WALLET_SCALARS, "Scalar length does not match expected size");
+        let mut offset = 0;
+
+        // Deserialize the balances
+        let mut balances_vec = Vec::with_capacity(MAX_BALANCES);
+        for _ in 0..MAX_BALANCES {
+            balances_vec.push(BalanceShare {
+                token: scalars[offset],
+                amount: scalars[offset + 1],
+                relayer_fee_balance: scalars[offset + 2],
+                protocol_fee_balance: scalars[offset + 3],
+            });
+            offset += 4;
+        }
+        let balances = size_vec(balances_vec).unwrap();
+
+        // Deserialize the orders
+        let mut orders_vec = Vec::with_capacity(MAX_ORDERS);
+        for _ in 0..MAX_ORDERS {
+            orders_vec.push(OrderShare {
+                quote_mint: scalars[offset],
+                base_mint: scalars[offset + 1],
+                side: scalars[offset + 2],
+                amount: scalars[offset + 3],
+                worst_case_price: scalars[offset + 4],
+            });
+            offset += 5;
+        }
+        let orders = size_vec(orders_vec).unwrap();
+
+        // Deserialize the keychain
+        let keychain = PublicKeychain {
+            pk_root: PublicRootKey {
+                x: [scalars[offset], scalars[offset + 1]],
+                y: [scalars[offset + 2], scalars[offset + 3]],
+            },
+            pk_match: PublicIdentificationKey { key: scalars[offset + 4] },
+            nonce: scalars[offset + 5],
+        };
+        offset += 6;
+
+        // Deserialize the max match fee
+        let max_match_fee = FixedPoint { repr: scalars[offset] };
+        offset += 1;
+
+        // Deserialize the managing cluster
+        let managing_cluster = BabyJubJubPoint { x: scalars[offset], y: scalars[offset + 1] };
+        offset += 2;
+
+        // Deserialize the blinder
+        let blinder = scalars[offset];
+        Self { balances, orders, keychain, max_match_fee, managing_cluster, blinder }
+    }
+}
+
+/// A secret share of a balance in a darkpool wallet
+#[derive(Copy, Clone, Debug)]
+pub struct BalanceShare {
+    /// The address of the token
+    pub token: ScalarField,
+    /// The amount of the balance
+    pub amount: ScalarField,
+    /// The amount of the balance owed to the managing relayer cluster
+    pub relayer_fee_balance: ScalarField,
+    /// The amount of the balance owed to the protocol
+    pub protocol_fee_balance: ScalarField,
+}
+
+/// A secret share of an order in a darkpool wallet
+#[derive(Clone, Copy, Debug)]
+pub struct OrderShare {
+    /// The address of the quote token
+    pub quote_mint: ScalarField,
+    /// The address of the base token
+    pub base_mint: ScalarField,
+    /// The direction of the order (buy/sell)
+    pub side: ScalarField,
+    /// The amount of the order
+    pub amount: ScalarField,
+    /// The worst case price that the user is willing to accept on this order.
+    /// For buy orders, this is the maximum price willing to pay.
+    /// For sell orders, this is the minimum price willing to accept.
+    pub worst_case_price: ScalarField,
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ff::UniformRand;
+    use rand::thread_rng;
+
+    use super::*;
+
+    #[test]
+    fn test_scalar_serialize_deserialize() {
+        // Generate random scalars
+        let mut rng = thread_rng();
+        let mut scalars = Vec::new();
+        for _ in 0..NUM_WALLET_SCALARS {
+            scalars.push(ScalarField::rand(&mut rng));
+        }
+
+        // Deserialize then serialize the wallet
+        let sized_scalars = size_vec(scalars).unwrap();
+        let wallet = WalletShare::scalar_deserialize(&sized_scalars);
+        let serialized = wallet.scalar_serialize();
+        assert_eq!(sized_scalars, serialized);
+    }
+}

--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         helpers::{
             delegate_call_helper, get_public_blinder_from_shares, map_call_error,
-            postcard_serialize, static_call_helper, u256_to_scalar,
+            postcard_serialize, static_call_helper,
         },
         solidity::{
             executeExternalTransferCall, insertNoteCommitmentCall, insertSharesCommitmentCall,
@@ -24,7 +24,7 @@ use alloc::{vec, vec::Vec};
 use alloy_sol_types::{SolCall, SolType};
 use contracts_common::{
     custom_serde::{pk_to_u256s, scalar_to_u256},
-    types::{ExternalTransfer, PublicEncryptionKey, PublicSigningKey, ScalarField},
+    types::{u256_to_scalar, ExternalTransfer, PublicEncryptionKey, PublicSigningKey, ScalarField},
 };
 use stylus_sdk::{abi::Bytes, alloy_primitives::U256, call::static_call, evm, prelude::*};
 

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -20,7 +20,7 @@ use crate::{
             is_native_eth_address, postcard_serialize,
             serialize_atomic_match_statements_for_verification,
             serialize_malleable_match_statements_for_verification,
-            serialize_match_statements_for_verification, u256_to_scalar,
+            serialize_match_statements_for_verification,
         },
         solidity::{
             executeTransferBatchCall, processAtomicMatchSettleVkeysCall,
@@ -33,9 +33,9 @@ use crate::{
 use alloc::{vec, vec::Vec};
 use alloy_sol_types::SolCall;
 use contracts_common::types::{
-    ExternalMatchResult, FeeTake, MatchPayload, SimpleErc20Transfer,
+    u256_to_scalar, ExternalMatchResult, FeeTake, MatchPayload, SimpleErc20Transfer,
     ValidMalleableMatchSettleAtomicStatement, ValidMatchSettleAtomicStatement,
-    ValidMatchSettleStatement, VerifyAtomicMatchCalldata, VerifyMatchCalldata,
+    ValidMatchSettleStatement, VerifyAtomicMatchCalldata, VerifyMatchCalldata, WalletShare,
 };
 use stylus_sdk::{
     abi::Bytes,
@@ -378,12 +378,12 @@ impl CoreSettlementContract {
     ) -> Result<(), Vec<u8>> {
         let internal_party_match_payload: MatchPayload =
             deserialize_from_calldata(&internal_party_match_payload)?;
-        let malleable_match_settle_atomic_statement: ValidMalleableMatchSettleAtomicStatement =
+        let statement: ValidMalleableMatchSettleAtomicStatement =
             deserialize_from_calldata(&malleable_match_settle_atomic_statement)?;
 
         // The transaction value should be zero unless the external party is selling
         // native ETH in the trade
-        let bounded_match_result = &malleable_match_settle_atomic_statement.match_result;
+        let bounded_match_result = &statement.match_result;
         let is_native_eth = is_native_eth_address(bounded_match_result.base_mint);
         let is_external_party_sell = bounded_match_result.is_external_party_sell();
         let native_eth_sell = is_native_eth && is_external_party_sell;
@@ -394,8 +394,8 @@ impl CoreSettlementContract {
         if_verifying!({
             // The protocol fee used in the proofs must match the fee configured in the
             // contract
-            let internal_fee_rates = malleable_match_settle_atomic_statement.internal_fee_rates;
-            let external_fee_rates = malleable_match_settle_atomic_statement.external_fee_rates;
+            let internal_fee_rates = statement.internal_fee_rates;
+            let external_fee_rates = statement.external_fee_rates;
             let protocol_fee_u256 =
                 storage.borrow_mut().external_match_protocol_fee(bounded_match_result.base_mint);
             let protocol_fee = u256_to_scalar(protocol_fee_u256)?;
@@ -412,7 +412,7 @@ impl CoreSettlementContract {
                 storage,
                 is_native_eth,
                 &internal_party_match_payload,
-                malleable_match_settle_atomic_statement.clone(),
+                statement.clone(),
                 proofs,
                 linking_proofs,
             )?;
@@ -421,14 +421,34 @@ impl CoreSettlementContract {
         // Build an external match result given the base amount
         let match_result = bounded_match_result.to_external_match_result(base_amount)?;
 
-        // TODO: Update the internal party's wallet
+        // Apply the external match directly to the internal party's wallet
+        let public_shares = statement.internal_party_public_shares;
+        let internal_party_fees = statement.internal_fee_rates;
+        let commitments_statement = internal_party_match_payload.valid_commitments_statement;
+        let reblind_statement = internal_party_match_payload.valid_reblind_statement;
+
+        let mut wallet_share = WalletShare::scalar_deserialize(&public_shares);
+        wallet_share.apply_external_match_to_shares(
+            internal_party_fees,
+            &match_result,
+            commitments_statement.indices,
+        );
+        let updated_public_shares = wallet_share.scalar_serialize();
+
+        rotate_wallet(
+            storage,
+            reblind_statement.original_shares_nullifier,
+            reblind_statement.merkle_root,
+            reblind_statement.reblinded_private_shares_commitment,
+            &updated_public_shares,
+        )?;
 
         // Execute the transfers to/from the external party
-        let external_party_fee_rate = malleable_match_settle_atomic_statement.external_fee_rates;
+        let external_party_fee_rate = statement.external_fee_rates;
         let (_, external_party_recv) = match_result.external_party_buy_mint_amount();
         let external_party_fees = external_party_fee_rate.get_fee_take(external_party_recv);
 
-        let relayer_fee_address = malleable_match_settle_atomic_statement.relayer_fee_address;
+        let relayer_fee_address = statement.relayer_fee_address;
         Self::execute_atomic_match_transfers(
             storage,
             receiver,

--- a/contracts-stylus/src/contracts/merkle.rs
+++ b/contracts-stylus/src/contracts/merkle.rs
@@ -14,7 +14,7 @@ use alloc::vec::Vec;
 use contracts_common::{
     constants::{MERKLE_HEIGHT, NUM_SCALARS_PK},
     custom_serde::{scalar_to_u256, BytesSerializable},
-    types::{PublicSigningKey, ScalarField},
+    types::{u256_to_scalar, PublicSigningKey, ScalarField},
 };
 use contracts_core::crypto::poseidon::compute_poseidon_hash;
 use stylus_sdk::{
@@ -29,7 +29,7 @@ use crate::{
     assert_result, if_verifying,
     utils::{
         constants::{TREE_FULL_ERROR_MESSAGE, ZEROS},
-        helpers::{assert_valid_signature, u256_to_scalar},
+        helpers::assert_valid_signature,
         solidity::{MerkleInsertion, MerkleOpeningNode},
     },
 };

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -4,10 +4,14 @@
 use core::borrow::{Borrow, BorrowMut};
 
 use alloc::vec::Vec;
-use contracts_common::constants::{
-    CORE_SETTLEMENT_ADDRESS_SELECTOR, CORE_WALLET_OPS_ADDRESS_SELECTOR, MERKLE_ADDRESS_SELECTOR,
-    TRANSFER_EXECUTOR_ADDRESS_SELECTOR, VERIFIER_CORE_ADDRESS_SELECTOR,
-    VERIFIER_SETTLEMENT_ADDRESS_SELECTOR, VKEYS_ADDRESS_SELECTOR,
+use contracts_common::{
+    constants::{
+        CORE_SETTLEMENT_ADDRESS_SELECTOR, CORE_WALLET_OPS_ADDRESS_SELECTOR,
+        MERKLE_ADDRESS_SELECTOR, TRANSFER_EXECUTOR_ADDRESS_SELECTOR,
+        VERIFIER_CORE_ADDRESS_SELECTOR, VERIFIER_SETTLEMENT_ADDRESS_SELECTOR,
+        VKEYS_ADDRESS_SELECTOR,
+    },
+    types::u256_to_scalar,
 };
 use stylus_sdk::{
     alloy_primitives::{Address, U256},
@@ -24,7 +28,7 @@ use crate::{
         darkpool::DarkpoolContract,
     },
     utils::{
-        helpers::{delegate_call_helper, u256_to_scalar},
+        helpers::delegate_call_helper,
         solidity::{init_0Call as initMerkleCall, isDummyUpgradeTargetCall},
     },
 };

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -2,10 +2,8 @@
 
 use alloc::vec::Vec;
 use alloy_sol_types::{SolCall, SolType};
-use ark_ff::PrimeField;
 use contracts_common::{
-    constants::{NUM_BYTES_U256, SCALAR_CONVERSION_ERROR_MESSAGE},
-    custom_serde::{bigint_from_le_bytes, statement_to_public_inputs, ScalarSerializable},
+    custom_serde::{statement_to_public_inputs, ScalarSerializable},
     types::{
         MatchAtomicPublicInputs, MatchPublicInputs, PublicSigningKey, ScalarField,
         ValidCommitmentsStatement, ValidMalleableMatchSettleAtomicStatement,
@@ -17,7 +15,7 @@ use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 use stylus_sdk::{
     abi::Bytes,
-    alloy_primitives::{Address, U256},
+    alloy_primitives::Address,
     call::{call, delegate_call, static_call, MutatingCallContext},
     storage::TopLevelStorage,
 };
@@ -215,21 +213,6 @@ pub fn call_helper<C: SolCall>(
     let res = call(storage, address, &calldata).map_err(map_call_error)?;
     C::abi_decode_returns(&res, false /* validate */)
         .map_err(|_| CALL_RETDATA_DECODING_ERROR_MESSAGE.to_vec())
-}
-
-/// Converts a U256 to a scalar
-#[cfg_attr(
-    not(any(
-        feature = "darkpool-test-contract",
-        feature = "merkle",
-        feature = "merkle-test-contract"
-    )),
-    allow(dead_code)
-)]
-pub fn u256_to_scalar(u256: U256) -> Result<ScalarField, Vec<u8>> {
-    let bigint = bigint_from_le_bytes(&u256.to_le_bytes::<NUM_BYTES_U256>())
-        .map_err(|_| SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())?;
-    ScalarField::from_bigint(bigint).ok_or(SCALAR_CONVERSION_ERROR_MESSAGE.to_vec())
 }
 
 /// Asserts the validity of the given signature using the given public signing


### PR DESCRIPTION
### Purpose
This PR applies the derived external match directly to the internal party's wallet shares when processing a malleable match. This is done by deserializing the shares into a runtime type, applying the update, then re-serializing for wallet rotation.

### Todo
- Split apart core settlement contract, it now is above the bytecode size limit.

### Testing
- Deferred until follow up