### PR TITLE
meta: patch stylus SDK to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1534,6 +1535,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1564,6 +1566,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -1752,6 +1755,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5402,6 +5406,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -6557,6 +6562,7 @@ dependencies = [
 [[package]]
 name = "test-helpers"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "eyre",
  "futures",
@@ -7192,6 +7198,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#ccbf8d02d36a29dd3364382f512aed53912f35e9"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239e728d663a3bdababa24dfdc697faec987593161c5ff54d72ee01df6721d59"
+checksum = "6d2cc5aeb8dfa1e451a49fac87bc4b86c5de40ebea153ed88e83eb92b8151e74"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d301f5bcfd37e3aac727c360d8b50c33ddff9169ce0370198dedda36a9927d"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -120,21 +120,15 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 2.0.1",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.5",
+ "derive_more",
  "serde",
- "serde_with",
- "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4f97a85a45965e0e4f9f5b94bbafaa3e4ee6868bdbcf2e4a9acb4b358038fe"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -146,11 +140,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39e8b96c9e25dde7222372332489075f7e750e4fd3e81c11eec0939b78b71b8"
+checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
 dependencies = [
- "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
@@ -167,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
+checksum = "074e41c92e2a3cc36448d4a9b94ba05b8faac466d7981d158ed68fd88e22d3b7"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -180,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
+checksum = "7f2d547eba3f2d331b0e08f64a24e202f66d4f291e2a3e0073914c0e1400ced3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -204,7 +197,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "crc",
- "serde",
  "thiserror 2.0.12",
 ]
 
@@ -233,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b11c382ca8075128d1ae6822b60921cf484c911d9a5831797a01218f98125f"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -245,17 +237,17 @@ dependencies = [
  "alloy-serde",
  "auto_impl",
  "c-kzg",
- "derive_more 2.0.1",
- "either",
+ "derive_more",
+ "once_cell",
  "serde",
  "sha2",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd9e75c5dd40319ebbe807ebe9dfb10c24e4a70d9c7d638e62921d8dd093c8b"
+checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -266,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+checksum = "d62cf1b25f5a50ca2d329b0b4aeb0a0dedeaf225ad3c5099d83b1a4c4616186e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -278,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcf26d02a72e23d5bc245425ea403c93ba17d254f20f9c23556a249c6c7e143"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -292,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44dd4429e190f727358571175ebf323db360a303bf4e1731213f510ced1c2e6"
+checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -309,7 +301,6 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -318,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f736e1d1eb1b770dbd32919bdf46d4dcd4617f2eed07947dfb32649962baba"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -331,15 +322,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
+checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if 1.0.0",
  "const-hex",
- "derive_more 2.0.1",
+ "derive_more",
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
@@ -359,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a557f9e3ec89437b06db3bfc97d20782b1f7cc55b5b602b6a82bf3f64d7efb0e"
+checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -372,7 +363,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -380,7 +370,6 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "dashmap",
- "either",
  "futures",
  "futures-utils-wasm",
  "lru",
@@ -420,15 +409,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec6dc89c4c3ef166f9fa436d1831f8142c16cf2e637647c936a6aaaabd8d898"
+checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "alloy-transport-http",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest 0.12.15",
@@ -438,16 +426,15 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3849f8131a18cc5d7f95f301d68a6af5aa2db28ad8522fb9db1f27b3794e8b68"
+checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -457,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd6d480e4e6e456f30eeeb3aef1512aaecb68df2a35d1f78865dbc4d20dc0fd"
+checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -468,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8b6d55bdaa0c4a08650d4b32f174494cbade56adf6f2fcfa2a4f3490cb5511"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -488,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1824791912f468a481dedc1db50feef3e85a078f6d743a62db2ee9c2ca674882"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -499,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d087fe5aea96a93fbe71be8aaed5c57c3caac303c09e674bc5b1647990d648b"
+checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -514,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2940353d2425bb75965cd5101075334e6271051e35610f903bf8099a52b0b1a9"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -530,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+checksum = "13f28f2131dc3a7b8e2cda882758ad4d5231ca26281b9861d4b18c700713e2da"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -544,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+checksum = "1ee2da033256a3b27131c030933eab0460a709fbcc4d4bd57bf9a5650b2441c5"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -557,26 +544,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "syn-solidity 0.8.25",
+ "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+checksum = "4e9d9918b0abb632818bf27e2dfb86b209be8433baacf22100b190bbc0904bd4"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck 0.5.0",
- "macro-string",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.100",
- "syn-solidity 0.8.25",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -591,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.25"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+checksum = "75f306fc801b3aa2e3c4785b7b5252ec8b19f77b30e3b75babfd23849c81bd8c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -604,16 +590,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6818b4c82a474cc01ac9e88ccfcd9f9b7bc893b2f8aea7e890a28dcd55c0a7aa"
+checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
- "derive_more 2.0.1",
- "futures",
  "futures-utils-wasm",
- "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -626,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc3079a33483afa1b1365a3add3ea3e21c75b10f704870198ba7846627d10f2"
+checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -648,7 +631,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
- "derive_more 1.0.0",
+ "derive_more",
  "nybbles",
  "serde",
  "smallvec",
@@ -725,15 +708,6 @@ name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "ark-bls12-377"
@@ -1420,11 +1394,10 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
 dependencies = [
- "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -1551,7 +1524,6 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1562,7 +1534,6 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1593,7 +1564,6 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -1782,7 +1752,6 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1837,6 +1806,7 @@ dependencies = [
 name = "contracts-stylus"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
@@ -2185,7 +2155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -2200,32 +2169,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl 2.0.1",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -2233,17 +2182,6 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2359,7 +2297,6 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
  "signature",
  "spki",
 ]
@@ -2394,9 +2331,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "elliptic-curve"
@@ -2413,7 +2347,6 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -3642,7 +3575,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -3885,7 +3817,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "serdect",
  "sha2",
  "signature",
 ]
@@ -4136,17 +4067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,8 +4190,8 @@ dependencies = [
 
 [[package]]
 name = "mini-alloc"
-version = "0.6.0"
-source = "git+https://github.com/joeykraut/stylus-sdk-rs#2904695f9a86ad5c71d77b5398d1b40c742f55a2"
+version = "0.8.3"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs-private.git#ac19f899a4c25db7db7a1a607b3ccb30d8817a78"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -5482,7 +5402,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -5881,7 +5800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if 1.0.0",
- "derive_more 1.0.0",
+ "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -5974,7 +5893,6 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -6103,8 +6021,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "indexmap 1.9.3",
- "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6400,27 +6316,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "stylus-core"
+version = "0.8.3"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs-private.git#ac19f899a4c25db7db7a1a607b3ccb30d8817a78"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "cfg-if 1.0.0",
+ "dyn-clone",
+]
+
+[[package]]
 name = "stylus-proc"
-version = "0.6.0"
-source = "git+https://github.com/joeykraut/stylus-sdk-rs#2904695f9a86ad5c71d77b5398d1b40c742f55a2"
+version = "0.8.3"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs-private.git#ac19f899a4c25db7db7a1a607b3ccb30d8817a78"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "cfg-if 1.0.0",
  "convert_case",
  "lazy_static",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
  "sha3",
- "syn 1.0.109",
- "syn-solidity 0.7.7",
+ "syn 2.0.100",
+ "syn-solidity",
+ "trybuild",
 ]
 
 [[package]]
 name = "stylus-sdk"
-version = "0.6.0"
-source = "git+https://github.com/joeykraut/stylus-sdk-rs#2904695f9a86ad5c71d77b5398d1b40c742f55a2"
+version = "0.8.3"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs-private.git#ac19f899a4c25db7db7a1a607b3ccb30d8817a78"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6429,8 +6358,9 @@ dependencies = [
  "hex",
  "keccak-const",
  "lazy_static",
- "mini-alloc 0.6.0",
+ "mini-alloc 0.8.3",
  "regex",
+ "stylus-core",
  "stylus-proc",
 ]
 
@@ -6480,18 +6410,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -6598,6 +6516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6622,9 +6546,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "eyre",
  "futures",
@@ -7016,8 +6948,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -7106,6 +7036,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.8.20",
+]
 
 [[package]]
 name = "tungstenite"
@@ -7247,7 +7192,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#82645a9207fcbec28842cdfa2a4f5398409aa5cc"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ ark-crypto-primitives = { version = "0.4", default-features = false, features = 
     "crh",
     "merkle_tree",
 ] }
-alloy = { version = "0.13", default-features = false }
-alloy-contract = { version = "0.13", default-features = false }
-alloy-primitives = { version = "=0.8.25", default-features = false }
-alloy-sol-types = { version = "=0.8.25", default-features = false }
+alloy = { version = "0.11", default-features = false }
+alloy-contract = { version = "0.11", default-features = false }
+alloy-primitives = { version = "=0.8.20", default-features = false }
+alloy-sol-types = { version = "=0.8.20", default-features = false }
 serde = { version = "1.0.197", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.4", default-features = false, features = [
@@ -36,16 +36,16 @@ ruint = "1.11"
 eyre = "0.6.8"
 clap = { version = "4.4.7", features = ["derive"] }
 tokio = { version = "1.12.0", features = ["full"] }
-constants = { git = "https://github.com/renegade-fi/renegade.git", default-features = false }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", default-features = false }
-circuits = { git = "https://github.com/renegade-fi/renegade.git" }
-circuit-types = { git = "https://github.com/renegade-fi/renegade.git", features = [
+constants = { path = "../renegade/constants", default-features = false }
+renegade-crypto = { path = "../renegade/renegade-crypto", default-features = false }
+circuits = { path = "../renegade/circuits" }
+circuit-types = { path = "../renegade/circuit-types", features = [
     "test-helpers",
 ] }
 itertools = "0.12"
 mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git", default-features = false }
-stylus-sdk = { git = "https://github.com/joeykraut/stylus-sdk-rs" }
+stylus-sdk = { git = "https://github.com/OffchainLabs/stylus-sdk-rs-private.git" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ ruint = "1.11"
 eyre = "0.6.8"
 clap = { version = "4.4.7", features = ["derive"] }
 tokio = { version = "1.12.0", features = ["full"] }
-constants = { path = "../renegade/constants", default-features = false }
-renegade-crypto = { path = "../renegade/renegade-crypto", default-features = false }
-circuits = { path = "../renegade/circuits" }
-circuit-types = { path = "../renegade/circuit-types", features = [
+constants = { git = "https://github.com/renegade-fi/renegade.git", default-features = false }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", default-features = false }
+circuits = { git = "https://github.com/renegade-fi/renegade.git" }
+circuit-types = { git = "https://github.com/renegade-fi/renegade.git", features = [
     "test-helpers",
 ] }
 itertools = "0.12"
@@ -72,10 +72,3 @@ incremental = false # no incremental builds
 # We patch `ahash` here since version mismatches w/ the relayer code have
 # led to verification errors in the past.
 ahash = { git = "https://github.com/tkaitchuck/aHash.git", tag = "v0.8.11" }
-
-[patch."https://github.com/renegade-fi/renegade-contracts.git"]
-# The `arbitrum-client` crate, which we depend on in e.g. `test-helpers`,
-# depends on `contracts-common`, but from the git source.
-# In order to have consistent types in the `arbitrum-client` interfaces,
-# we patch the `contracts-common` dependency to point to the local crate.
-contracts-common = { path = "./contracts-common" }

--- a/contracts-stylus/Cargo.toml
+++ b/contracts-stylus/Cargo.toml
@@ -13,6 +13,7 @@ contracts-common = { path = "../contracts-common" }
 contracts-core = { path = "../contracts-core" }
 postcard = { workspace = true }
 alloy-sol-types = { workspace = true }
+alloy-primitives = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -1,7 +1,6 @@
 //! The gas sponsor contract, used to sponsor the gas costs of external (atomic)
 //! matches
 
-use alloy_sol_types::SolCall;
 use contracts_common::{
     constants::NUM_BYTES_U256,
     types::{ExternalMatchResult, ValidMatchSettleAtomicStatement},
@@ -9,12 +8,11 @@ use contracts_common::{
 use contracts_core::crypto::ecdsa::ecdsa_verify;
 use stylus_sdk::{
     abi::Bytes,
-    alloy_primitives::{hex, Address, U256, U64},
-    block,
+    alloy_primitives::{Address, U256, U64},
     call::{call, Call},
     contract, evm, msg,
     prelude::*,
-    storage::{GlobalStorage, StorageAddress, StorageBool, StorageCache, StorageMap, StorageU64},
+    storage::{StorageAddress, StorageBool, StorageMap, StorageU64},
     tx,
 };
 
@@ -24,8 +22,7 @@ use crate::{
         backends::{PrecompileEcRecoverBackend, StylusHasher},
         helpers::{check_address_not_zero, deserialize_from_calldata, is_native_eth_address},
         solidity::{
-            sponsorAtomicMatchSettleWithReceiverCall, GasSponsorPausedFallback, IArbGasInfo,
-            IArbWasm, IDarkpool, IErc20, InsufficientSponsorBalance, NonceUsed,
+            GasSponsorPausedFallback, IDarkpool, IErc20, InsufficientSponsorBalance, NonceUsed,
             OwnershipTransferred, Paused, SponsoredExternalMatch, Unpaused,
         },
     },
@@ -43,44 +40,6 @@ const ERR_NONCE_ALREADY_USED: &[u8] = b"nonce already used";
 /// The revert message returned when the sponsor does not have enough ETH to
 /// withdraw
 const ERR_INSUFFICIENT_BALANCE: &[u8] = b"insufficient balance";
-
-// -------------
-// | CONSTANTS |
-// -------------
-
-/// The cost of invoking a sponsored match settlement, which includes:
-/// 1. The base gas cost of any Ethereum transaction
-/// 2. The overhead of the delegatecall from the proxy, assuming the contract
-///    address is cold and using an empirical estimate of calldata size, rounded
-///    to a reasonable value
-const INVOCATION_BASE_GAS_COST: u64 = 21_000 + 3500;
-
-/// The cost in gas of a (non-zero) byte of calldata
-const GAS_PER_CALLDATA_BYTE: u64 = 16;
-
-/// The cost in gas of the native ETH refund operations which take place after
-/// the final gas metering check, obtained empirically and rounded to a
-/// reasonable value
-const NATIVE_REFUND_OPS_GAS_COST: u64 = 12_500;
-
-/// A buffer in gas to account for empirically-observed gas overheads when
-/// selling native ETH. It is not entirely clear what the cause of this overhead
-/// is.
-const NATIVE_ETH_SELL_GAS_BUFFER: u64 = 20_000;
-
-/// The address of the ArbGasInfo precompile
-const ARB_GAS_INFO_ADDRESS: Address =
-    Address::new(hex!("000000000000000000000000000000000000006C"));
-
-/// The address of the ArbWasm precompile
-const ARB_WASM_ADDRESS: Address = Address::new(hex!("0000000000000000000000000000000000000071"));
-
-/// The storage slot at which the implementation address of the gas sponsor
-/// contract is stored, as specified by EIP-1967:
-///
-/// https://eips.ethereum.org/EIPS/eip-1967#logic-contract-address
-const IMPL_ADDRESS_STORAGE_SLOT: U256 =
-    U256::from_be_bytes(hex!("360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"));
 
 // -----------------------
 // | CONTRACT DEFINITION |
@@ -215,94 +174,6 @@ impl GasSponsorContract {
     // | SPONSORED SETTLEMENT |
     // ------------------------
 
-    /// Sponsor the gas costs of an atomic match settlement with the caller as
-    /// the receiver
-    #[payable]
-    #[allow(clippy::too_many_arguments)]
-    pub fn sponsor_atomic_match_settle(
-        &mut self,
-        internal_party_match_payload: Bytes,
-        valid_match_settle_atomic_statement: Bytes,
-        match_proofs: Bytes,
-        match_linking_proofs: Bytes,
-        refund_address: Address,
-        nonce: U256,
-        signature: Bytes,
-    ) -> Result<(), Vec<u8>> {
-        self.sponsor_atomic_match_settle_with_receiver(
-            Address::ZERO,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-            refund_address,
-            nonce,
-            signature,
-        )
-    }
-
-    /// Sponsor the gas costs of an atomic match settlement with the given
-    /// receiver
-    #[payable]
-    #[allow(clippy::too_many_arguments)]
-    pub fn sponsor_atomic_match_settle_with_receiver(
-        &mut self,
-        receiver: Address,
-        internal_party_match_payload: Bytes,
-        valid_match_settle_atomic_statement: Bytes,
-        match_proofs: Bytes,
-        match_linking_proofs: Bytes,
-        refund_address: Address,
-        nonce: U256,
-        signature: Bytes,
-    ) -> Result<(), Vec<u8>> {
-        let initial_gas = evm::gas_left();
-
-        // Resolve the receiver to use
-        let receiver = if receiver == Address::ZERO { msg::sender() } else { receiver };
-
-        self.sponsored_match_inner(
-            receiver,
-            internal_party_match_payload.clone(),
-            valid_match_settle_atomic_statement.clone(),
-            match_proofs.clone(),
-            match_linking_proofs.clone(),
-            refund_address,
-            nonce,
-            U256::ZERO, // refund_amount
-            signature.clone(),
-        )?;
-
-        let gas_cost = estimate_final_gas_cost(
-            initial_gas,
-            receiver,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-            refund_address,
-            nonce,
-            signature,
-        )?;
-
-        // If gas sponsorship is paused, return early, no refunding will be done
-        if self.is_paused()? {
-            evm::log(GasSponsorPausedFallback { nonce });
-            return Ok(());
-        }
-
-        refund_gas_cost(
-            true, // refund_native_eth
-            refund_address,
-            Address::ZERO, // buy_token_addr
-            gas_cost,
-            receiver,
-            nonce,
-        )?;
-
-        Ok(())
-    }
-
     /// Sponsor the gas costs of an atomic match settlement, with the given
     /// options (receiver, refund address, native ETH vs buy-side token
     /// refund, refund amount).
@@ -355,51 +226,6 @@ impl GasSponsorContract {
             nonce,
         )?;
 
-        Ok(())
-    }
-
-    // --------------------------
-    // | UNSPONSORED SETTLEMENT |
-    // --------------------------
-
-    /// Processes the atomic match settlement through the darkpool contract
-    #[payable]
-    fn process_atomic_match_settle(
-        &mut self,
-        internal_party_match_payload: Bytes,
-        valid_match_settle_atomic_statement: Bytes,
-        match_proofs: Bytes,
-        match_linking_proofs: Bytes,
-    ) -> Result<(), Vec<u8>> {
-        let receiver = msg::sender();
-        self.process_atomic_match_settle_with_receiver(
-            receiver,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-        )
-    }
-
-    /// Calls the darkpool contract's
-    /// `process_atomic_match_settle_with_receiver` method, transferring the
-    /// input tokens from the caller to the gas sponsor
-    #[payable]
-    pub fn process_atomic_match_settle_with_receiver(
-        &mut self,
-        receiver: Address,
-        internal_party_match_payload: Bytes,
-        valid_match_settle_atomic_statement: Bytes,
-        match_proofs: Bytes,
-        match_linking_proofs: Bytes,
-    ) -> Result<(), Vec<u8>> {
-        self.atomic_match_inner(
-            receiver,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-        )?;
         Ok(())
     }
 }
@@ -553,106 +379,6 @@ impl GasSponsorContract {
 // ----------------------
 // | NON-MEMBER HELPERS |
 // ----------------------
-
-/// Estimates the units of gas used to invoke the
-/// `sponsor_atomic_match_settle_with_receiver` method
-#[allow(clippy::too_many_arguments)]
-fn estimate_invocation_gas(
-    receiver: Address,
-    internal_party_match_payload: Bytes,
-    valid_match_settle_atomic_statement: Bytes,
-    match_proofs: Bytes,
-    match_linking_proofs: Bytes,
-    refund_address: Address,
-    nonce: U256,
-    signature: Bytes,
-) -> Result<u64, Vec<u8>> {
-    // Compute the cost of calldata, assuming no zero bytes
-    let calldata = sponsorAtomicMatchSettleWithReceiverCall {
-        receiver,
-        internal_party_match_payload: internal_party_match_payload.0.into(),
-        valid_match_settle_atomic_statement: valid_match_settle_atomic_statement.0.into(),
-        match_proofs: match_proofs.0.into(),
-        match_linking_proofs: match_linking_proofs.0.into(),
-        refund_address,
-        nonce,
-        signature: signature.0.into(),
-    };
-    let calldata_len = calldata.abi_encoded_size();
-    let calldata_gas = (calldata_len as u64) * GAS_PER_CALLDATA_BYTE;
-
-    // Compute the initialization gas cost, pessimistically assuming
-    // that the gas sponsor contract is uncached.
-
-    // TODO: Check the `ArbWasmCache` precompile to see if the gas sponsor
-    // contract is cached once we update the Stylus SDK
-
-    // We need to use the address of the gas sponsor implementation contract, not
-    // the proxy from which we assume this method is being delegate-called.
-    // To do so, we read the implementation address from the designated
-    // EIP-1967 storage slot.
-    let gas_sponsor_impl_address_slot = StorageCache::get_word(IMPL_ADDRESS_STORAGE_SLOT);
-    let gas_sponsor_impl_address = Address::from_word(gas_sponsor_impl_address_slot);
-
-    let (init_gas, _) =
-        IArbWasm::new(ARB_WASM_ADDRESS).program_init_gas(Call::new(), gas_sponsor_impl_address)?;
-
-    // Check if this is a native ETH sell, as this requires accounting for some
-    // opaque overhead. It is sufficient to check that the message value is
-    // non-zero. If this is not a native ETH sell and the value is non-zero,
-    // there will be a revert in the darkpool.
-    let is_native_eth_sell = msg::value() > U256::ZERO;
-    let native_eth_sell_gas = if is_native_eth_sell { NATIVE_ETH_SELL_GAS_BUFFER } else { 0 };
-
-    Ok(INVOCATION_BASE_GAS_COST + init_gas + calldata_gas + native_eth_sell_gas)
-}
-
-/// Estimate the total gas spent, including cost of remaining operations.
-/// We frontload as many operations as possible so the final evm::gas_left()
-/// call is as accurate as possible.
-#[allow(clippy::too_many_arguments)]
-fn estimate_final_gas_cost(
-    initial_gas: u64,
-    receiver: Address,
-    internal_party_match_payload: Bytes,
-    valid_match_settle_atomic_statement: Bytes,
-    match_proofs: Bytes,
-    match_linking_proofs: Bytes,
-    refund_address: Address,
-    nonce: U256,
-    signature: Bytes,
-) -> Result<U256, Vec<u8>> {
-    let invocation_gas = estimate_invocation_gas(
-        receiver,
-        internal_party_match_payload,
-        valid_match_settle_atomic_statement,
-        match_proofs,
-        match_linking_proofs,
-        refund_address,
-        nonce,
-        signature,
-    )?;
-
-    // Get the L2 gas price. On Arbitrum, this is always the basefee:
-    // https://docs.arbitrum.io/how-arbitrum-works/gas-fees#l2-tips
-    let gas_price = block::basefee();
-
-    // Get the L1 gas cost - this is the cost in wei
-    let l1_gas_cost =
-        IArbGasInfo::new(ARB_GAS_INFO_ADDRESS).get_current_tx_l_1_gas_fees(Call::new())?;
-
-    // Precompute as much of the gas tallying arithmetic as possible
-    let gas_tally = initial_gas + invocation_gas + NATIVE_REFUND_OPS_GAS_COST;
-
-    // Finally, check the remaining gas
-    let remaining_gas = evm::gas_left();
-    let gas_spent = U256::from(gas_tally - remaining_gas);
-
-    // Compute the total gas cost
-    let gas_cost = gas_price * gas_spent + l1_gas_cost;
-
-    Ok(gas_cost)
-}
 
 /// Resolves the refund address to use for the given arguments.
 fn resolve_refund_address(

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -12,7 +12,7 @@ use stylus_sdk::{
     alloy_primitives::{hex, Address, U256, U64},
     block,
     call::{call, Call},
-    console, contract, evm, msg,
+    contract, evm, msg,
     prelude::*,
     storage::{GlobalStorage, StorageAddress, StorageBool, StorageCache, StorageMap, StorageU64},
     tx,

--- a/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
@@ -12,7 +12,7 @@ use stylus_sdk::{
     alloy_primitives::{Address, U256},
     call::transfer_eth,
     evm, msg,
-    prelude::{entrypoint, public, sol_storage},
+    prelude::*,
 };
 
 use super::dummy_erc20::Erc20;

--- a/contracts-stylus/src/utils/helpers.rs
+++ b/contracts-stylus/src/utils/helpers.rs
@@ -17,7 +17,7 @@ use stylus_sdk::{
     abi::Bytes,
     alloy_primitives::Address,
     call::{call, delegate_call, static_call, MutatingCallContext},
-    storage::TopLevelStorage,
+    prelude::TopLevelStorage,
 };
 
 use crate::{

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -64,9 +64,6 @@ sol! {
     // Testing functions
     function isDummyUpgradeTarget() external view returns (bool);
 
-    // Gas sponsorship functions
-    function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bytes signature) external payable;
-
     // ----------
     // | EVENTS |
     // ----------
@@ -116,17 +113,5 @@ sol_interface! {
         function transfer(address to, uint256 value) external returns (bool);
         function approve(address spender, uint256 value) external returns (bool);
         function balanceOf(address account) external view returns (uint256);
-    }
-}
-
-sol_interface! {
-    interface IArbGasInfo {
-        function getCurrentTxL1GasFees() external view returns (uint256);
-    }
-}
-
-sol_interface! {
-    interface IArbWasm {
-        function programInitGas(address program) external view returns (uint64 gas, uint64 gasWhenCached);
     }
 }

--- a/contracts-utils/Cargo.toml
+++ b/contracts-utils/Cargo.toml
@@ -22,7 +22,7 @@ jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { workspace = true }
 renegade-crypto = { workspace = true }
 circuit-types = { workspace = true }
-circuit-macros = { git = "https://github.com/renegade-fi/renegade.git" }
+circuit-macros = { path = "../../renegade/circuit-macros" }
 circuits = { workspace = true }
 constants = { workspace = true }
 

--- a/contracts-utils/Cargo.toml
+++ b/contracts-utils/Cargo.toml
@@ -22,7 +22,7 @@ jf-utils = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 jf-primitives = { workspace = true }
 renegade-crypto = { workspace = true }
 circuit-types = { workspace = true }
-circuit-macros = { path = "../../renegade/circuit-macros" }
+circuit-macros = { git = "https://github.com/renegade-fi/renegade.git" }
 circuits = { workspace = true }
 constants = { workspace = true }
 

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -34,6 +34,6 @@ inventory = "0.3"
 num-bigint = "0.4"
 ruint = { workspace = true }
 
-test-helpers = { git = "https://github.com/renegade-fi/renegade.git" }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", default-features = false }
+test-helpers = { path = "../../renegade/test-helpers" }
+renegade-crypto = { workspace = true, default-features = false }
 colored = "2"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -34,6 +34,6 @@ inventory = "0.3"
 num-bigint = "0.4"
 ruint = { workspace = true }
 
-test-helpers = { path = "../../renegade/test-helpers" }
+test-helpers = { git = "https://github.com/renegade-fi/renegade.git" }
 renegade-crypto = { workspace = true, default-features = false }
 colored = "2"

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -124,14 +124,6 @@ sol!(
 );
 
 sol!(
-    #[sol(rpc)]
-    contract IAtomicMatchSettleContract {
-        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-    }
-);
-
-sol!(
     #[allow(clippy::too_many_arguments)]
     #[sol(rpc)]
     contract GasSponsorContract {
@@ -139,10 +131,17 @@ sol!(
         function unpause() external;
         function receiveEth() external payable;
         function withdrawEth(address receiver, uint256 amount) external;
-        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
-        function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
-        function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bool memory refund_native_eth, uint256 memory conversion_rate, bytes memory signature) external payable;
+        function sponsorAtomicMatchSettleWithRefundOptions(
+            address receiver,
+            bytes memory internal_party_match_payload,
+            bytes memory valid_match_settle_atomic_statement,
+            bytes memory match_proofs,
+            bytes memory match_linking_proofs,
+            address memory refund_address,
+            uint256 memory nonce,
+            bool memory refund_native_eth,
+            uint256 memory refund_amount,
+            bytes memory signature
+        ) external payable;
     }
 );

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -1,7 +1,6 @@
 //! Constants used in the integration tests
 
 use alloy_primitives::U256;
-use ruint::uint;
 
 /// The default hostport that the Nitro devnet L2 node runs on
 pub(crate) const DEFAULT_DEVNET_HOSTPORT: &str = "http://localhost:8547";
@@ -12,10 +11,6 @@ pub(crate) const DEFAULT_DEVNET_PKEY: &str =
 
 /// The name of the domain separator for Permit2 typed data
 pub(crate) const PERMIT2_EIP712_DOMAIN_NAME: &str = "Permit2";
-
-/// The gas cost tolerance, i.e. the margin of error in units of gas
-/// that is permissible in our gas refund accounting
-pub(crate) const GAS_COST_TOLERANCE: U256 = uint!(15_000U256);
 
 /// The amount of token to refund in an in-kind sponsorship test,
 /// regardless of what asset is being used for refunding.

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -9,7 +9,6 @@ use abis::{
     DarkpoolTestContract::{self, DarkpoolTestContractInstance},
     DummyErc20Contract::{self, DummyErc20ContractInstance},
     GasSponsorContract::{self, GasSponsorContractInstance},
-    IAtomicMatchSettleContract::IAtomicMatchSettleContractInstance,
     TransferExecutorContract::TransferExecutorContractInstance,
 };
 use alloy::{
@@ -51,8 +50,6 @@ pub type GasSponsorInstance = GasSponsorContractInstance<(), DynProvider, Ethere
 pub type TransferExecutorInstance = TransferExecutorContractInstance<(), DynProvider, Ethereum>;
 /// An instance of the dummy ERC20 contract
 pub type DummyErc20Instance = DummyErc20ContractInstance<(), DynProvider, Ethereum>;
-/// An instance of the atomic match settle interface
-pub type IAtomicMatchSettleInstance = IAtomicMatchSettleContractInstance<(), DynProvider, Ethereum>;
 
 /// The context provided to each integration test
 ///

--- a/integration/src/tests/atomic_settlement.rs
+++ b/integration/src/tests/atomic_settlement.rs
@@ -4,17 +4,16 @@ use alloy_primitives::{Address, U256};
 use ark_ff::One;
 use contracts_common::{constants::TEST_MERKLE_HEIGHT, types::ScalarField};
 use contracts_utils::merkle::new_ark_merkle_tree;
-use eyre::{eyre, Result};
+use eyre::Result;
 use scripts::utils::{call_helper, send_tx};
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
-    abis::IAtomicMatchSettleContract,
     utils::{
         insert_shares_and_get_root, serialize_to_calldata, setup_atomic_match_settle_test,
         setup_atomic_match_settle_test_native_eth, u256_to_scalar,
     },
-    IAtomicMatchSettleInstance, TestContext,
+    TestContext,
 };
 
 /// Test a successful call to `process_atomic_match_settle`
@@ -65,11 +64,11 @@ integration_test_async!(test_process_atomic_match_settle__internal_party);
 /// Test `process_atomic_match_settle` and verify the external party's state
 /// after update. That is, the erc20 transfers that result from the atomic match
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__external_party_buy_side(
+pub async fn test_process_atomic_match_settle__external_party_buy_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
     // Setup test data
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
@@ -132,24 +131,16 @@ pub async fn _test_process_atomic_match_settle__external_party_buy_side(
 
     Ok(())
 }
-
-/// Run the `test_process_atomic_match_settle__external_party_buy_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__external_party_buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_buy_side(ctx, contract).await
-}
 integration_test_async!(test_process_atomic_match_settle__external_party_buy_side);
 
 /// Test `process_atomic_match_settle` and verify the external party's state
 /// after update. That is, the erc20 transfers that result from the atomic match
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__external_party_sell_side(
+pub async fn test_process_atomic_match_settle__external_party_sell_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
     // Setup test data
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
@@ -212,25 +203,15 @@ pub async fn _test_process_atomic_match_settle__external_party_sell_side(
 
     Ok(())
 }
-
-/// Run the `test_process_atomic_match_settle__external_party_sell_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__external_party_sell_side(
-    ctx: TestContext,
-) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_sell_side(ctx, contract).await
-}
 integration_test_async!(test_process_atomic_match_settle__external_party_sell_side);
 
 /// Test `process_atomic_match_settle` with the native asset
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__native_asset_sell_side(
+pub async fn test_process_atomic_match_settle__native_asset_sell_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
     // Setup test data
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
@@ -261,7 +242,7 @@ pub async fn _test_process_atomic_match_settle__native_asset_sell_side(
             serialize_to_calldata(&data.match_atomic_linking_proofs)?,
         )
         .value(base_amount);
-    let receipt = send_tx(call).await?.ok_or_else(|| eyre!("No tx receipt"))?;
+    let receipt = send_tx(call).await?;
 
     let gas_used = receipt.gas_used;
     let gas_price = receipt.effective_gas_price;
@@ -296,22 +277,14 @@ pub async fn _test_process_atomic_match_settle__native_asset_sell_side(
 
     Ok(())
 }
-
-/// Run the `test_process_atomic_match_settle__native_asset_sell_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__native_asset_sell_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_sell_side(ctx, contract).await
-}
 integration_test_async!(test_process_atomic_match_settle__native_asset_sell_side);
 
 /// Test `process_atomic_match_settle` with native asset on buy side
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__native_asset_buy_side(
+pub async fn test_process_atomic_match_settle__native_asset_buy_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
@@ -338,7 +311,7 @@ pub async fn _test_process_atomic_match_settle__native_asset_buy_side(
         serialize_to_calldata(&data.match_atomic_proofs)?,
         serialize_to_calldata(&data.match_atomic_linking_proofs)?,
     );
-    let receipt = send_tx(call).await?.ok_or_else(|| eyre!("No tx receipt"))?;
+    let receipt = send_tx(call).await?;
 
     let gas_used = receipt.gas_used;
     let gas_price = receipt.effective_gas_price;
@@ -373,14 +346,6 @@ pub async fn _test_process_atomic_match_settle__native_asset_buy_side(
     );
 
     Ok(())
-}
-
-/// Run the `test_process_atomic_match_settle__native_asset_buy_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__native_asset_buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_buy_side(ctx, contract).await
 }
 integration_test_async!(test_process_atomic_match_settle__native_asset_buy_side);
 
@@ -502,11 +467,9 @@ integration_test_async!(test_process_atomic_match_settle_nonzero_transaction_val
 /// Test the `process_atomic_match_settle_with_receiver` method on the darkpool
 ///
 /// I.e. test an atomic settlement with a non-sender receiver specified
-pub async fn _test_process_atomic_match_settle_with_receiver(
-    ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
-) -> Result<()> {
+pub async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
     // Setup test with a random receiver address
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let receiver = Address::random();
     let base_addr = ctx.test_erc20_address1;
@@ -535,7 +498,7 @@ pub async fn _test_process_atomic_match_settle_with_receiver(
         serialize_to_calldata(&data.match_atomic_proofs)?,
         serialize_to_calldata(&data.match_atomic_linking_proofs)?,
     );
-    send_tx(call).await?.ok_or_else(|| eyre!("No tx receipt"))?;
+    send_tx(call).await?;
 
     // Get post-balances for receiver
     let sender_post_base_balance = ctx.get_erc20_balance(base_addr).await?;
@@ -582,14 +545,6 @@ pub async fn _test_process_atomic_match_settle_with_receiver(
     );
 
     Ok(())
-}
-
-/// Run the `test_process_atomic_match_settle_with_receiver` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle_with_receiver(ctx, contract).await
 }
 integration_test_async!(test_process_atomic_match_settle_with_receiver);
 

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -6,64 +6,13 @@ use scripts::utils::send_tx;
 use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
 
 use crate::{
-    abis::IAtomicMatchSettleContract,
     constants::REFUND_AMOUNT,
     utils::{
-        assert_native_eth_gas_refund, serialize_to_calldata, setup_sponsored_match_test,
-        SponsoredMatchTestOptions,
+        amount_received_in_match, assert_native_eth_gas_refund, setup_sponsored_match_test,
+        sponsor_match_with_test_data, SponsoredMatchTestOptions,
     },
     TestContext,
 };
-
-use super::atomic_settlement::{
-    _test_process_atomic_match_settle__external_party_buy_side,
-    _test_process_atomic_match_settle__external_party_sell_side,
-    _test_process_atomic_match_settle__native_asset_buy_side,
-    _test_process_atomic_match_settle__native_asset_sell_side,
-    _test_process_atomic_match_settle_with_receiver,
-};
-
-/// Test an unsponsored buy through the gas
-/// sponsor
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_buy_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__buy_side);
-
-/// Test an unsponsored sell through the gas
-/// sponsor
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__sell_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_sell_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__sell_side);
-
-/// Test an unsponsored buy through the gas sponsor with the native asset
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__native_asset_buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_buy_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__native_asset_buy_side);
-
-/// Test an unsponsored sell through the gas sponsor with the native asset
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__native_asset_sell_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_sell_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__native_asset_sell_side);
-
-/// Test an unsponsored match with a receiver through the gas sponsor
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match_with_receiver(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle_with_receiver(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match_with_receiver);
 
 /// Test a sponsored match through the gas sponsor.
 ///
@@ -71,21 +20,13 @@ integration_test_async!(test_unsponsored_match_with_receiver);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match_refund__simple(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
     let final_eth_balance = ctx.get_eth_balance().await?;
 
     assert_native_eth_gas_refund(initial_eth_balance, final_eth_balance, receipt)
@@ -98,35 +39,16 @@ integration_test_async!(test_sponsored_match_refund__simple);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match_refund__native_asset_buy(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { trade_native_eth: true, ..Default::default() },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { trade_native_eth: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let eth_received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
-
-    let match_result =
-        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement.match_result;
-
-    let fees = &data
-        .process_atomic_match_settle_data
-        .valid_match_settle_atomic_statement
-        .external_party_fees;
-
-    let eth_received_in_match = match_result.base_amount - fees.total();
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let final_eth_balance = ctx.get_eth_balance().await?;
     let post_refund_eth_balance = final_eth_balance - eth_received_in_match;
@@ -141,40 +63,24 @@ integration_test_async!(test_sponsored_match_refund__native_asset_buy);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match_refund__native_asset_sell(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { sell_side: true, trade_native_eth: true, ..Default::default() },
-        &ctx,
-    )
-    .await?;
+    let options =
+        SponsoredMatchTestOptions { sell_side: true, trade_native_eth: true, ..Default::default() };
+
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let base_amount = data
         .process_atomic_match_settle_data
         .valid_match_settle_atomic_statement
         .match_result
         .base_amount;
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract
-        .sponsorAtomicMatchSettle(
-            serialize_to_calldata(
-                &data.process_atomic_match_settle_data.internal_party_match_payload,
-            )?,
-            serialize_to_calldata(
-                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-            )?,
-            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-            serialize_to_calldata(
-                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
-            )?,
-            data.refund_address,
-            data.nonce,
-            data.signature,
-        )
-        .value(base_amount);
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let final_eth_balance = ctx.get_eth_balance().await?;
     let post_refund_eth_balance = final_eth_balance + base_amount;
+
     assert_native_eth_gas_refund(initial_eth_balance, post_refund_eth_balance, receipt)
 }
 integration_test_async!(test_sponsored_match_refund__native_asset_sell);
@@ -185,39 +91,19 @@ integration_test_async!(test_sponsored_match_refund__native_asset_sell);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__duplicate_nonce(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data1 = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
-    let data2 = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data1 = setup_sponsored_match_test(options, &ctx).await?;
+    let mut data2 = setup_sponsored_match_test(options, &ctx).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(
-            &data1.process_atomic_match_settle_data.internal_party_match_payload,
-        )?,
-        serialize_to_calldata(
-            &data1.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data1.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data1.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data1.refund_address,
-        data1.nonce,
-        data1.signature.clone(),
-    );
-    send_tx(settle_tx).await?.expect("no tx receipt");
+    // Ensure we reuse the signed components of the first sponsored match
+    data2.nonce = data1.nonce;
+    data2.refund_address = data1.refund_address;
+    data2.refund_amount = data1.refund_amount;
+    data2.signature = data1.signature.clone();
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(
-            &data2.process_atomic_match_settle_data.internal_party_match_payload,
-        )?,
-        serialize_to_calldata(
-            &data2.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data2.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data2.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        // Here, we reuse the refund address + nonce + signature from the first match
-        data1.refund_address,
-        data1.nonce,
-        data1.signature,
-    );
-    let result = send_tx(settle_tx).await;
+    sponsor_match_with_test_data(&gas_sponsor_contract, data1).await?;
+    let result = sponsor_match_with_test_data(&gas_sponsor_contract, data2).await;
+
     assert_true_result!(result.is_err())
 }
 integration_test_async!(test_sponsored_match__duplicate_nonce);
@@ -229,20 +115,14 @@ integration_test_async!(test_sponsored_match__duplicate_nonce);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__invalid_signature(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let mut data = setup_sponsored_match_test(options, &ctx).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        Address::random(), // Incorrect refund address
-        data.nonce,
-        data.signature,
-    );
-    let result = send_tx(settle_tx).await;
+    // Set an incorrect refund address
+    data.refund_address = Address::random();
+
+    let result = sponsor_match_with_test_data(&gas_sponsor_contract, data).await;
+
     assert_true_result!(result.is_err())
 }
 integration_test_async!(test_sponsored_match__invalid_signature);
@@ -253,24 +133,16 @@ integration_test_async!(test_sponsored_match__invalid_signature);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__paused(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     // Pause the gas sponsor
     send_tx(gas_sponsor_contract.pause()).await?;
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
     let gas_cost = receipt.gas_used as u128 * receipt.effective_gas_price;
     let final_eth_balance = ctx.get_eth_balance().await?;
 
@@ -284,26 +156,17 @@ integration_test_async!(test_sponsored_match__paused);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     // Withdraw all ETH from the gas sponsor
     let balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
     let withdraw_tx = gas_sponsor_contract.withdrawEth(ctx.client.address(), balance);
-    send_tx(withdraw_tx).await?.expect("no tx receipt");
+    send_tx(withdraw_tx).await?;
 
     let initial_eth_balance = ctx.get_eth_balance().await?;
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let gas_cost = receipt.gas_used as u128 * receipt.effective_gas_price;
     let final_eth_balance = ctx.get_eth_balance().await?;
@@ -319,43 +182,27 @@ integration_test_async!(test_sponsored_match__underfunded);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__in_kind__simple(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let (buy_token_addr, _) = data
         .process_atomic_match_settle_data
         .valid_match_settle_atomic_statement
         .match_result
         .external_party_buy_mint_amount();
-    let initial_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        Address::ZERO, // receiver
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
     );
-    send_tx(settle_tx).await?.expect("no tx receipt");
-    let final_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
 
-    assert_eq_result!(initial_balance - final_balance, U256::from(REFUND_AMOUNT))
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let post_refund_balance = final_balance - received_in_match;
+
+    assert_eq_result!(post_refund_balance - initial_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__in_kind__simple);
 
@@ -366,36 +213,26 @@ integration_test_async!(test_sponsored_match__in_kind__simple);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__in_kind__native_buy(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            trade_native_eth: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
-    let initial_eth_balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
+    let options = SponsoredMatchTestOptions {
+        in_kind_refund: true,
+        trade_native_eth: true,
+        ..Default::default()
+    };
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        Address::ZERO, // receiver
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let eth_received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
     );
-    send_tx(settle_tx).await?.expect("no tx receipt");
-    let final_eth_balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
 
-    assert_eq_result!(initial_eth_balance - final_eth_balance, U256::from(REFUND_AMOUNT))
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let post_refund_eth_balance = final_eth_balance - eth_received_in_match;
+
+    assert_native_eth_gas_refund(initial_eth_balance, post_refund_eth_balance, receipt)
 }
 integration_test_async!(test_sponsored_match__in_kind__native_buy);
 
@@ -406,28 +243,13 @@ integration_test_async!(test_sponsored_match__in_kind__native_buy);
 pub async fn test_sponsored_match__refund_address__explicit(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
     let refund_address = Address::random();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { refund_address, ..Default::default() },
-        &ctx,
-    )
-    .await?;
-    let initial_eth_balance = ctx.get_eth_balance_of(refund_address).await?;
+    let options = SponsoredMatchTestOptions { refund_address, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
     let final_eth_balance = ctx.get_eth_balance_of(refund_address).await?;
-
-    assert_native_eth_gas_refund(initial_eth_balance, final_eth_balance, receipt)
+    assert_eq_result!(final_eth_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__refund_address__explicit);
 
@@ -440,35 +262,16 @@ pub async fn test_sponsored_match__refund_address__tx_origin(ctx: TestContext) -
     // Generate a random receiver address different from tx::origin to ensure
     // we can properly test that the refund goes to tx::origin and not the receiver
     let receiver = Address::random();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { receiver, sign_refund_amount: true, ..Default::default() },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { receiver, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     // tx::origin() will be ctx.client.address() in this case
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        receiver,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
     let final_eth_balance = ctx.get_eth_balance().await?;
 
-    let diff = initial_eth_balance - final_eth_balance;
-    let gas_cost = receipt.gas_used as u128 * receipt.effective_gas_price;
-    assert_eq_result!(U256::from(gas_cost) - diff, U256::from(REFUND_AMOUNT))?;
+    assert_native_eth_gas_refund(initial_eth_balance, final_eth_balance, receipt)?;
 
     // Verify that the refund went to tx::origin and not the receiver
     let receiver_eth_balance = ctx.get_eth_balance_of(receiver).await?;
@@ -485,61 +288,39 @@ pub async fn test_sponsored_match__refund_address__receiver(ctx: TestContext) ->
     // Generate a random receiver address different from tx::origin to ensure
     // we can properly test that the refund goes to the receiver and not tx::origin
     let receiver = Address::random();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            receiver,
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
+    let options =
+        SponsoredMatchTestOptions { receiver, in_kind_refund: true, ..Default::default() };
+
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let (buy_token_addr, _) = data
         .process_atomic_match_settle_data
         .valid_match_settle_atomic_statement
         .match_result
         .external_party_buy_mint_amount();
-    let initial_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
+
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
 
     // Record tx::origin's initial balance to verify it doesn't receive the refund
-    let tx_origin_initial_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, ctx.client.address()).await?;
+    let tx_origin_initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        receiver,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        Address::ZERO, // refund_address
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
-    );
-    send_tx(settle_tx).await?.expect("no tx receipt");
-    let final_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
-
-    assert_eq_result!(initial_balance - final_balance, U256::from(REFUND_AMOUNT))?;
-
-    // Verify that the refund was sent to the receiver
-    let receiver_balance = ctx.get_erc20_balance_of(buy_token_addr, receiver).await?;
-    assert_true_result!(receiver_balance > U256::ZERO)?;
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Verify that tx::origin did not receive the refund by checking its balance
     // didn't change
-    let tx_origin_final_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, ctx.client.address()).await?;
+    let tx_origin_final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
     assert_eq!(
         tx_origin_final_balance, tx_origin_initial_balance,
         "tx::origin's balance changed when it should not have received the refund"
     );
+
+    // Verify that the refund was sent to the receiver
+    let receiver_balance = ctx.get_erc20_balance_of(buy_token_addr, receiver).await?;
+    let post_refund_balance = receiver_balance - received_in_match;
+    assert_eq_result!(post_refund_balance, REFUND_AMOUNT)?;
 
     Ok(())
 }
@@ -551,17 +332,8 @@ integration_test_async!(test_sponsored_match__refund_address__receiver);
 pub async fn test_sponsored_match__refund_address__msg_sender(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
 
-    // Generate a random receiver address different from tx::origin to ensure
-    // we can properly test that the refund goes to the receiver and not tx::origin
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let (buy_token_addr, _) = data
         .process_atomic_match_settle_data
@@ -569,39 +341,18 @@ pub async fn test_sponsored_match__refund_address__msg_sender(ctx: TestContext) 
         .match_result
         .external_party_buy_mint_amount();
 
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
+
     // msg::sender() will be ctx.client.address() in this case
     let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        Address::ZERO, // receiver
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        Address::ZERO, // refund_address
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
-    );
-    send_tx(settle_tx).await?;
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
-    let base_amount = &data
-        .process_atomic_match_settle_data
-        .valid_match_settle_atomic_statement
-        .match_result
-        .base_amount;
-    let fees = &data
-        .process_atomic_match_settle_data
-        .valid_match_settle_atomic_statement
-        .external_party_fees;
-
-    let received_in_match = base_amount - fees.total();
     let post_refund_balance = final_balance - received_in_match;
 
-    assert_eq_result!(post_refund_balance - initial_balance, U256::from(REFUND_AMOUNT))
+    assert_eq_result!(post_refund_balance - initial_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__refund_address__msg_sender);

--- a/integration/src/utils/sponsored_match.rs
+++ b/integration/src/utils/sponsored_match.rs
@@ -3,29 +3,27 @@
 use alloy::rpc::types::TransactionReceipt;
 use alloy_primitives::{utils::parse_ether, Address, Bytes, U256};
 use ark_std::UniformRand;
-use contracts_common::types::ScalarField;
+use contracts_common::types::{ScalarField, ValidMatchSettleAtomicStatement};
 use contracts_utils::{
     crypto::hash_and_sign_message, proof_system::test_data::SponsoredAtomicMatchSettleData,
 };
 use eyre::Result;
 use rand::thread_rng;
 use scripts::utils::send_tx;
-use test_helpers::assert_true_result;
+use test_helpers::assert_eq_result;
 
-use crate::{
-    abis::DummyErc20Contract,
-    constants::{GAS_COST_TOLERANCE, REFUND_AMOUNT},
-    TestContext,
+use crate::{abis::DummyErc20Contract, constants::REFUND_AMOUNT, GasSponsorInstance, TestContext};
+
+use super::{
+    native_eth_address, scalar_to_u256, serialize_to_calldata, setup_atomic_match_settle_test,
 };
-
-use super::{native_eth_address, scalar_to_u256, setup_atomic_match_settle_test};
 
 // ---------
 // | Types |
 // ---------
 
 /// The options for setting up a sponsored match test
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct SponsoredMatchTestOptions {
     /// Whether or not the external party sells the base
     pub sell_side: bool,
@@ -37,10 +35,6 @@ pub struct SponsoredMatchTestOptions {
     pub receiver: Address,
     /// Whether to refund through the buy-side token
     pub in_kind_refund: bool,
-    /// Whether to sign the refund amount. This should be `true`
-    /// if we are invoking the `sponsorAtomicMatchSettleWithRefundOptions`
-    /// method directly.
-    pub sign_refund_amount: bool,
 }
 
 // -----------
@@ -69,16 +63,12 @@ pub async fn setup_sponsored_match_test(
     let mut rng = thread_rng();
     let nonce = scalar_to_u256(ScalarField::rand(&mut rng));
     let nonce_bytes = nonce.to_be_bytes_vec();
+    let refund_amount_bytes = REFUND_AMOUNT.to_be_bytes_vec();
 
     let mut message = Vec::new();
     message.extend_from_slice(&nonce_bytes);
     message.extend_from_slice(options.refund_address.as_ref());
-
-    if options.sign_refund_amount {
-        // Add the refund amount to the message
-        let refund_amount_bytes = REFUND_AMOUNT.to_be_bytes_vec();
-        message.extend_from_slice(&refund_amount_bytes);
-    }
+    message.extend_from_slice(&refund_amount_bytes);
 
     if options.in_kind_refund {
         // Fund the gas sponsor with some ERC20s
@@ -109,15 +99,79 @@ pub async fn setup_sponsored_match_test(
     })
 }
 
-/// Asserts that the gas refund through native ETH is within the acceptable
-/// tolerance
+/// Asserts that the gas refund through native ETH matches the refund amount.
+/// The `post_refund_eth_balance` is expected to be the balance after accounting
+/// for gas costs & gas refund, but not factoring in any native ETH traded.
 pub fn assert_native_eth_gas_refund(
     initial_eth_balance: U256,
     post_refund_eth_balance: U256,
     receipt: TransactionReceipt,
 ) -> Result<()> {
-    let gas_price = receipt.effective_gas_price;
-    let eth_diff = initial_eth_balance.checked_sub(post_refund_eth_balance).unwrap_or_default();
-    let gas_diff = eth_diff / U256::from(gas_price);
-    assert_true_result!(gas_diff < GAS_COST_TOLERANCE)
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+    let eth_diff = initial_eth_balance - post_refund_eth_balance;
+    assert_eq_result!(gas_cost - eth_diff, REFUND_AMOUNT)
+}
+
+/// Invoke the `sponsor_atomic_match_settle_with_refund_options` method on the
+/// gas sponsor with the given test data
+pub async fn sponsor_match_with_test_data(
+    gas_sponsor: &GasSponsorInstance,
+    data: SponsoredAtomicMatchSettleData,
+) -> Result<TransactionReceipt> {
+    let SponsoredAtomicMatchSettleData {
+        process_atomic_match_settle_data,
+        refund_address,
+        receiver,
+        nonce,
+        refund_native_eth,
+        refund_amount,
+        signature,
+    } = data;
+
+    let internal_party_match_payload =
+        serialize_to_calldata(&process_atomic_match_settle_data.internal_party_match_payload)?;
+
+    let valid_match_settle_atomic_statement = serialize_to_calldata(
+        &process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    )?;
+
+    let match_proofs =
+        serialize_to_calldata(&process_atomic_match_settle_data.match_atomic_proofs)?;
+
+    let match_linking_proofs =
+        serialize_to_calldata(&process_atomic_match_settle_data.match_atomic_linking_proofs)?;
+
+    let mut settle_tx = gas_sponsor.sponsorAtomicMatchSettleWithRefundOptions(
+        receiver,
+        internal_party_match_payload,
+        valid_match_settle_atomic_statement,
+        match_proofs,
+        match_linking_proofs,
+        refund_address,
+        nonce,
+        refund_native_eth,
+        refund_amount,
+        signature,
+    );
+
+    let match_result =
+        &process_atomic_match_settle_data.valid_match_settle_atomic_statement.match_result;
+
+    let native_eth_sell = match_result.base_mint == native_eth_address() && !match_result.direction;
+
+    if native_eth_sell {
+        settle_tx = settle_tx.value(match_result.base_amount);
+    }
+
+    let receipt = send_tx(settle_tx).await?;
+    Ok(receipt)
+}
+
+/// Calculate the amount received by the external party in an atomic match
+pub fn amount_received_in_match(statement: &ValidMatchSettleAtomicStatement) -> U256 {
+    let base_amount = statement.match_result.base_amount;
+
+    let fee_total = statement.external_party_fees.total();
+
+    base_amount - fee_total
 }

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 alloy = { workspace = true, default-features = true, features = ["rlp"] }
 alloy-contract = { workspace = true }
 # In the scripts, we use higher versions of the alloy-sol crates in line with `alloy-contract`
-alloy-sol-types = { version = "0.8" }
+alloy-sol-types = { workspace = true }
 alloy-primitives = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 tokio = { workspace = true }
@@ -16,7 +16,7 @@ itertools = { workspace = true }
 circuits = { workspace = true, features = ["test_helpers"] }
 circuit-types = { workspace = true }
 constants = { workspace = true }
-util = { path = "../../renegade/util", features = [
+util = { git = "https://github.com/renegade-fi/renegade.git", features = [
     "errors",
 ] }
 mpc-plonk = { workspace = true }

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -16,7 +16,7 @@ itertools = { workspace = true }
 circuits = { workspace = true, features = ["test_helpers"] }
 circuit-types = { workspace = true }
 constants = { workspace = true }
-util = { git = "https://github.com/renegade-fi/renegade.git", features = [
+util = { path = "../../renegade/util", features = [
     "errors",
 ] }
 mpc-plonk = { workspace = true }

--- a/scripts/src/commands.rs
+++ b/scripts/src/commands.rs
@@ -1,9 +1,12 @@
 //! Implementations of the various deploy scripts
 
 use alloy::{
+    network::TransactionBuilder,
     primitives::{Address, Bytes, U256},
     providers::Provider,
+    rpc::types::TransactionRequest,
 };
+use alloy_sol_types::SolConstructor;
 use circuit_types::traits::SingleProverCircuit;
 use circuits::zk_circuits::{
     valid_commitments::SizedValidCommitments, valid_fee_redemption::SizedValidFeeRedemption,
@@ -40,14 +43,14 @@ use crate::{
         DeployTestContractsArgs, GenVkeysArgs, UpgradeArgs,
     },
     constants::{
-        Permit2, TransparentUpgradeableProxy, NUM_BYTES_ADDRESS, NUM_BYTES_STORAGE_SLOT,
+        TransparentUpgradeableProxy, NUM_BYTES_ADDRESS, NUM_BYTES_STORAGE_SLOT, PERMIT2_BYTECODE,
         PERMIT2_CONTRACT_KEY, PROCESS_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEYS_FILE,
         PROCESS_MATCH_SETTLE_ATOMIC_VKEYS_FILE, PROCESS_MATCH_SETTLE_VKEYS_FILE,
         PROXY_ADMIN_CONTRACT_KEY, PROXY_ADMIN_STORAGE_SLOT, PROXY_CONTRACT_KEY,
         TEST_ERC20_DECIMALS, TEST_ERC20_TICKER1, TEST_ERC20_TICKER2, TEST_FUNDING_AMOUNT,
-        VALID_FEE_REDEMPTION_VKEY_FILE, VALID_OFFLINE_FEE_SETTLEMENT_VKEY_FILE,
-        VALID_RELAYER_FEE_SETTLEMENT_VKEY_FILE, VALID_WALLET_CREATE_VKEY_FILE,
-        VALID_WALLET_UPDATE_VKEY_FILE,
+        TRANSPARENT_UPGRADEABLE_PROXY_BYTECODE, VALID_FEE_REDEMPTION_VKEY_FILE,
+        VALID_OFFLINE_FEE_SETTLEMENT_VKEY_FILE, VALID_RELAYER_FEE_SETTLEMENT_VKEY_FILE,
+        VALID_WALLET_CREATE_VKEY_FILE, VALID_WALLET_UPDATE_VKEY_FILE,
     },
     errors::ScriptError,
     solidity::{DummyErc20, DummyWeth, ProxyAdmin},
@@ -56,8 +59,8 @@ use crate::{
         build_stylus_contract, darkpool_initialize_calldata, deploy_stylus_contract,
         gas_sponsor_initialize_calldata, get_protocol_external_fee_collection_address,
         get_public_encryption_key, read_deployment_address, read_stylus_deployment_address,
-        send_tx, setup_client, write_deployment_address, write_stylus_contract_address,
-        write_vkey_file, LocalWalletHttpClient,
+        send_raw_tx, send_tx, setup_client, write_deployment_address,
+        write_stylus_contract_address, write_vkey_file, LocalWalletHttpClient,
     },
 };
 
@@ -382,16 +385,10 @@ async fn deploy_proxy(
 ) -> Result<(), ScriptError> {
     // Deploy proxy contract
     let owner_address = client.address();
-    let proxy_contract = TransparentUpgradeableProxy::deploy(
-        client.provider(),
-        implementation_address,
-        owner_address,
-        initialization_calldata,
-    )
-    .await
-    .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?;
+    let deploy_code =
+        get_proxy_deploy_code(implementation_address, owner_address, initialization_calldata)?;
 
-    let proxy_address = *proxy_contract.address();
+    let proxy_address = deploy_from_bytecode(&client, deploy_code).await?;
 
     info!("Proxy contract deployed at address:\n\t{:#x}", proxy_address);
 
@@ -422,14 +419,51 @@ pub async fn deploy_permit2(
     client: LocalWalletHttpClient,
     deployments_path: &str,
 ) -> Result<(), ScriptError> {
-    // Get Permit2 contract ABI and bytecode
-    let permit2 = Permit2::deploy(client.provider())
-        .await
-        .map_err(|e| ScriptError::ContractDeployment(e.to_string()))?;
-    let permit2_address = *permit2.address();
+    let bytecode = hex::decode(PERMIT2_BYTECODE).map_err(err_str!(ScriptError::ArtifactParsing))?;
+
+    let permit2_address = deploy_from_bytecode(&client, bytecode).await?;
 
     info!("Permit2 contract deployed at address:\n\t{:#x}", permit2_address);
     write_deployment_address(deployments_path, PERMIT2_CONTRACT_KEY, permit2_address)
+}
+
+/// Get the deploy code for a proxy contract.
+/// Concretely, this is the bytecode of the proxy contract
+/// concatenated with the calldata for the constructor.
+fn get_proxy_deploy_code(
+    implementation_address: Address,
+    owner_address: Address,
+    initialization_calldata: Bytes,
+) -> Result<Vec<u8>, ScriptError> {
+    let bytecode = hex::decode(TRANSPARENT_UPGRADEABLE_PROXY_BYTECODE)
+        .map_err(err_str!(ScriptError::ArtifactParsing))?;
+
+    let constructor_calldata = TransparentUpgradeableProxy::constructorCall {
+        _logic: implementation_address,
+        initialOwner: owner_address,
+        _data: initialization_calldata,
+    }
+    .abi_encode();
+
+    let deploy_code = [&bytecode[..], &constructor_calldata[..]].concat();
+    Ok(deploy_code)
+}
+
+/// Deploys a contract from its "deploy code" (bytecode + any constructor
+/// calldata). Returns the deployed contract's address.
+async fn deploy_from_bytecode(
+    client: &LocalWalletHttpClient,
+    deploy_code: Vec<u8>,
+) -> Result<Address, ScriptError> {
+    let provider = client.provider();
+    let tx = TransactionRequest::default().with_deploy_code(deploy_code);
+    let receipt = send_raw_tx(&provider, tx).await?;
+
+    let address = receipt.contract_address.ok_or_else(|| {
+        ScriptError::ContractDeployment("Deployed contract address not found".to_string())
+    })?;
+
+    Ok(address)
 }
 
 /// Deploys the ERC-20 contract & approves the Permit2 contract

--- a/scripts/src/constants.rs
+++ b/scripts/src/constants.rs
@@ -7,22 +7,17 @@ use alloy::sol;
 // Compiled from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.0/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
 sol! {
     #[allow(missing_docs)]
-    #[sol(bytecode = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts/TransparentUpgradeableProxy.bin")))]
     #[sol(rpc)]
     TransparentUpgradeableProxy,
     "artifacts/TransparentUpgradeableProxy.abi"
 }
+/// The bytecode of the `TransparentUpgradeableProxy` contract
+pub const TRANSPARENT_UPGRADEABLE_PROXY_BYTECODE: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts/TransparentUpgradeableProxy.bin"));
 
-// The ABI of the `Permit2` contract
-//
-// Compiled from https://github.com/Uniswap/permit2/blob/main/src/Permit2.sol
-sol! {
-    #[allow(missing_docs)]
-    #[sol(bytecode = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts/Permit2.bin")))]
-    #[sol(rpc)]
-    Permit2,
-    "artifacts/Permit2.abi"
-}
+/// The bytecode of the `Permit2` contract
+pub const PERMIT2_BYTECODE: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts/Permit2.bin"));
 
 /// The number of confirmations to wait for the contract deployment transaction
 pub const NUM_DEPLOY_CONFIRMATIONS: usize = 0;

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -12,10 +12,10 @@ use std::{
 };
 
 use alloy::{
-    network::Ethereum,
+    network::{Ethereum, EthereumWallet},
     primitives::Address,
     providers::{DynProvider, Provider, ProviderBuilder},
-    rpc::types::TransactionReceipt,
+    rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::PrivateKeySigner,
     transports::http::reqwest::Url,
 };
@@ -69,7 +69,8 @@ impl Borrow<DynProvider<Ethereum>> for LocalWalletHttpClient {
 impl LocalWalletHttpClient {
     /// Creates a new LocalWalletHttpClient
     pub fn new(signer: PrivateKeySigner, url: Url) -> Self {
-        let provider = ProviderBuilder::new().wallet(signer.clone()).on_http(url.clone());
+        let eth_wallet = EthereumWallet::from(signer.clone());
+        let provider = ProviderBuilder::new().wallet(eth_wallet).on_http(url.clone());
         Self { url, provider: DynProvider::new(provider), signer }
     }
 
@@ -118,6 +119,21 @@ pub async fn send_tx<C: CallDecoder + Unpin>(
         pending_tx.get_receipt().await.map_err(err_str!(ScriptError::ContractInteraction))?;
 
     Ok(Some(receipt))
+}
+
+/// Sends a transaction request, waiting for the transaction to go from pending
+/// to executed, and returns the transaction receipt
+pub async fn send_raw_tx(
+    provider: &DynProvider<Ethereum>,
+    tx: TransactionRequest,
+) -> Result<TransactionReceipt, ScriptError> {
+    let pending_tx =
+        provider.send_transaction(tx).await.map_err(err_str!(ScriptError::ContractInteraction))?;
+
+    let receipt =
+        pending_tx.get_receipt().await.map_err(err_str!(ScriptError::ContractInteraction))?;
+
+    Ok(receipt)
 }
 
 /// Send a call and return the result

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -113,12 +113,12 @@ pub async fn setup_client(
 /// executed, and returns the transaction receipt
 pub async fn send_tx<C: CallDecoder + Unpin>(
     call: EthereumCall<'_, C>,
-) -> Result<Option<TransactionReceipt>, ScriptError> {
+) -> Result<TransactionReceipt, ScriptError> {
     let pending_tx = call.send().await.map_err(err_str!(ScriptError::ContractInteraction))?;
     let receipt =
         pending_tx.get_receipt().await.map_err(err_str!(ScriptError::ContractInteraction))?;
 
-    Ok(Some(receipt))
+    Ok(receipt)
 }
 
 /// Sends a transaction request, waiting for the transaction to go from pending


### PR DESCRIPTION
This PR updates the Stylus SDK to the latest version, making the necessary changes to have all crates in the project compile.

Two changes of note:
1. We remove the now-unused methods on the gas sponsor contract. They are not worth maintaining in a change like this, and I will need to update the integration tests later anyway.
2. A lot of our current usage of the Stylus SDK invokes deprecated methods. We leave these in for now to mitigate the blast radius of this PR.

### TODO:
- [x] Replace deprecated Stylus SDK methods where appropriate
- [x] Update integration tests & get them passing