### PR TITLE
integration: gas_sponsorship: update tests

### DIFF
--- a/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
+++ b/contracts-stylus/src/contracts/test_contracts/dummy_weth.rs
@@ -12,7 +12,7 @@ use stylus_sdk::{
     alloy_primitives::{Address, U256},
     call::transfer_eth,
     evm, msg,
-    prelude::{entrypoint, public, sol_storage},
+    prelude::*,
 };
 
 use super::dummy_erc20::Erc20;

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -124,14 +124,6 @@ sol!(
 );
 
 sol!(
-    #[sol(rpc)]
-    contract IAtomicMatchSettleContract {
-        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-    }
-);
-
-sol!(
     #[allow(clippy::too_many_arguments)]
     #[sol(rpc)]
     contract GasSponsorContract {

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -131,10 +131,17 @@ sol!(
         function unpause() external;
         function receiveEth() external payable;
         function withdrawEth(address receiver, uint256 amount) external;
-        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
-        function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
-        function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bool memory refund_native_eth, uint256 memory conversion_rate, bytes memory signature) external payable;
+        function sponsorAtomicMatchSettleWithRefundOptions(
+            address receiver,
+            bytes memory internal_party_match_payload,
+            bytes memory valid_match_settle_atomic_statement,
+            bytes memory match_proofs,
+            bytes memory match_linking_proofs,
+            address memory refund_address,
+            uint256 memory nonce,
+            bool memory refund_native_eth,
+            uint256 memory refund_amount,
+            bytes memory signature
+        ) external payable;
     }
 );

--- a/integration/src/constants.rs
+++ b/integration/src/constants.rs
@@ -1,7 +1,6 @@
 //! Constants used in the integration tests
 
 use alloy_primitives::U256;
-use ruint::uint;
 
 /// The default hostport that the Nitro devnet L2 node runs on
 pub(crate) const DEFAULT_DEVNET_HOSTPORT: &str = "http://localhost:8547";
@@ -12,10 +11,6 @@ pub(crate) const DEFAULT_DEVNET_PKEY: &str =
 
 /// The name of the domain separator for Permit2 typed data
 pub(crate) const PERMIT2_EIP712_DOMAIN_NAME: &str = "Permit2";
-
-/// The gas cost tolerance, i.e. the margin of error in units of gas
-/// that is permissible in our gas refund accounting
-pub(crate) const GAS_COST_TOLERANCE: U256 = uint!(15_000U256);
 
 /// The amount of token to refund in an in-kind sponsorship test,
 /// regardless of what asset is being used for refunding.

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -9,7 +9,6 @@ use abis::{
     DarkpoolTestContract::{self, DarkpoolTestContractInstance},
     DummyErc20Contract::{self, DummyErc20ContractInstance},
     GasSponsorContract::{self, GasSponsorContractInstance},
-    IAtomicMatchSettleContract::IAtomicMatchSettleContractInstance,
     TransferExecutorContract::TransferExecutorContractInstance,
 };
 use alloy::{
@@ -51,8 +50,6 @@ pub type GasSponsorInstance = GasSponsorContractInstance<(), DynProvider, Ethere
 pub type TransferExecutorInstance = TransferExecutorContractInstance<(), DynProvider, Ethereum>;
 /// An instance of the dummy ERC20 contract
 pub type DummyErc20Instance = DummyErc20ContractInstance<(), DynProvider, Ethereum>;
-/// An instance of the atomic match settle interface
-pub type IAtomicMatchSettleInstance = IAtomicMatchSettleContractInstance<(), DynProvider, Ethereum>;
 
 /// The context provided to each integration test
 ///

--- a/integration/src/tests/atomic_settlement.rs
+++ b/integration/src/tests/atomic_settlement.rs
@@ -9,12 +9,11 @@ use scripts::utils::{call_helper, send_tx};
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
-    abis::IAtomicMatchSettleContract,
     utils::{
         insert_shares_and_get_root, serialize_to_calldata, setup_atomic_match_settle_test,
         setup_atomic_match_settle_test_native_eth, u256_to_scalar,
     },
-    IAtomicMatchSettleInstance, TestContext,
+    TestContext,
 };
 
 /// Test a successful call to `process_atomic_match_settle`
@@ -65,11 +64,11 @@ integration_test_async!(test_process_atomic_match_settle__internal_party);
 /// Test `process_atomic_match_settle` and verify the external party's state
 /// after update. That is, the erc20 transfers that result from the atomic match
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__external_party_buy_side(
+pub async fn test_process_atomic_match_settle__external_party_buy_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
     // Setup test data
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
@@ -132,24 +131,16 @@ pub async fn _test_process_atomic_match_settle__external_party_buy_side(
 
     Ok(())
 }
-
-/// Run the `test_process_atomic_match_settle__external_party_buy_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__external_party_buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_buy_side(ctx, contract).await
-}
 integration_test_async!(test_process_atomic_match_settle__external_party_buy_side);
 
 /// Test `process_atomic_match_settle` and verify the external party's state
 /// after update. That is, the erc20 transfers that result from the atomic match
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__external_party_sell_side(
+pub async fn test_process_atomic_match_settle__external_party_sell_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
     // Setup test data
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let base_addr = ctx.test_erc20_address1;
     let quote_addr = ctx.test_erc20_address2;
@@ -212,25 +203,15 @@ pub async fn _test_process_atomic_match_settle__external_party_sell_side(
 
     Ok(())
 }
-
-/// Run the `test_process_atomic_match_settle__external_party_sell_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__external_party_sell_side(
-    ctx: TestContext,
-) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_sell_side(ctx, contract).await
-}
 integration_test_async!(test_process_atomic_match_settle__external_party_sell_side);
 
 /// Test `process_atomic_match_settle` with the native asset
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__native_asset_sell_side(
+pub async fn test_process_atomic_match_settle__native_asset_sell_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
     // Setup test data
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
@@ -296,22 +277,14 @@ pub async fn _test_process_atomic_match_settle__native_asset_sell_side(
 
     Ok(())
 }
-
-/// Run the `test_process_atomic_match_settle__native_asset_sell_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__native_asset_sell_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_sell_side(ctx, contract).await
-}
 integration_test_async!(test_process_atomic_match_settle__native_asset_sell_side);
 
 /// Test `process_atomic_match_settle` with native asset on buy side
 #[allow(non_snake_case)]
-pub async fn _test_process_atomic_match_settle__native_asset_buy_side(
+pub async fn test_process_atomic_match_settle__native_asset_buy_side(
     ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
 ) -> Result<()> {
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let quote_addr = ctx.test_erc20_address2;
     let darkpool = ctx.darkpool_contract();
@@ -373,14 +346,6 @@ pub async fn _test_process_atomic_match_settle__native_asset_buy_side(
     );
 
     Ok(())
-}
-
-/// Run the `test_process_atomic_match_settle__native_asset_buy_side` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle__native_asset_buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_buy_side(ctx, contract).await
 }
 integration_test_async!(test_process_atomic_match_settle__native_asset_buy_side);
 
@@ -502,11 +467,9 @@ integration_test_async!(test_process_atomic_match_settle_nonzero_transaction_val
 /// Test the `process_atomic_match_settle_with_receiver` method on the darkpool
 ///
 /// I.e. test an atomic settlement with a non-sender receiver specified
-pub async fn _test_process_atomic_match_settle_with_receiver(
-    ctx: TestContext,
-    contract: IAtomicMatchSettleInstance,
-) -> Result<()> {
+pub async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
     // Setup test with a random receiver address
+    let contract = ctx.darkpool_contract();
     let use_gas_sponsor = contract.address() == ctx.gas_sponsor_contract().address();
     let receiver = Address::random();
     let base_addr = ctx.test_erc20_address1;
@@ -582,14 +545,6 @@ pub async fn _test_process_atomic_match_settle_with_receiver(
     );
 
     Ok(())
-}
-
-/// Run the `test_process_atomic_match_settle_with_receiver` test
-/// through the darkpool contract
-#[allow(non_snake_case)]
-async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.darkpool_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle_with_receiver(ctx, contract).await
 }
 integration_test_async!(test_process_atomic_match_settle_with_receiver);
 

--- a/integration/src/tests/atomic_settlement.rs
+++ b/integration/src/tests/atomic_settlement.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, U256};
 use ark_ff::One;
 use contracts_common::{constants::TEST_MERKLE_HEIGHT, types::ScalarField};
 use contracts_utils::merkle::new_ark_merkle_tree;
-use eyre::{eyre, Result};
+use eyre::Result;
 use scripts::utils::{call_helper, send_tx};
 use test_helpers::{assert_eq_result, integration_test_async};
 
@@ -242,7 +242,7 @@ pub async fn test_process_atomic_match_settle__native_asset_sell_side(
             serialize_to_calldata(&data.match_atomic_linking_proofs)?,
         )
         .value(base_amount);
-    let receipt = send_tx(call).await?.ok_or_else(|| eyre!("No tx receipt"))?;
+    let receipt = send_tx(call).await?;
 
     let gas_used = receipt.gas_used;
     let gas_price = receipt.effective_gas_price;
@@ -311,7 +311,7 @@ pub async fn test_process_atomic_match_settle__native_asset_buy_side(
         serialize_to_calldata(&data.match_atomic_proofs)?,
         serialize_to_calldata(&data.match_atomic_linking_proofs)?,
     );
-    let receipt = send_tx(call).await?.ok_or_else(|| eyre!("No tx receipt"))?;
+    let receipt = send_tx(call).await?;
 
     let gas_used = receipt.gas_used;
     let gas_price = receipt.effective_gas_price;
@@ -498,7 +498,7 @@ pub async fn test_process_atomic_match_settle_with_receiver(ctx: TestContext) ->
         serialize_to_calldata(&data.match_atomic_proofs)?,
         serialize_to_calldata(&data.match_atomic_linking_proofs)?,
     );
-    send_tx(call).await?.ok_or_else(|| eyre!("No tx receipt"))?;
+    send_tx(call).await?;
 
     // Get post-balances for receiver
     let sender_post_base_balance = ctx.get_erc20_balance(base_addr).await?;

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -6,7 +6,6 @@ use scripts::utils::send_tx;
 use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
 
 use crate::{
-    abis::IAtomicMatchSettleContract,
     constants::REFUND_AMOUNT,
     utils::{
         assert_native_eth_gas_refund, serialize_to_calldata, setup_sponsored_match_test,
@@ -14,56 +13,6 @@ use crate::{
     },
     TestContext,
 };
-
-use super::atomic_settlement::{
-    _test_process_atomic_match_settle__external_party_buy_side,
-    _test_process_atomic_match_settle__external_party_sell_side,
-    _test_process_atomic_match_settle__native_asset_buy_side,
-    _test_process_atomic_match_settle__native_asset_sell_side,
-    _test_process_atomic_match_settle_with_receiver,
-};
-
-/// Test an unsponsored buy through the gas
-/// sponsor
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_buy_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__buy_side);
-
-/// Test an unsponsored sell through the gas
-/// sponsor
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__sell_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__external_party_sell_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__sell_side);
-
-/// Test an unsponsored buy through the gas sponsor with the native asset
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__native_asset_buy_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_buy_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__native_asset_buy_side);
-
-/// Test an unsponsored sell through the gas sponsor with the native asset
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match__native_asset_sell_side(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle__native_asset_sell_side(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match__native_asset_sell_side);
-
-/// Test an unsponsored match with a receiver through the gas sponsor
-#[allow(non_snake_case)]
-pub async fn test_unsponsored_match_with_receiver(ctx: TestContext) -> Result<()> {
-    let contract = IAtomicMatchSettleContract::new(ctx.gas_sponsor_proxy_address, ctx.provider());
-    _test_process_atomic_match_settle_with_receiver(ctx, contract).await
-}
-integration_test_async!(test_unsponsored_match_with_receiver);
 
 /// Test a sponsored match through the gas sponsor.
 ///

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -8,8 +8,8 @@ use test_helpers::{assert_eq_result, assert_true_result, integration_test_async}
 use crate::{
     constants::REFUND_AMOUNT,
     utils::{
-        assert_native_eth_gas_refund, serialize_to_calldata, setup_sponsored_match_test,
-        SponsoredMatchTestOptions,
+        amount_received_in_match, assert_native_eth_gas_refund, setup_sponsored_match_test,
+        sponsor_match_with_test_data, SponsoredMatchTestOptions,
     },
     TestContext,
 };
@@ -20,21 +20,13 @@ use crate::{
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match_refund__simple(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
     let final_eth_balance = ctx.get_eth_balance().await?;
 
     assert_native_eth_gas_refund(initial_eth_balance, final_eth_balance, receipt)
@@ -47,35 +39,16 @@ integration_test_async!(test_sponsored_match_refund__simple);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match_refund__native_asset_buy(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { trade_native_eth: true, ..Default::default() },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { trade_native_eth: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let eth_received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
-
-    let match_result =
-        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement.match_result;
-
-    let fees = &data
-        .process_atomic_match_settle_data
-        .valid_match_settle_atomic_statement
-        .external_party_fees;
-
-    let eth_received_in_match = match_result.base_amount - fees.total();
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let final_eth_balance = ctx.get_eth_balance().await?;
     let post_refund_eth_balance = final_eth_balance - eth_received_in_match;
@@ -90,40 +63,24 @@ integration_test_async!(test_sponsored_match_refund__native_asset_buy);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match_refund__native_asset_sell(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { sell_side: true, trade_native_eth: true, ..Default::default() },
-        &ctx,
-    )
-    .await?;
+    let options =
+        SponsoredMatchTestOptions { sell_side: true, trade_native_eth: true, ..Default::default() };
+
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let base_amount = data
         .process_atomic_match_settle_data
         .valid_match_settle_atomic_statement
         .match_result
         .base_amount;
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract
-        .sponsorAtomicMatchSettle(
-            serialize_to_calldata(
-                &data.process_atomic_match_settle_data.internal_party_match_payload,
-            )?,
-            serialize_to_calldata(
-                &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-            )?,
-            serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-            serialize_to_calldata(
-                &data.process_atomic_match_settle_data.match_atomic_linking_proofs,
-            )?,
-            data.refund_address,
-            data.nonce,
-            data.signature,
-        )
-        .value(base_amount);
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let final_eth_balance = ctx.get_eth_balance().await?;
     let post_refund_eth_balance = final_eth_balance + base_amount;
+
     assert_native_eth_gas_refund(initial_eth_balance, post_refund_eth_balance, receipt)
 }
 integration_test_async!(test_sponsored_match_refund__native_asset_sell);
@@ -134,39 +91,19 @@ integration_test_async!(test_sponsored_match_refund__native_asset_sell);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__duplicate_nonce(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data1 = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
-    let data2 = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data1 = setup_sponsored_match_test(options, &ctx).await?;
+    let mut data2 = setup_sponsored_match_test(options, &ctx).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(
-            &data1.process_atomic_match_settle_data.internal_party_match_payload,
-        )?,
-        serialize_to_calldata(
-            &data1.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data1.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data1.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data1.refund_address,
-        data1.nonce,
-        data1.signature.clone(),
-    );
-    send_tx(settle_tx).await?.expect("no tx receipt");
+    // Ensure we reuse the signed components of the first sponsored match
+    data2.nonce = data1.nonce;
+    data2.refund_address = data1.refund_address;
+    data2.refund_amount = data1.refund_amount;
+    data2.signature = data1.signature.clone();
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(
-            &data2.process_atomic_match_settle_data.internal_party_match_payload,
-        )?,
-        serialize_to_calldata(
-            &data2.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data2.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data2.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        // Here, we reuse the refund address + nonce + signature from the first match
-        data1.refund_address,
-        data1.nonce,
-        data1.signature,
-    );
-    let result = send_tx(settle_tx).await;
+    sponsor_match_with_test_data(&gas_sponsor_contract, data1).await?;
+    let result = sponsor_match_with_test_data(&gas_sponsor_contract, data2).await;
+
     assert_true_result!(result.is_err())
 }
 integration_test_async!(test_sponsored_match__duplicate_nonce);
@@ -178,20 +115,14 @@ integration_test_async!(test_sponsored_match__duplicate_nonce);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__invalid_signature(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let mut data = setup_sponsored_match_test(options, &ctx).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        Address::random(), // Incorrect refund address
-        data.nonce,
-        data.signature,
-    );
-    let result = send_tx(settle_tx).await;
+    // Set an incorrect refund address
+    data.refund_address = Address::random();
+
+    let result = sponsor_match_with_test_data(&gas_sponsor_contract, data).await;
+
     assert_true_result!(result.is_err())
 }
 integration_test_async!(test_sponsored_match__invalid_signature);
@@ -202,24 +133,16 @@ integration_test_async!(test_sponsored_match__invalid_signature);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__paused(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     // Pause the gas sponsor
     send_tx(gas_sponsor_contract.pause()).await?;
+
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
     let gas_cost = receipt.gas_used as u128 * receipt.effective_gas_price;
     let final_eth_balance = ctx.get_eth_balance().await?;
 
@@ -233,26 +156,17 @@ integration_test_async!(test_sponsored_match__paused);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(Default::default() /* options */, &ctx).await?;
+    let options: SponsoredMatchTestOptions = Default::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     // Withdraw all ETH from the gas sponsor
     let balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
     let withdraw_tx = gas_sponsor_contract.withdrawEth(ctx.client.address(), balance);
-    send_tx(withdraw_tx).await?.expect("no tx receipt");
+    send_tx(withdraw_tx).await?;
 
     let initial_eth_balance = ctx.get_eth_balance().await?;
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let gas_cost = receipt.gas_used as u128 * receipt.effective_gas_price;
     let final_eth_balance = ctx.get_eth_balance().await?;
@@ -268,43 +182,27 @@ integration_test_async!(test_sponsored_match__underfunded);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__in_kind__simple(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let (buy_token_addr, _) = data
         .process_atomic_match_settle_data
         .valid_match_settle_atomic_statement
         .match_result
         .external_party_buy_mint_amount();
-    let initial_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        Address::ZERO, // receiver
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
     );
-    send_tx(settle_tx).await?.expect("no tx receipt");
-    let final_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
 
-    assert_eq_result!(initial_balance - final_balance, U256::from(REFUND_AMOUNT))
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let post_refund_balance = final_balance - received_in_match;
+
+    assert_eq_result!(post_refund_balance - initial_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__in_kind__simple);
 
@@ -315,36 +213,26 @@ integration_test_async!(test_sponsored_match__in_kind__simple);
 #[allow(non_snake_case)]
 pub async fn test_sponsored_match__in_kind__native_buy(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            trade_native_eth: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
-    let initial_eth_balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
+    let options = SponsoredMatchTestOptions {
+        in_kind_refund: true,
+        trade_native_eth: true,
+        ..Default::default()
+    };
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        Address::ZERO, // receiver
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let eth_received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
     );
-    send_tx(settle_tx).await?.expect("no tx receipt");
-    let final_eth_balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
 
-    assert_eq_result!(initial_eth_balance - final_eth_balance, U256::from(REFUND_AMOUNT))
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let post_refund_eth_balance = final_eth_balance - eth_received_in_match;
+
+    assert_native_eth_gas_refund(initial_eth_balance, post_refund_eth_balance, receipt)
 }
 integration_test_async!(test_sponsored_match__in_kind__native_buy);
 
@@ -355,28 +243,13 @@ integration_test_async!(test_sponsored_match__in_kind__native_buy);
 pub async fn test_sponsored_match__refund_address__explicit(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
     let refund_address = Address::random();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { refund_address, ..Default::default() },
-        &ctx,
-    )
-    .await?;
-    let initial_eth_balance = ctx.get_eth_balance_of(refund_address).await?;
+    let options = SponsoredMatchTestOptions { refund_address, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettle(
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
     let final_eth_balance = ctx.get_eth_balance_of(refund_address).await?;
-
-    assert_native_eth_gas_refund(initial_eth_balance, final_eth_balance, receipt)
+    assert_eq_result!(final_eth_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__refund_address__explicit);
 
@@ -389,35 +262,16 @@ pub async fn test_sponsored_match__refund_address__tx_origin(ctx: TestContext) -
     // Generate a random receiver address different from tx::origin to ensure
     // we can properly test that the refund goes to tx::origin and not the receiver
     let receiver = Address::random();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions { receiver, sign_refund_amount: true, ..Default::default() },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { receiver, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     // tx::origin() will be ctx.client.address() in this case
     let initial_eth_balance = ctx.get_eth_balance().await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        receiver,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        data.refund_address,
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
-    );
-    let receipt = send_tx(settle_tx).await?.expect("no tx receipt");
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
     let final_eth_balance = ctx.get_eth_balance().await?;
 
-    let diff = initial_eth_balance - final_eth_balance;
-    let gas_cost = receipt.gas_used as u128 * receipt.effective_gas_price;
-    assert_eq_result!(U256::from(gas_cost) - diff, U256::from(REFUND_AMOUNT))?;
+    assert_native_eth_gas_refund(initial_eth_balance, final_eth_balance, receipt)?;
 
     // Verify that the refund went to tx::origin and not the receiver
     let receiver_eth_balance = ctx.get_eth_balance_of(receiver).await?;
@@ -434,61 +288,39 @@ pub async fn test_sponsored_match__refund_address__receiver(ctx: TestContext) ->
     // Generate a random receiver address different from tx::origin to ensure
     // we can properly test that the refund goes to the receiver and not tx::origin
     let receiver = Address::random();
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            receiver,
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
+    let options =
+        SponsoredMatchTestOptions { receiver, in_kind_refund: true, ..Default::default() };
+
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let (buy_token_addr, _) = data
         .process_atomic_match_settle_data
         .valid_match_settle_atomic_statement
         .match_result
         .external_party_buy_mint_amount();
-    let initial_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
+
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
 
     // Record tx::origin's initial balance to verify it doesn't receive the refund
-    let tx_origin_initial_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, ctx.client.address()).await?;
+    let tx_origin_initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        receiver,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        Address::ZERO, // refund_address
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
-    );
-    send_tx(settle_tx).await?.expect("no tx receipt");
-    let final_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, *gas_sponsor_contract.address()).await?;
-
-    assert_eq_result!(initial_balance - final_balance, U256::from(REFUND_AMOUNT))?;
-
-    // Verify that the refund was sent to the receiver
-    let receiver_balance = ctx.get_erc20_balance_of(buy_token_addr, receiver).await?;
-    assert_true_result!(receiver_balance > U256::ZERO)?;
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Verify that tx::origin did not receive the refund by checking its balance
     // didn't change
-    let tx_origin_final_balance =
-        ctx.get_erc20_balance_of(buy_token_addr, ctx.client.address()).await?;
+    let tx_origin_final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
     assert_eq!(
         tx_origin_final_balance, tx_origin_initial_balance,
         "tx::origin's balance changed when it should not have received the refund"
     );
+
+    // Verify that the refund was sent to the receiver
+    let receiver_balance = ctx.get_erc20_balance_of(buy_token_addr, receiver).await?;
+    let post_refund_balance = receiver_balance - received_in_match;
+    assert_eq_result!(post_refund_balance, REFUND_AMOUNT)?;
 
     Ok(())
 }
@@ -500,17 +332,8 @@ integration_test_async!(test_sponsored_match__refund_address__receiver);
 pub async fn test_sponsored_match__refund_address__msg_sender(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
 
-    // Generate a random receiver address different from tx::origin to ensure
-    // we can properly test that the refund goes to the receiver and not tx::origin
-    let data = setup_sponsored_match_test(
-        SponsoredMatchTestOptions {
-            in_kind_refund: true,
-            sign_refund_amount: true,
-            ..Default::default()
-        },
-        &ctx,
-    )
-    .await?;
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
 
     let (buy_token_addr, _) = data
         .process_atomic_match_settle_data
@@ -518,39 +341,18 @@ pub async fn test_sponsored_match__refund_address__msg_sender(ctx: TestContext) 
         .match_result
         .external_party_buy_mint_amount();
 
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
+
     // msg::sender() will be ctx.client.address() in this case
     let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
 
-    let settle_tx = gas_sponsor_contract.sponsorAtomicMatchSettleWithRefundOptions(
-        Address::ZERO, // receiver
-        serialize_to_calldata(&data.process_atomic_match_settle_data.internal_party_match_payload)?,
-        serialize_to_calldata(
-            &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
-        )?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_proofs)?,
-        serialize_to_calldata(&data.process_atomic_match_settle_data.match_atomic_linking_proofs)?,
-        Address::ZERO, // refund_address
-        data.nonce,
-        data.refund_native_eth,
-        data.refund_amount,
-        data.signature,
-    );
-    send_tx(settle_tx).await?;
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
-    let base_amount = &data
-        .process_atomic_match_settle_data
-        .valid_match_settle_atomic_statement
-        .match_result
-        .base_amount;
-    let fees = &data
-        .process_atomic_match_settle_data
-        .valid_match_settle_atomic_statement
-        .external_party_fees;
-
-    let received_in_match = base_amount - fees.total();
     let post_refund_balance = final_balance - received_in_match;
 
-    assert_eq_result!(post_refund_balance - initial_balance, U256::from(REFUND_AMOUNT))
+    assert_eq_result!(post_refund_balance - initial_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__refund_address__msg_sender);

--- a/integration/src/utils/sponsored_match.rs
+++ b/integration/src/utils/sponsored_match.rs
@@ -3,29 +3,27 @@
 use alloy::rpc::types::TransactionReceipt;
 use alloy_primitives::{utils::parse_ether, Address, Bytes, U256};
 use ark_std::UniformRand;
-use contracts_common::types::ScalarField;
+use contracts_common::types::{ScalarField, ValidMatchSettleAtomicStatement};
 use contracts_utils::{
     crypto::hash_and_sign_message, proof_system::test_data::SponsoredAtomicMatchSettleData,
 };
 use eyre::Result;
 use rand::thread_rng;
 use scripts::utils::send_tx;
-use test_helpers::assert_true_result;
+use test_helpers::assert_eq_result;
 
-use crate::{
-    abis::DummyErc20Contract,
-    constants::{GAS_COST_TOLERANCE, REFUND_AMOUNT},
-    TestContext,
+use crate::{abis::DummyErc20Contract, constants::REFUND_AMOUNT, GasSponsorInstance, TestContext};
+
+use super::{
+    native_eth_address, scalar_to_u256, serialize_to_calldata, setup_atomic_match_settle_test,
 };
-
-use super::{native_eth_address, scalar_to_u256, setup_atomic_match_settle_test};
 
 // ---------
 // | Types |
 // ---------
 
 /// The options for setting up a sponsored match test
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct SponsoredMatchTestOptions {
     /// Whether or not the external party sells the base
     pub sell_side: bool,
@@ -37,10 +35,6 @@ pub struct SponsoredMatchTestOptions {
     pub receiver: Address,
     /// Whether to refund through the buy-side token
     pub in_kind_refund: bool,
-    /// Whether to sign the refund amount. This should be `true`
-    /// if we are invoking the `sponsorAtomicMatchSettleWithRefundOptions`
-    /// method directly.
-    pub sign_refund_amount: bool,
 }
 
 // -----------
@@ -69,16 +63,12 @@ pub async fn setup_sponsored_match_test(
     let mut rng = thread_rng();
     let nonce = scalar_to_u256(ScalarField::rand(&mut rng));
     let nonce_bytes = nonce.to_be_bytes_vec();
+    let refund_amount_bytes = REFUND_AMOUNT.to_be_bytes_vec();
 
     let mut message = Vec::new();
     message.extend_from_slice(&nonce_bytes);
     message.extend_from_slice(options.refund_address.as_ref());
-
-    if options.sign_refund_amount {
-        // Add the refund amount to the message
-        let refund_amount_bytes = REFUND_AMOUNT.to_be_bytes_vec();
-        message.extend_from_slice(&refund_amount_bytes);
-    }
+    message.extend_from_slice(&refund_amount_bytes);
 
     if options.in_kind_refund {
         // Fund the gas sponsor with some ERC20s
@@ -109,15 +99,79 @@ pub async fn setup_sponsored_match_test(
     })
 }
 
-/// Asserts that the gas refund through native ETH is within the acceptable
-/// tolerance
+/// Asserts that the gas refund through native ETH matches the refund amount.
+/// The `post_refund_eth_balance` is expected to be the balance after accounting
+/// for gas costs & gas refund, but not factoring in any native ETH traded.
 pub fn assert_native_eth_gas_refund(
     initial_eth_balance: U256,
     post_refund_eth_balance: U256,
     receipt: TransactionReceipt,
 ) -> Result<()> {
-    let gas_price = receipt.effective_gas_price;
-    let eth_diff = initial_eth_balance.checked_sub(post_refund_eth_balance).unwrap_or_default();
-    let gas_diff = eth_diff / U256::from(gas_price);
-    assert_true_result!(gas_diff < GAS_COST_TOLERANCE)
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+    let eth_diff = initial_eth_balance - post_refund_eth_balance;
+    assert_eq_result!(gas_cost - eth_diff, REFUND_AMOUNT)
+}
+
+/// Invoke the `sponsor_atomic_match_settle_with_refund_options` method on the
+/// gas sponsor with the given test data
+pub async fn sponsor_match_with_test_data(
+    gas_sponsor: &GasSponsorInstance,
+    data: SponsoredAtomicMatchSettleData,
+) -> Result<TransactionReceipt> {
+    let SponsoredAtomicMatchSettleData {
+        process_atomic_match_settle_data,
+        refund_address,
+        receiver,
+        nonce,
+        refund_native_eth,
+        refund_amount,
+        signature,
+    } = data;
+
+    let internal_party_match_payload =
+        serialize_to_calldata(&process_atomic_match_settle_data.internal_party_match_payload)?;
+
+    let valid_match_settle_atomic_statement = serialize_to_calldata(
+        &process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    )?;
+
+    let match_proofs =
+        serialize_to_calldata(&process_atomic_match_settle_data.match_atomic_proofs)?;
+
+    let match_linking_proofs =
+        serialize_to_calldata(&process_atomic_match_settle_data.match_atomic_linking_proofs)?;
+
+    let mut settle_tx = gas_sponsor.sponsorAtomicMatchSettleWithRefundOptions(
+        receiver,
+        internal_party_match_payload,
+        valid_match_settle_atomic_statement,
+        match_proofs,
+        match_linking_proofs,
+        refund_address,
+        nonce,
+        refund_native_eth,
+        refund_amount,
+        signature,
+    );
+
+    let match_result =
+        &process_atomic_match_settle_data.valid_match_settle_atomic_statement.match_result;
+
+    let native_eth_sell = match_result.base_mint == native_eth_address() && !match_result.direction;
+
+    if native_eth_sell {
+        settle_tx = settle_tx.value(match_result.base_amount);
+    }
+
+    let receipt = send_tx(settle_tx).await?;
+    Ok(receipt)
+}
+
+/// Calculate the amount received by the external party in an atomic match
+pub fn amount_received_in_match(statement: &ValidMatchSettleAtomicStatement) -> U256 {
+    let base_amount = statement.match_result.base_amount;
+
+    let fee_total = statement.external_party_fees.total();
+
+    base_amount - fee_total
 }

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -113,12 +113,12 @@ pub async fn setup_client(
 /// executed, and returns the transaction receipt
 pub async fn send_tx<C: CallDecoder + Unpin>(
     call: EthereumCall<'_, C>,
-) -> Result<Option<TransactionReceipt>, ScriptError> {
+) -> Result<TransactionReceipt, ScriptError> {
     let pending_tx = call.send().await.map_err(err_str!(ScriptError::ContractInteraction))?;
     let receipt =
         pending_tx.get_receipt().await.map_err(err_str!(ScriptError::ContractInteraction))?;
 
-    Ok(Some(receipt))
+    Ok(receipt)
 }
 
 /// Sends a transaction request, waiting for the transaction to go from pending


### PR DESCRIPTION
This PR updates the gas sponsorship integration tests to account for the removal of the `sponsorAtomicMatchSettle`, `sponsorAtomicMatchSettleWithReceiver`, and unsponsored atomic match methods.

### Testing
All unit & integration tests pass

### TODO
Replace deprecated Stylus SDK methods, where appropriate