### PR TITLE
contracts-stylus: darkpool: Transition to delegate callee mapping

### DIFF
--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -135,27 +135,21 @@ pub struct CoreSettlementContract {
     /// Added at the bottom of the storage layout to
     /// prevent collisions with existing fields when this field was added
     pub(crate) external_match_fee_overrides: StorageMap<Address, StorageU256>,
+
+    // --- Updated Fields for Delegate Call Mappings --- //
+    /// A mapping from a "selector" to the delegate address used to call it
+    ///
+    /// The selector here is not the Solidity selector, but rather an index into
+    /// a list of delegate call addresses
+    ///
+    /// Added at the bottom of the storage layout to
+    /// prevent collisions with existing fields when this field was added
+    pub(crate) delegate_addresses: StorageMap<u64, StorageAddress>,
 }
 
 impl CoreContractStorage for CoreSettlementContract {
-    fn verifier_core_address(&self) -> Address {
-        self.verifier_core_address.get()
-    }
-
-    fn verifier_settlement_address(&self) -> Address {
-        self.verifier_settlement_address.get()
-    }
-
-    fn vkeys_address(&self) -> Address {
-        self.vkeys_address.get()
-    }
-
-    fn merkle_address(&self) -> Address {
-        self.merkle_address.get()
-    }
-
-    fn transfer_executor_address(&self) -> Address {
-        self.transfer_executor_address.get()
+    fn get_delegate_address(&self, selector: u64) -> Address {
+        self.delegate_addresses.get(selector)
     }
 
     fn nullifier_set(&self) -> &StorageMap<U256, StorageBool> {
@@ -455,9 +449,7 @@ impl CoreSettlementContract {
             external_party_fees,
             match_result,
             relayer_fee_address,
-        )?;
-
-        Ok(())
+        )
     }
 }
 

--- a/contracts-stylus/src/contracts/core/core_settlement.rs
+++ b/contracts-stylus/src/contracts/core/core_settlement.rs
@@ -28,6 +28,7 @@ use crate::{
             verifyAtomicMatchCall, verifyMatchCall,
         },
     },
+    IMPL_ADDRESS_STORAGE_GAP1_SIZE, IMPL_ADDRESS_STORAGE_GAP2_SIZE,
     INVALID_TRANSACTION_VALUE_ERROR_MESSAGE,
 };
 use alloc::{vec, vec::Vec};
@@ -76,21 +77,9 @@ pub struct CoreSettlementContract {
     /// (unused in the darkpool core contract)
     _paused: StorageBool,
 
-    /// The address of the darkpool core contract
-    /// (unused in the darkpool core contract)
-    _core_wallet_ops_address: StorageAddress,
-
-    /// The address of the verifier core contract
-    verifier_core_address: StorageAddress,
-
-    /// The address of the vkeys contract
-    vkeys_address: StorageAddress,
-
-    /// The address of the Merkle contract
-    merkle_address: StorageAddress,
-
-    /// The address of the transfer executor contract
-    transfer_executor_address: StorageAddress,
+    /// A storage gap covering a deprecated implementation of the delegate call
+    /// addresses in which addresses were inlined into contract storage
+    _impl_address_gap0: StorageArray<StorageAddress, IMPL_ADDRESS_STORAGE_GAP1_SIZE>,
 
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
@@ -117,17 +106,9 @@ pub struct CoreSettlementContract {
     /// The address of the protocol external fee collection wallet
     protocol_external_fee_collection_address: StorageAddress,
 
-    /// The address of the core settlement contract
-    ///
-    /// Added at the bottom of the storage layout to
-    /// prevent collisions with existing fields when this field was added
-    pub(crate) _core_settlement_address: StorageAddress,
-
-    /// The address of the verifier settlement contract
-    ///
-    /// Added at the bottom of the storage layout to
-    /// prevent collisions with existing fields when this field was added
-    pub(crate) verifier_settlement_address: StorageAddress,
+    /// A storage gap covering a deprecated implementation of the delegate call
+    /// addresses in which addresses were inlined into contract storage
+    _impl_address_gap1: StorageArray<StorageAddress, IMPL_ADDRESS_STORAGE_GAP2_SIZE>,
 
     // --- Updated Fields for per-asset fees --- //
     /// A mapping of per-asset fee overrides for the protocol

--- a/contracts-stylus/src/contracts/core/core_wallet_ops.rs
+++ b/contracts-stylus/src/contracts/core/core_wallet_ops.rs
@@ -26,6 +26,7 @@ use crate::{
             validWalletUpdateVkeyCall,
         },
     },
+    IMPL_ADDRESS_STORAGE_GAP1_SIZE, IMPL_ADDRESS_STORAGE_GAP2_SIZE,
 };
 use alloc::{vec, vec::Vec};
 use alloy_sol_types::SolCall;
@@ -74,21 +75,9 @@ pub struct CoreWalletOpsContract {
     /// (unused in the darkpool core contract)
     _paused: StorageBool,
 
-    /// The address of the darkpool core contract
-    /// (unused in the darkpool core contract)
-    _core_wallet_ops_address: StorageAddress,
-
-    /// The address of the verifier core contract
-    verifier_core_address: StorageAddress,
-
-    /// The address of the vkeys contract
-    vkeys_address: StorageAddress,
-
-    /// The address of the Merkle contract
-    merkle_address: StorageAddress,
-
-    /// The address of the transfer executor contract
-    transfer_executor_address: StorageAddress,
+    /// A storage gap covering a deprecated implementation of the delegate call
+    /// addresses in which addresses were inlined into contract storage
+    _impl_address_gap0: StorageArray<StorageAddress, IMPL_ADDRESS_STORAGE_GAP1_SIZE>,
 
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
@@ -115,17 +104,9 @@ pub struct CoreWalletOpsContract {
     /// The address of the protocol external fee collection wallet
     protocol_external_fee_collection_address: StorageAddress,
 
-    /// The address of the core settlement contract
-    ///
-    /// Added at the bottom of the storage layout to
-    /// prevent collisions with existing fields when this field was added
-    pub(crate) _core_settlement_address: StorageAddress,
-
-    /// The address of the verifier settlement contract
-    ///
-    /// Added at the bottom of the storage layout to
-    /// prevent collisions with existing fields when this field was added
-    pub(crate) verifier_settlement_address: StorageAddress,
+    /// A storage gap covering a deprecated implementation of the delegate call
+    /// addresses in which addresses were inlined into contract storage
+    _impl_address_gap1: StorageArray<StorageAddress, IMPL_ADDRESS_STORAGE_GAP2_SIZE>,
 
     // --- Updated Fields for per-asset fees --- //
     /// A mapping of per-asset fee overrides for the protocol

--- a/contracts-stylus/src/contracts/core/core_wallet_ops.rs
+++ b/contracts-stylus/src/contracts/core/core_wallet_ops.rs
@@ -133,27 +133,20 @@ pub struct CoreWalletOpsContract {
     /// Added at the bottom of the storage layout to
     /// prevent collisions with existing fields when this field was added
     pub(crate) _external_match_fee_overrides: StorageMap<Address, StorageU256>,
+
+    /// A mapping from a "selector" to the delegate address used to call it
+    ///
+    /// The selector here is not the Solidity selector, but rather an index into
+    /// a list of delegate call addresses
+    ///
+    /// Added at the bottom of the storage layout to
+    /// prevent collisions with existing fields when this field was added
+    pub(crate) delegate_addresses: StorageMap<u64, StorageAddress>,
 }
 
 impl CoreContractStorage for CoreWalletOpsContract {
-    fn verifier_core_address(&self) -> Address {
-        self.verifier_core_address.get()
-    }
-
-    fn verifier_settlement_address(&self) -> Address {
-        self.verifier_settlement_address.get()
-    }
-
-    fn vkeys_address(&self) -> Address {
-        self.vkeys_address.get()
-    }
-
-    fn merkle_address(&self) -> Address {
-        self.merkle_address.get()
-    }
-
-    fn transfer_executor_address(&self) -> Address {
-        self.transfer_executor_address.get()
+    fn get_delegate_address(&self, selector: u64) -> Address {
+        self.delegate_addresses.get(selector)
     }
 
     fn nullifier_set(&self) -> &StorageMap<U256, StorageBool> {

--- a/contracts-stylus/src/contracts/core/mod.rs
+++ b/contracts-stylus/src/contracts/core/mod.rs
@@ -6,6 +6,12 @@ use stylus_sdk::{
     storage::{StorageArray, StorageBool, StorageMap, StorageU256},
 };
 
+use crate::{
+    CORE_SETTLEMENT_DELEGATE_SELECTOR, CORE_WALLET_OPS_DELEGATE_SELECTOR, MERKLE_DELEGATE_SELECTOR,
+    TRANSFER_EXECUTOR_DELEGATE_SELECTOR, VERIFIER_CORE_DELEGATE_SELECTOR,
+    VERIFIER_SETTLEMENT_DELEGATE_SELECTOR, VKEYS_DELEGATE_SELECTOR,
+};
+
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
 pub mod core_helpers;
 #[cfg(feature = "core-settlement")]
@@ -17,20 +23,43 @@ pub mod core_wallet_ops;
 /// core contracts
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
 pub trait CoreContractStorage {
+    /// Get the address of a delegate contract using the given selector
+    fn get_delegate_address(&self, selector: u64) -> Address;
+
+    /// Get the address of the core wallet ops contract
+    fn core_wallet_ops_address(&self) -> Address {
+        self.get_delegate_address(CORE_WALLET_OPS_DELEGATE_SELECTOR)
+    }
+
+    /// Get the address of the core settlement contract
+    fn core_settlement_address(&self) -> Address {
+        self.get_delegate_address(CORE_SETTLEMENT_DELEGATE_SELECTOR)
+    }
+
     /// Get the address of the verifier core contract
-    fn verifier_core_address(&self) -> Address;
+    fn verifier_core_address(&self) -> Address {
+        self.get_delegate_address(VERIFIER_CORE_DELEGATE_SELECTOR)
+    }
 
     /// Get the address of the verifier settlement contract
-    fn verifier_settlement_address(&self) -> Address;
+    fn verifier_settlement_address(&self) -> Address {
+        self.get_delegate_address(VERIFIER_SETTLEMENT_DELEGATE_SELECTOR)
+    }
 
     /// Get the address of the vkeys contract
-    fn vkeys_address(&self) -> Address;
+    fn vkeys_address(&self) -> Address {
+        self.get_delegate_address(VKEYS_DELEGATE_SELECTOR)
+    }
 
     /// Get the address of the Merkle contract
-    fn merkle_address(&self) -> Address;
+    fn merkle_address(&self) -> Address {
+        self.get_delegate_address(MERKLE_DELEGATE_SELECTOR)
+    }
 
     /// Get the address of the transfer executor contract
-    fn transfer_executor_address(&self) -> Address;
+    fn transfer_executor_address(&self) -> Address {
+        self.get_delegate_address(TRANSFER_EXECUTOR_DELEGATE_SELECTOR)
+    }
 
     /// Get the set of state nullifiers
     fn nullifier_set(&self) -> &StorageMap<U256, StorageBool>;

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -33,7 +33,8 @@ use crate::{
             VerifierSettlementAddressChanged, VkeysAddressChanged,
         },
     },
-    CORE_SETTLEMENT_DELEGATE_SELECTOR, CORE_WALLET_OPS_DELEGATE_SELECTOR, MERKLE_DELEGATE_SELECTOR,
+    CORE_SETTLEMENT_DELEGATE_SELECTOR, CORE_WALLET_OPS_DELEGATE_SELECTOR,
+    IMPL_ADDRESS_STORAGE_GAP1_SIZE, IMPL_ADDRESS_STORAGE_GAP2_SIZE, MERKLE_DELEGATE_SELECTOR,
     TRANSFER_EXECUTOR_DELEGATE_SELECTOR, VERIFIER_CORE_DELEGATE_SELECTOR,
     VERIFIER_SETTLEMENT_DELEGATE_SELECTOR, VKEYS_DELEGATE_SELECTOR,
 };
@@ -57,20 +58,9 @@ pub struct DarkpoolContract {
     /// Whether or not the darkpool is paused
     paused: StorageBool,
 
-    /// The address of the darkpool core contract
-    pub(crate) _core_wallet_ops_address: StorageAddress,
-
-    /// The address of the verifier core contract
-    pub(crate) _verifier_core_address: StorageAddress,
-
-    /// The address of the vkeys contract
-    pub(crate) _vkeys_address: StorageAddress,
-
-    /// The address of the Merkle contract
-    pub(crate) _merkle_address: StorageAddress,
-
-    /// The address of the transfer executor contract
-    pub(crate) _transfer_executor_address: StorageAddress,
+    /// A storage gap covering a deprecated implementation of the delegate call
+    /// addresses in which addresses were inlined into contract storage
+    _impl_address_gap0: StorageArray<StorageAddress, IMPL_ADDRESS_STORAGE_GAP1_SIZE>,
 
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
@@ -100,17 +90,9 @@ pub struct DarkpoolContract {
     /// parties
     pub(crate) protocol_external_fee_collection_address: StorageAddress,
 
-    /// The address of the core settlement contract
-    ///
-    /// Added at the bottom of the storage layout to
-    /// prevent collisions with existing fields when this field was added
-    pub(crate) core_settlement_address: StorageAddress,
-
-    /// The address of the verifier settlement contract
-    ///
-    /// Added at the bottom of the storage layout to
-    /// prevent collisions with existing fields when this field was added
-    pub(crate) verifier_settlement_address: StorageAddress,
+    /// A storage gap covering a deprecated implementation of the delegate call
+    /// addresses in which addresses were inlined into contract storage
+    _impl_address_gap1: StorageArray<StorageAddress, IMPL_ADDRESS_STORAGE_GAP2_SIZE>,
 
     // --- Updated Fields for per-asset fees --- //
     /// A mapping of per-asset fee overrides for the protocol on external

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -33,6 +33,9 @@ use crate::{
             VerifierSettlementAddressChanged, VkeysAddressChanged,
         },
     },
+    CORE_SETTLEMENT_DELEGATE_SELECTOR, CORE_WALLET_OPS_DELEGATE_SELECTOR, MERKLE_DELEGATE_SELECTOR,
+    TRANSFER_EXECUTOR_DELEGATE_SELECTOR, VERIFIER_CORE_DELEGATE_SELECTOR,
+    VERIFIER_SETTLEMENT_DELEGATE_SELECTOR, VKEYS_DELEGATE_SELECTOR,
 };
 
 /// The darkpool contract's storage layout
@@ -55,19 +58,19 @@ pub struct DarkpoolContract {
     paused: StorageBool,
 
     /// The address of the darkpool core contract
-    pub(crate) core_wallet_ops_address: StorageAddress,
+    pub(crate) _core_wallet_ops_address: StorageAddress,
 
     /// The address of the verifier core contract
-    pub(crate) verifier_core_address: StorageAddress,
+    pub(crate) _verifier_core_address: StorageAddress,
 
     /// The address of the vkeys contract
-    pub(crate) vkeys_address: StorageAddress,
+    pub(crate) _vkeys_address: StorageAddress,
 
     /// The address of the Merkle contract
-    pub(crate) merkle_address: StorageAddress,
+    pub(crate) _merkle_address: StorageAddress,
 
     /// The address of the transfer executor contract
-    pub(crate) transfer_executor_address: StorageAddress,
+    pub(crate) _transfer_executor_address: StorageAddress,
 
     /// The set of wallet nullifiers, representing a mapping from a nullifier
     /// (which is a Bn254 scalar field element serialized into 32 bytes) to a
@@ -119,6 +122,16 @@ pub struct DarkpoolContract {
     /// Added at the bottom of the storage layout to
     /// prevent collisions with existing fields when this field was added
     pub(crate) external_match_fee_overrides: StorageMap<Address, StorageU256>,
+
+    // --- Updated Fields for Delegate Call Mappings --- //
+    /// A mapping from a "selector" to the delegate address used to call it
+    ///
+    /// The selector here is not the Solidity selector, but rather an index into
+    /// a list of delegate call addresses
+    ///
+    /// Added at the bottom of the storage layout to
+    /// prevent collisions with existing fields when this field was added
+    pub(crate) delegate_addresses: StorageMap<u64, StorageAddress>,
 }
 
 #[public]
@@ -256,7 +269,7 @@ impl DarkpoolContract {
     pub fn get_root<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
     ) -> Result<U256, Vec<u8>> {
-        let merkle_address = storage.borrow_mut().merkle_address.get();
+        let merkle_address = Self::get_delegate_address(storage, MERKLE_DELEGATE_SELECTOR);
         let (res,) = delegate_call_helper::<rootCall>(storage, merkle_address, ())?.into();
         Ok(res)
     }
@@ -266,7 +279,7 @@ impl DarkpoolContract {
         storage: &mut S,
         root: U256,
     ) -> Result<bool, Vec<u8>> {
-        let merkle_address = storage.borrow_mut().merkle_address.get();
+        let merkle_address = Self::get_delegate_address(storage, MERKLE_DELEGATE_SELECTOR);
         let (res,) =
             delegate_call_helper::<rootInHistoryCall>(storage, merkle_address, (root,))?.into();
 
@@ -391,17 +404,31 @@ impl DarkpoolContract {
 
     // --- Implementation Addresses --- //
 
+    /// Sets a delegate call address
+    fn set_delegate_address<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        selector: u64,
+        address: Address,
+    ) -> Result<(), Vec<u8>> {
+        DarkpoolContract::_check_owner(storage)?;
+        check_address_not_zero(address)?;
+        storage.borrow_mut().delegate_addresses.insert(selector, address);
+
+        Ok(())
+    }
+
     /// Sets the darkpool core address
     pub fn set_core_wallet_ops_address<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
         core_wallet_ops_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(core_wallet_ops_address)?;
-        storage.borrow_mut().core_wallet_ops_address.set(core_wallet_ops_address);
+        DarkpoolContract::set_delegate_address(
+            storage,
+            CORE_WALLET_OPS_DELEGATE_SELECTOR,
+            core_wallet_ops_address,
+        )?;
 
         evm::log(CoreWalletOpsAddressChanged { new_address: core_wallet_ops_address });
-
         Ok(())
     }
 
@@ -410,9 +437,11 @@ impl DarkpoolContract {
         storage: &mut S,
         core_settlement_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(core_settlement_address)?;
-        storage.borrow_mut().core_settlement_address.set(core_settlement_address);
+        DarkpoolContract::set_delegate_address(
+            storage,
+            CORE_SETTLEMENT_DELEGATE_SELECTOR,
+            core_settlement_address,
+        )?;
 
         evm::log(CoreSettlementAddressChanged { new_address: core_settlement_address });
         Ok(())
@@ -423,9 +452,12 @@ impl DarkpoolContract {
         storage: &mut S,
         verifier_core_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(verifier_core_address)?;
-        storage.borrow_mut().verifier_core_address.set(verifier_core_address);
+        DarkpoolContract::set_delegate_address(
+            storage,
+            VERIFIER_CORE_DELEGATE_SELECTOR,
+            verifier_core_address,
+        )?;
+
         evm::log(VerifierCoreAddressChanged { new_address: verifier_core_address });
         Ok(())
     }
@@ -435,9 +467,11 @@ impl DarkpoolContract {
         storage: &mut S,
         verifier_settlement_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(verifier_settlement_address)?;
-        storage.borrow_mut().verifier_settlement_address.set(verifier_settlement_address);
+        DarkpoolContract::set_delegate_address(
+            storage,
+            VERIFIER_SETTLEMENT_DELEGATE_SELECTOR,
+            verifier_settlement_address,
+        )?;
 
         evm::log(VerifierSettlementAddressChanged { new_address: verifier_settlement_address });
         Ok(())
@@ -448,9 +482,8 @@ impl DarkpoolContract {
         storage: &mut S,
         vkeys_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(vkeys_address)?;
-        storage.borrow_mut().vkeys_address.set(vkeys_address);
+        DarkpoolContract::set_delegate_address(storage, VKEYS_DELEGATE_SELECTOR, vkeys_address)?;
+
         evm::log(VkeysAddressChanged { new_address: vkeys_address });
         Ok(())
     }
@@ -460,9 +493,8 @@ impl DarkpoolContract {
         storage: &mut S,
         merkle_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(merkle_address)?;
-        storage.borrow_mut().merkle_address.set(merkle_address);
+        DarkpoolContract::set_delegate_address(storage, MERKLE_DELEGATE_SELECTOR, merkle_address)?;
+
         evm::log(MerkleAddressChanged { new_address: merkle_address });
         Ok(())
     }
@@ -472,10 +504,11 @@ impl DarkpoolContract {
         storage: &mut S,
         transfer_executor_address: Address,
     ) -> Result<(), Vec<u8>> {
-        DarkpoolContract::_check_owner(storage)?;
-        check_address_not_zero(transfer_executor_address)?;
-
-        storage.borrow_mut().transfer_executor_address.set(transfer_executor_address);
+        DarkpoolContract::set_delegate_address(
+            storage,
+            TRANSFER_EXECUTOR_DELEGATE_SELECTOR,
+            transfer_executor_address,
+        )?;
 
         evm::log(TransferExecutorAddressChanged { new_address: transfer_executor_address });
         Ok(())
@@ -493,10 +526,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let delegate = Self::get_delegate_address(storage, CORE_WALLET_OPS_DELEGATE_SELECTOR);
         delegate_call_helper::<newWalletCall>(
             storage,
-            core_wallet_ops_address,
+            delegate,
             (proof.to_vec().into(), valid_wallet_create_statement_bytes.to_vec().into()),
         )
         .map(|_| ())
@@ -512,10 +545,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let delegate = Self::get_delegate_address(storage, CORE_WALLET_OPS_DELEGATE_SELECTOR);
         delegate_call_helper::<updateWalletCall>(
             storage,
-            core_wallet_ops_address,
+            delegate,
             (
                 proof.to_vec().into(),
                 valid_wallet_update_statement_bytes.to_vec().into(),
@@ -543,10 +576,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let delegate = Self::get_delegate_address(storage, CORE_SETTLEMENT_DELEGATE_SELECTOR);
         delegate_call_helper::<processMatchSettleCall>(
             storage,
-            core_settlement_address,
+            delegate,
             (
                 party_0_match_payload.to_vec().into(),
                 party_1_match_payload.to_vec().into(),
@@ -584,10 +617,10 @@ impl DarkpoolContract {
         DarkpoolContract::_check_not_paused(storage)?;
 
         let receiver = msg::sender();
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let delegate = Self::get_delegate_address(storage, CORE_SETTLEMENT_DELEGATE_SELECTOR);
         delegate_call_helper::<processAtomicMatchSettleCall>(
             storage,
-            core_settlement_address,
+            delegate,
             (
                 receiver,
                 internal_party_match_payload.to_vec().into(),
@@ -611,10 +644,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let delegate = Self::get_delegate_address(storage, CORE_SETTLEMENT_DELEGATE_SELECTOR);
         delegate_call_helper::<processAtomicMatchSettleCall>(
             storage,
-            core_settlement_address,
+            delegate,
             (
                 receiver,
                 internal_party_match_payload.to_vec().into(),
@@ -648,10 +681,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_settlement_address = storage.borrow_mut().get_core_settlement_address();
+        let delegate = Self::get_delegate_address(storage, CORE_SETTLEMENT_DELEGATE_SELECTOR);
         delegate_call_helper::<processMalleableAtomicMatchSettleCall>(
             storage,
-            core_settlement_address,
+            delegate,
             (
                 base_amount,
                 receiver,
@@ -674,10 +707,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let delegate = Self::get_delegate_address(storage, CORE_WALLET_OPS_DELEGATE_SELECTOR);
         delegate_call_helper::<settleOnlineRelayerFeeCall>(
             storage,
-            core_wallet_ops_address,
+            delegate,
             (
                 proof.to_vec().into(),
                 valid_relayer_fee_settlement_statement.to_vec().into(),
@@ -696,10 +729,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let delegate = Self::get_delegate_address(storage, CORE_WALLET_OPS_DELEGATE_SELECTOR);
         delegate_call_helper::<settleOfflineFeeCall>(
             storage,
-            core_wallet_ops_address,
+            delegate,
             (proof.to_vec().into(), valid_offline_fee_settlement_statement.to_vec().into()),
         )
         .map(|_| ())
@@ -714,10 +747,10 @@ impl DarkpoolContract {
     ) -> Result<(), Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
-        let core_wallet_ops_address = storage.borrow_mut().get_core_wallet_ops_address();
+        let delegate = Self::get_delegate_address(storage, CORE_WALLET_OPS_DELEGATE_SELECTOR);
         delegate_call_helper::<redeemFeeCall>(
             storage,
-            core_wallet_ops_address,
+            delegate,
             (
                 proof.to_vec().into(),
                 valid_fee_redemption_statement.to_vec().into(),
@@ -784,14 +817,12 @@ impl DarkpoolContract {
     // | CORE HELPERS |
     // ----------------
 
-    /// Get the core wallet ops address
-    pub fn get_core_wallet_ops_address(&self) -> Address {
-        self.core_wallet_ops_address.get()
-    }
-
-    /// Get the core settlement address
-    pub fn get_core_settlement_address(&self) -> Address {
-        self.core_settlement_address.get()
+    /// Get the delegate call address for a given selector
+    pub fn get_delegate_address<S: TopLevelStorage + Borrow<Self>>(
+        storage: &S,
+        selector: u64,
+    ) -> Address {
+        storage.borrow().delegate_addresses.get(selector)
     }
 
     /// Gets the affine coordinates of the protocol public encryption key

--- a/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
+++ b/contracts-stylus/src/contracts/test_contracts/darkpool_test_contract.rs
@@ -43,24 +43,8 @@ struct DarkpoolTestContract {
 }
 
 impl CoreContractStorage for DarkpoolTestContract {
-    fn verifier_core_address(&self) -> Address {
-        self.darkpool.verifier_core_address.get()
-    }
-
-    fn verifier_settlement_address(&self) -> Address {
-        self.darkpool.verifier_settlement_address.get()
-    }
-
-    fn vkeys_address(&self) -> Address {
-        self.darkpool.vkeys_address.get()
-    }
-
-    fn merkle_address(&self) -> Address {
-        self.darkpool.merkle_address.get()
-    }
-
-    fn transfer_executor_address(&self) -> Address {
-        self.darkpool.transfer_executor_address.get()
+    fn get_delegate_address(&self, selector: u64) -> Address {
+        self.darkpool.delegate_addresses.get(selector)
     }
 
     fn nullifier_set(&self) -> &StorageMap<U256, StorageBool> {
@@ -141,18 +125,17 @@ impl DarkpoolTestContract {
     /// either the verifier, vkeys, or Merkle contract, depending on the
     /// given address selector.
     ///
-    /// A succesful call implies that the verifier / vkeys / Merkle contract has
-    /// been upgraded to the dummy upgrade target.
+    /// A successful call implies that the verifier / vkeys / Merkle contract
+    /// has been upgraded to the dummy upgrade target.
     pub fn is_implementation_upgraded(&mut self, address_selector: u8) -> Result<bool, Vec<u8>> {
-        let this = BorrowMut::<DarkpoolContract>::borrow_mut(self);
         let implementation_address = match address_selector {
-            CORE_WALLET_OPS_ADDRESS_SELECTOR => this.get_core_wallet_ops_address(),
-            CORE_SETTLEMENT_ADDRESS_SELECTOR => this.get_core_settlement_address(),
-            VERIFIER_CORE_ADDRESS_SELECTOR => this.verifier_core_address.get(),
-            VERIFIER_SETTLEMENT_ADDRESS_SELECTOR => this.verifier_settlement_address.get(),
-            VKEYS_ADDRESS_SELECTOR => this.vkeys_address.get(),
-            MERKLE_ADDRESS_SELECTOR => this.merkle_address.get(),
-            TRANSFER_EXECUTOR_ADDRESS_SELECTOR => this.transfer_executor_address.get(),
+            CORE_WALLET_OPS_ADDRESS_SELECTOR => self.core_wallet_ops_address(),
+            CORE_SETTLEMENT_ADDRESS_SELECTOR => self.core_settlement_address(),
+            VERIFIER_CORE_ADDRESS_SELECTOR => self.verifier_core_address(),
+            VERIFIER_SETTLEMENT_ADDRESS_SELECTOR => self.verifier_settlement_address(),
+            VKEYS_ADDRESS_SELECTOR => self.vkeys_address(),
+            MERKLE_ADDRESS_SELECTOR => self.merkle_address(),
+            TRANSFER_EXECUTOR_ADDRESS_SELECTOR => self.transfer_executor_address(),
             _ => panic!(),
         };
 
@@ -169,8 +152,7 @@ impl DarkpoolTestContract {
 
     /// Re-initializes the Merkle tree, resetting it to an empty tree
     pub fn clear_merkle(&mut self) -> Result<(), Vec<u8>> {
-        let merkle_address = BorrowMut::<DarkpoolContract>::borrow_mut(self).merkle_address.get();
-
+        let merkle_address = self.merkle_address();
         delegate_call_helper::<initMerkleCall>(self, merkle_address, ()).map(|_| ())
     }
 }

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -184,6 +184,20 @@ pub const MERKLE_STORAGE_GAP_SIZE: usize = 64;
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
 pub const TRANSFER_EXECUTOR_STORAGE_GAP_SIZE: usize = 64;
 
+/// The number of storage slots to allocate for the first deprecated
+/// implementation address storage gap
+///
+/// This value is specified in number of storage slots
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const IMPL_ADDRESS_STORAGE_GAP1_SIZE: usize = 5;
+
+/// The number of storage slots to allocate for the second deprecated
+/// implementation address storage gap
+///
+/// This value is specified in number of storage slots
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const IMPL_ADDRESS_STORAGE_GAP2_SIZE: usize = 2;
+
 /// The delegate call selector the core wallet ops contract
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
 pub const CORE_WALLET_OPS_DELEGATE_SELECTOR: u64 = 1;

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -6,6 +6,11 @@ use contracts_common::{
     types::ScalarField,
 };
 use core::marker::PhantomData;
+use stylus_sdk::alloy_primitives::U256;
+
+// ------------------
+// | Error Messages |
+// ------------------
 
 /// The revert message when verification is disabled but
 /// the chain is not a Renegade devnet
@@ -117,6 +122,10 @@ pub const CALL_RETDATA_DECODING_ERROR_MESSAGE: &[u8] = b"error decoding retdata"
 #[cfg(feature = "transfer-executor")]
 pub const MISSING_TRANSFER_AUX_DATA_ERROR_MESSAGE: &[u8] = b"missing transfer aux data";
 
+// ----------------------
+// | Contract Addresses |
+// ----------------------
+
 /// A dummy address for the native asset, constant across all chains
 /// 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
 #[cfg(any(
@@ -154,6 +163,10 @@ pub const PAIRING_CHECK_RESULT_LAST_BYTE_INDEX: usize = 31;
 /// The byte length of the input to the `ecRecover` precompile
 pub const EC_RECOVER_INPUT_LEN: usize = 128;
 
+// --------------------------
+// | Storage Configurations |
+// --------------------------
+
 /// The number of storage slots to allocate for the Merkle contract,
 /// used in creating storage gaps in contracts in the same context
 /// to ensure that there are no storage collisions
@@ -170,6 +183,38 @@ pub const MERKLE_STORAGE_GAP_SIZE: usize = 64;
 /// context to ensure that there are no storage collisions
 #[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
 pub const TRANSFER_EXECUTOR_STORAGE_GAP_SIZE: usize = 64;
+
+/// The delegate call selector the core wallet ops contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const CORE_WALLET_OPS_DELEGATE_SELECTOR: u64 = 1;
+
+/// The delegate call selector the core settlement contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const CORE_SETTLEMENT_DELEGATE_SELECTOR: u64 = 2;
+
+/// The delegate call selector the verifier core contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const VERIFIER_CORE_DELEGATE_SELECTOR: u64 = 3;
+
+/// The delegate call selector for the verifier settlement contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const VERIFIER_SETTLEMENT_DELEGATE_SELECTOR: u64 = 4;
+
+/// The delegate call selector for the vkeys contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const VKEYS_DELEGATE_SELECTOR: u64 = 5;
+
+/// The delegate call selector for the merkle contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const MERKLE_DELEGATE_SELECTOR: u64 = 6;
+
+/// The delegate call selector for the transfer executor contract
+#[cfg(any(feature = "darkpool", feature = "darkpool-test-contract", feature = "darkpool-core"))]
+pub const TRANSFER_EXECUTOR_DELEGATE_SELECTOR: u64 = 7;
+
+// ---------------------
+// | Verification Keys |
+// ---------------------
 
 /// The serialized VALID WALLET CREATE verification key
 #[cfg(feature = "vkeys")]
@@ -262,6 +307,10 @@ pub const PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_BYTES: &[u8] =
 #[cfg(feature = "test-vkeys")]
 pub const PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_BYTES: &[u8] =
     include_bytes!("../../vkeys/test/process_malleable_match_settle_atomic");
+
+// -------------------------
+// | Merkle State Defaults |
+// -------------------------
 
 /// The path of values in an empty Merkle tree of height `TEST_MERKLE_HEIGHT`,
 /// going from root to leaf


### PR DESCRIPTION
### Purpose
This PR removes the inlined delegate callee addresses from contract storage (replacing them with storage gaps), and instead uses a mapping from a delegate callee "selector" to its address. 

This will require special logic when upgraded to initialize these addresses.

### Testing
- [x] All unit and integration tests pass