### PR TITLE
contracts-utils, integration: utils: Generate malleable match calldata

### DIFF
--- a/contracts-stylus/src/contracts/core/core_malleable_match_settle.rs
+++ b/contracts-stylus/src/contracts/core/core_malleable_match_settle.rs
@@ -20,7 +20,7 @@ use crate::{
             deserialize_from_calldata, get_weth_address, is_native_eth_address, postcard_serialize,
             serialize_malleable_match_statements_for_verification,
         },
-        solidity::{processMalleableMatchSettleAtomicVkeysCall, verifyAtomicMatchCall},
+        solidity::{processMalleableAtomicMatchSettleVkeysCall, verifyAtomicMatchCall},
     },
     IMPL_ADDRESS_STORAGE_GAP1_SIZE, IMPL_ADDRESS_STORAGE_GAP2_SIZE,
     INVALID_TRANSACTION_VALUE_ERROR_MESSAGE,
@@ -281,7 +281,7 @@ impl CoreMalleableMatchSettleContract {
         linking_proofs: Bytes,
     ) -> Result<(), Vec<u8>> {
         let process_malleable_match_settle_atomic_vkeys =
-            fetch_vkeys(storage, &processMalleableMatchSettleAtomicVkeysCall::SELECTOR)?;
+            fetch_vkeys(storage, &processMalleableAtomicMatchSettleVkeysCall::SELECTOR)?;
 
         if is_native_eth {
             let weth = get_weth_address();

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -36,7 +36,7 @@ sol! {
     function validWalletUpdateVkey() external view returns (bytes);
     function processMatchSettleVkeys() external view returns (bytes);
     function processAtomicMatchSettleVkeys() external view returns (bytes);
-    function processMalleableMatchSettleAtomicVkeys() external view returns (bytes);
+    function processMalleableAtomicMatchSettleVkeys() external view returns (bytes);
     function validRelayerFeeSettlementVkey() external view returns (bytes);
     function validOfflineFeeSettlementVkey() external view returns (bytes);
     function validFeeRedemptionVkey() external view returns (bytes);

--- a/contracts-utils/src/conversion.rs
+++ b/contracts-utils/src/conversion.rs
@@ -3,10 +3,11 @@
 use alloy_primitives::{Address, U160, U256};
 use circuit_types::{
     elgamal::{ElGamalCiphertext, EncryptionKey},
-    fees::FeeTake,
+    fees::{FeeTake, FeeTakeRate},
+    fixed_point::FixedPoint,
     keychain::{NonNativeScalar, PublicSigningKey as CircuitPublicSigningKey},
     note::NOTE_CIPHERTEXT_SIZE,
-    r#match::{ExternalMatchResult, OrderSettlementIndices},
+    r#match::{BoundedMatchResult, ExternalMatchResult, OrderSettlementIndices},
     traits::BaseType,
     transfers::{ExternalTransfer, ExternalTransferDirection},
     Amount, PlonkLinkProof, PlonkProof, PolynomialCommitment, SizedWalletShare,
@@ -14,6 +15,7 @@ use circuit_types::{
 use circuits::zk_circuits::{
     valid_commitments::ValidCommitmentsStatement,
     valid_fee_redemption::SizedValidFeeRedemptionStatement,
+    valid_malleable_match_settle_atomic::SizedValidMalleableMatchSettleAtomicStatement,
     valid_match_settle::SizedValidMatchSettleStatement,
     valid_match_settle_atomic::SizedValidMatchSettleAtomicStatement,
     valid_offline_fee_settlement::SizedValidOfflineFeeSettlementStatement,
@@ -24,8 +26,10 @@ use circuits::zk_circuits::{
 };
 use constants::{Scalar, SystemCurve};
 use contracts_common::types::{
-    BabyJubJubPoint as ContractBabyJubJubPoint, ExternalMatchResult as ContractExternalMatchResult,
-    ExternalTransfer as ContractExternalTransfer, FeeTake as ContractFeeTake, G1Affine,
+    BabyJubJubPoint as ContractBabyJubJubPoint, BoundedMatchResult as ContractBoundedMatchResult,
+    ExternalMatchResult as ContractExternalMatchResult,
+    ExternalTransfer as ContractExternalTransfer, FeeRates as ContractFeeRates,
+    FeeTake as ContractFeeTake, FixedPoint as ContractFixedPoint, G1Affine,
     LinkingProof as ContractLinkingProof, LinkingVerificationKey,
     NoteCiphertext as ContractNoteCiphertext,
     OrderSettlementIndices as ContractOrderSettlementIndices, Proof as ContractProof,
@@ -33,6 +37,7 @@ use contracts_common::types::{
     PublicSigningKey as ContractPublicSigningKey, ScalarField,
     ValidCommitmentsStatement as ContractValidCommitmentsStatement,
     ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+    ValidMalleableMatchSettleAtomicStatement as ContractValidMalleableMatchSettleAtomicStatement,
     ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
     ValidMatchSettleStatement as ContractValidMatchSettleStatement,
     ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
@@ -159,6 +164,11 @@ pub fn to_contract_public_signing_key(
     Ok(ContractPublicSigningKey { x, y })
 }
 
+/// Convert a [`FixedPoint`] to its corresponding smart contract type
+fn to_contract_fixed_point(fixed_point: &FixedPoint) -> Result<ContractFixedPoint> {
+    Ok(ContractFixedPoint { repr: fixed_point.repr.inner() })
+}
+
 /// Convert a [`SizedValidWalletCreateStatement`] to its corresponding smart
 /// contract type
 pub fn to_contract_valid_wallet_create_statement(
@@ -270,11 +280,39 @@ fn to_contract_external_match_result(
     })
 }
 
+/// Convert a [`BoundedMatchResult`] to its corresponding smart contract type
+fn to_contract_bounded_match_result(
+    match_result: &BoundedMatchResult,
+) -> Result<ContractBoundedMatchResult> {
+    let quote_mint = biguint_to_address(&match_result.quote_mint)?;
+    let base_mint = biguint_to_address(&match_result.base_mint)?;
+    let price = to_contract_fixed_point(&match_result.price)?;
+    let min_base_amount = amount_to_u256(match_result.min_base_amount)?;
+    let max_base_amount = amount_to_u256(match_result.max_base_amount)?;
+
+    Ok(ContractBoundedMatchResult {
+        quote_mint,
+        base_mint,
+        price,
+        min_base_amount,
+        max_base_amount,
+        direction: match_result.direction,
+    })
+}
+
 /// Convert a [`FeeTake`] to its corresponding smart contract type
 fn to_contract_fee_take(fee_take: &FeeTake) -> Result<ContractFeeTake> {
     Ok(ContractFeeTake {
         relayer_fee: amount_to_u256(fee_take.relayer_fee)?,
         protocol_fee: amount_to_u256(fee_take.protocol_fee)?,
+    })
+}
+
+/// Convert a [`FeeRates`] to its corresponding smart contract type
+fn to_contract_fee_rates(fee_rates: &FeeTakeRate) -> Result<ContractFeeRates> {
+    Ok(ContractFeeRates {
+        relayer_fee_rate: to_contract_fixed_point(&fee_rates.relayer_fee_rate)?,
+        protocol_fee_rate: to_contract_fixed_point(&fee_rates.protocol_fee_rate)?,
     })
 }
 
@@ -294,6 +332,24 @@ pub fn to_contract_valid_match_settle_atomic_statement(
         internal_party_modified_shares,
         internal_party_indices,
         protocol_fee: statement.protocol_fee.repr.inner(),
+        relayer_fee_address: biguint_to_address(&statement.relayer_fee_address)?,
+    })
+}
+
+/// Convert a [`SizedValidMalleableMatchSettleAtomicStatement`] to its
+/// corresponding smart contract type
+pub fn to_contract_valid_malleable_match_settle_atomic_statement(
+    statement: &SizedValidMalleableMatchSettleAtomicStatement,
+) -> Result<ContractValidMalleableMatchSettleAtomicStatement> {
+    let internal_party_public_shares =
+        wallet_shares_to_scalar_vec(&statement.internal_party_public_shares);
+    let match_result = to_contract_bounded_match_result(&statement.bounded_match_result)?;
+
+    Ok(ContractValidMalleableMatchSettleAtomicStatement {
+        match_result,
+        external_fee_rates: to_contract_fee_rates(&statement.external_fee_rates)?,
+        internal_fee_rates: to_contract_fee_rates(&statement.internal_fee_rates)?,
+        internal_party_public_shares,
         relayer_fee_address: biguint_to_address(&statement.relayer_fee_address)?,
     })
 }

--- a/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
+++ b/contracts-utils/src/proof_system/dummy_renegade_circuits.rs
@@ -253,7 +253,7 @@ pub struct DummyValidMalleableMatchSettleAtomic;
 
 impl SingleProverCircuit for DummyValidMalleableMatchSettleAtomic {
     type Statement = SizedValidMalleableMatchSettleAtomicStatement;
-    type Witness = DummyValidMatchSettleAtomicWitness;
+    type Witness = DummyValidMalleableMatchSettleAtomicWitness;
 
     fn name() -> String {
         "Dummy Valid Malleable Match Settle Atomic".to_string()

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -6,10 +6,10 @@ use ark_ff::One;
 use ark_std::UniformRand;
 use circuit_types::{
     elgamal::EncryptionKey,
-    fees::FeeTake,
+    fees::{FeeTake, FeeTakeRate},
     fixed_point::FixedPoint,
     keychain::PublicSigningKey,
-    r#match::ExternalMatchResult,
+    r#match::{BoundedMatchResult, ExternalMatchResult, OrderSettlementIndices},
     srs::SYSTEM_SRS,
     traits::{CircuitBaseType, SingleProverCircuit},
     transfers::ExternalTransfer,
@@ -18,6 +18,7 @@ use circuit_types::{
 use circuits::zk_circuits::{
     valid_commitments::ValidCommitmentsStatement,
     valid_fee_redemption::SizedValidFeeRedemptionStatement,
+    valid_malleable_match_settle_atomic::SizedValidMalleableMatchSettleAtomicStatement,
     valid_match_settle::SizedValidMatchSettleStatement,
     valid_match_settle_atomic::SizedValidMatchSettleAtomicStatement,
     valid_offline_fee_settlement::SizedValidOfflineFeeSettlementStatement,
@@ -26,7 +27,7 @@ use circuits::zk_circuits::{
     valid_wallet_create::SizedValidWalletCreateStatement,
     valid_wallet_update::SizedValidWalletUpdateStatement,
 };
-use constants::{Scalar, ScalarField, SystemCurve};
+use constants::{Scalar, ScalarField, SystemCurve, MAX_BALANCES, MAX_ORDERS};
 use contracts_common::{
     custom_serde::{statement_to_public_inputs, BytesSerializable},
     types::{
@@ -34,6 +35,7 @@ use contracts_common::{
         MatchLinkingVkeys, MatchLinkingWirePolyComms, MatchPayload, MatchProofs, MatchPublicInputs,
         MatchVkeys, Proof as ContractProof,
         ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+        ValidMalleableMatchSettleAtomicStatement as ContractValidMalleableMatchSettleAtomicStatement,
         ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
         ValidMatchSettleStatement as ContractValidMatchSettleStatement,
         ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
@@ -48,7 +50,11 @@ use jf_primitives::pcs::{prelude::Commitment, StructuredReferenceString};
 
 use mpc_plonk::{proof_system::PlonkKzgSnark, transcript::SolidityTranscript};
 use num_bigint::BigUint;
-use rand::{seq::SliceRandom, CryptoRng, Rng, RngCore};
+use rand::{
+    seq::{IteratorRandom, SliceRandom},
+    CryptoRng, Rng, RngCore,
+};
+use renegade_crypto::fields::biguint_to_scalar;
 use std::iter;
 
 use crate::{
@@ -56,6 +62,7 @@ use crate::{
     conversion::{
         to_circuit_pubkey, to_contract_link_proof, to_contract_proof,
         to_contract_valid_commitments_statement, to_contract_valid_fee_redemption_statement,
+        to_contract_valid_malleable_match_settle_atomic_statement,
         to_contract_valid_match_settle_atomic_statement, to_contract_valid_match_settle_statement,
         to_contract_valid_offline_fee_settlement_statement, to_contract_valid_reblind_statement,
         to_contract_valid_relayer_fee_settlement_statement,
@@ -63,13 +70,16 @@ use crate::{
         to_contract_vkey,
     },
     crypto::{hash_and_sign_message, random_keypair},
-    proof_system::dummy_renegade_circuits::DummyValidMatchSettleAtomic,
+    proof_system::dummy_renegade_circuits::{
+        DummyValidMalleableMatchSettleAtomic, DummyValidMatchSettleAtomic,
+    },
 };
 
 use super::{
     dummy_renegade_circuits::{
         DummyValidCommitments, DummyValidCommitmentsWitness, DummyValidFeeRedemption,
-        DummyValidMatchSettle, DummyValidMatchSettleAtomicWitness, DummyValidMatchSettleWitness,
+        DummyValidMalleableMatchSettleAtomicWitness, DummyValidMatchSettle,
+        DummyValidMatchSettleAtomicWitness, DummyValidMatchSettleWitness,
         DummyValidOfflineFeeSettlement, DummyValidReblind, DummyValidReblindWitness,
         DummyValidRelayerFeeSettlement, DummyValidWalletCreate, DummyValidWalletUpdate,
     },
@@ -102,6 +112,48 @@ pub fn address_to_biguint(address: AlloyAddress) -> BigUint {
 /// Generates a circuit type type with random scalars
 pub fn dummy_circuit_type<R: RngCore + CryptoRng, C: CircuitBaseType>(rng: &mut R) -> C {
     C::from_scalars(&mut iter::repeat_with(|| Scalar::random(rng)))
+}
+
+/// Generates dummy [`OrderSettlementIndices`] with random scalars
+pub fn dummy_settlement_indices<R: RngCore + CryptoRng>(rng: &mut R) -> OrderSettlementIndices {
+    let order = (0..MAX_ORDERS).choose(rng).unwrap();
+    let send = (0..MAX_BALANCES).choose(rng).unwrap();
+    let mut recv = (0..MAX_BALANCES).choose(rng).unwrap();
+    while recv == send {
+        recv = (0..MAX_BALANCES).choose(rng).unwrap();
+    }
+
+    OrderSettlementIndices { balance_send: send, balance_receive: recv, order }
+}
+
+/// Generates a dummy [`FeeTakeRate`] with random scalars
+pub fn dummy_fee_take_rate<R: RngCore + CryptoRng>(rng: &mut R) -> FeeTakeRate {
+    let protocol_fee = random_fee_rate(rng);
+    dummy_fee_take_rate_with_protocol_fee(rng, protocol_fee)
+}
+
+/// Generates a dummy fee take rate with protocol fee specified
+pub fn dummy_fee_take_rate_with_protocol_fee<R: RngCore + CryptoRng>(
+    rng: &mut R,
+    protocol_fee: FixedPoint,
+) -> FeeTakeRate {
+    FeeTakeRate { relayer_fee_rate: random_fee_rate(rng), protocol_fee_rate: protocol_fee }
+}
+
+/// Generates a random fee rate
+pub fn random_fee_rate<R: RngCore + CryptoRng>(rng: &mut R) -> FixedPoint {
+    random_fixed_point(0.00001, 0.01, rng)
+}
+
+/// Generates a random [`FixedPoint`] in the configured range
+pub fn random_fixed_point<R: RngCore + CryptoRng>(min: f64, max: f64, rng: &mut R) -> FixedPoint {
+    let min = FixedPoint::from_f64_round_down(min).repr;
+    let max = FixedPoint::from_f64_round_down(max).repr;
+    let min_bigint = min.to_biguint();
+    let max_bigint = max.to_biguint();
+    let random_repr = rng.gen_range(min_bigint..max_bigint);
+
+    FixedPoint::from_repr(biguint_to_scalar(&random_repr))
 }
 
 /// Generates a dummy [`ValidReblindStatement`] with the given merkle root
@@ -874,4 +926,143 @@ pub fn mutate_random_linking_proof<R: CryptoRng + RngCore>(
     ];
     let proof = proofs.choose_mut(rng).unwrap();
     proof.linking_quotient_poly_comm = G1Affine::rand(rng);
+}
+
+/// The inputs for the `process_malleable_match_settle_atomic` darkpool method
+pub struct ProcessMalleableMatchSettleAtomicData {
+    /// The internal party's match payload
+    pub internal_party_match_payload: MatchPayload,
+    /// The `VALID MALLEABLE MATCH SETTLE ATOMIC` statement
+    pub valid_malleable_match_settle_atomic_statement:
+        ContractValidMalleableMatchSettleAtomicStatement,
+    /// The Plonk proofs submitted to `process_malleable_match_settle_atomic`
+    pub match_atomic_proofs: MatchAtomicProofs,
+    /// The linking proofs submitted to `process_malleable_match_settle_atomic`
+    pub match_atomic_linking_proofs: MatchAtomicLinkingProofs,
+}
+
+/// Generates the statements for a malleable match
+fn dummy_malleable_match_statements<R: CryptoRng + RngCore>(
+    rng: &mut R,
+    merkle_root: Scalar,
+    protocol_fee: FixedPoint,
+    bounded_match_result: BoundedMatchResult,
+) -> (ValidCommitmentsStatement, ValidReblindStatement, SizedValidMalleableMatchSettleAtomicStatement)
+{
+    let indices = dummy_settlement_indices(rng);
+    let relayer_fee_address = address_to_biguint(random_address(rng));
+
+    let valid_commitments = ValidCommitmentsStatement { indices };
+    let valid_reblind = dummy_valid_reblind_statement(rng, merkle_root);
+    let malleable_match_statement = SizedValidMalleableMatchSettleAtomicStatement {
+        bounded_match_result,
+        external_fee_rates: dummy_fee_take_rate_with_protocol_fee(rng, protocol_fee),
+        internal_fee_rates: dummy_fee_take_rate_with_protocol_fee(rng, protocol_fee),
+        internal_party_public_shares: dummy_circuit_type(rng),
+        relayer_fee_address,
+    };
+
+    (valid_commitments, valid_reblind, malleable_match_statement)
+}
+
+/// Generate proofs and linking hints for a malleable match
+fn malleable_match_proofs_and_hints<R: CryptoRng + RngCore>(
+    rng: &mut R,
+    valid_commitments_statement: ValidCommitmentsStatement,
+    valid_reblind_statement: ValidReblindStatement,
+    valid_malleable_match_settle_atomic_statement: SizedValidMalleableMatchSettleAtomicStatement,
+) -> Result<MatchAtomicProofsAndHints> {
+    // Generate dummy witness types
+    let (
+        valid_commitments_witness,
+        valid_reblind_witness,
+        valid_malleable_match_settle_atomic_witness,
+    ) = dummy_malleable_match_witnesses(rng);
+
+    // Prove `VALID COMMITMENTS`
+    let (valid_commitments, valid_commitments_hint) = DummyValidCommitments::prove_with_link_hint(
+        valid_commitments_witness.clone(),
+        valid_commitments_statement,
+    )?;
+    let valid_commitments = to_contract_proof(&valid_commitments)?;
+
+    // Prove `VALID REBLIND`
+    let (valid_reblind, valid_reblind_hint) =
+        DummyValidReblind::prove_with_link_hint(valid_reblind_witness, valid_reblind_statement)?;
+    let valid_reblind = to_contract_proof(&valid_reblind)?;
+
+    // Prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
+    let (valid_malleable_match_settle_atomic, valid_malleable_match_settle_atomic_hint) =
+        DummyValidMalleableMatchSettleAtomic::prove_with_link_hint(
+            valid_malleable_match_settle_atomic_witness,
+            valid_malleable_match_settle_atomic_statement,
+        )?;
+    let valid_malleable_match_settle_atomic =
+        to_contract_proof(&valid_malleable_match_settle_atomic)?;
+
+    // Bundle the return type
+    Ok((
+        MatchAtomicProofs {
+            valid_commitments,
+            valid_reblind,
+            valid_match_settle_atomic: valid_malleable_match_settle_atomic,
+        },
+        // Link hints
+        [
+            (valid_reblind_hint, valid_commitments_hint.clone()),
+            (valid_commitments_hint, valid_malleable_match_settle_atomic_hint),
+        ],
+    ))
+}
+
+/// Get witness types for a malleable match
+pub fn dummy_malleable_match_witnesses<R: RngCore + CryptoRng>(
+    rng: &mut R,
+) -> (
+    DummyValidCommitmentsWitness,
+    DummyValidReblindWitness,
+    DummyValidMalleableMatchSettleAtomicWitness,
+) {
+    let valid_commitments: DummyValidCommitmentsWitness = dummy_circuit_type(rng);
+    let valid_reblind = DummyValidReblindWitness {
+        valid_reblind_commitments: valid_commitments.valid_reblind_commitments,
+    };
+    let valid_malleable_match_settle_atomic = DummyValidMalleableMatchSettleAtomicWitness {
+        valid_commitments_match_settle0: valid_commitments.valid_commitments_match_settle0,
+    };
+
+    (valid_commitments, valid_reblind, valid_malleable_match_settle_atomic)
+}
+
+/// Generates the calldata for a malleable match
+pub fn generate_malleable_match_calldata<R: CryptoRng + RngCore>(
+    rng: &mut R,
+    merkle_root: Scalar,
+    protocol_fee: FixedPoint,
+    bounded_match_result: BoundedMatchResult,
+) -> Result<ProcessMalleableMatchSettleAtomicData> {
+    let (valid_commitments_statement, valid_reblind_statement, malleable_match_statement) =
+        dummy_malleable_match_statements(rng, merkle_root, protocol_fee, bounded_match_result);
+    let (match_atomic_proofs, link_hints) = malleable_match_proofs_and_hints(
+        rng,
+        valid_commitments_statement,
+        valid_reblind_statement.clone(),
+        malleable_match_statement.clone(),
+    )?;
+    let match_atomic_linking_proofs = match_atomic_link_proofs(link_hints)?;
+
+    let internal_party_match_payload = MatchPayload {
+        valid_commitments_statement: to_contract_valid_commitments_statement(
+            valid_commitments_statement,
+        ),
+        valid_reblind_statement: to_contract_valid_reblind_statement(&valid_reblind_statement),
+    };
+
+    Ok(ProcessMalleableMatchSettleAtomicData {
+        internal_party_match_payload,
+        valid_malleable_match_settle_atomic_statement:
+            to_contract_valid_malleable_match_settle_atomic_statement(&malleable_match_statement)?,
+        match_atomic_proofs,
+        match_atomic_linking_proofs,
+    })
 }

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -41,6 +41,7 @@ sol!(
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
+        function processMalleableAtomicMatchSettle(uint256 memory base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable;
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -19,6 +19,7 @@ use alloy::{
     signers::k256::ecdsa::SigningKey,
 };
 use alloy_primitives::U256;
+use circuit_types::fixed_point::FixedPoint;
 use clap::Parser;
 use cli::Cli;
 use contracts_common::types::ScalarField;
@@ -140,6 +141,15 @@ impl TestContext {
         let nullifier_spent = contract.isNullifierSpent(nullifier_u256).call().await?._0;
 
         Ok(nullifier_spent)
+    }
+
+    /// Get the protocol fee of the darkpool as a scalar
+    pub async fn get_protocol_fee(&self) -> Result<FixedPoint> {
+        let contract = self.darkpool_contract();
+        let fee_u256 = contract.getFee().call().await?._0;
+
+        let fee_scalar = Scalar::new(u256_to_scalar(fee_u256));
+        Ok(FixedPoint::from_repr(fee_scalar))
     }
 
     /// Build an instance of the darkpool contract

--- a/integration/src/tests/malleable_atomic_settlement.rs
+++ b/integration/src/tests/malleable_atomic_settlement.rs
@@ -1,0 +1,31 @@
+//! Integration tests for malleable atomic settlement
+use eyre::Result;
+use scripts::utils::send_tx;
+use test_helpers::integration_test_async;
+
+use crate::{
+    utils::{serialize_to_calldata, setup_malleable_match_test},
+    TestContext,
+};
+
+/// Test a basic malleable match
+#[allow(non_snake_case)]
+async fn test_malleable_match__basic(ctx: TestContext) -> Result<()> {
+    let darkpool = ctx.darkpool_contract();
+    let (base_amount, payload) = setup_malleable_match_test(&ctx).await?;
+
+    let receiver = ctx.client.address();
+    let tx = darkpool.processMalleableAtomicMatchSettle(
+        base_amount,
+        receiver,
+        serialize_to_calldata(&payload.internal_party_match_payload)?,
+        serialize_to_calldata(&payload.valid_malleable_match_settle_atomic_statement)?,
+        serialize_to_calldata(&payload.match_atomic_proofs)?,
+        serialize_to_calldata(&payload.match_atomic_linking_proofs)?,
+    );
+    send_tx(tx).await?;
+
+    // TODO: Check the balances of the darkpool, receiver, and fee recipients
+    Ok(())
+}
+integration_test_async!(test_malleable_match__basic);

--- a/integration/src/tests/mod.rs
+++ b/integration/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod darkpool_components;
 mod external_transfer;
 mod fees;
 mod gas_sponsorship;
+mod malleable_atomic_settlement;
 mod precompile;
 
 // TODO: Add test cases covering invalid historical Merkle roots,

--- a/integration/src/utils/malleable_match.rs
+++ b/integration/src/utils/malleable_match.rs
@@ -1,0 +1,116 @@
+//! Integration test utils for malleable matches
+
+use alloy_primitives::U256;
+use circuit_types::{
+    fixed_point::FixedPoint,
+    r#match::{BoundedMatchResult, ExternalMatchResult},
+    Amount,
+};
+use constants::Scalar;
+use contracts_utils::proof_system::test_data::{
+    generate_malleable_match_calldata, random_fixed_point, ProcessMalleableMatchSettleAtomicData,
+};
+use eyre::Result;
+use rand::{thread_rng, Rng};
+use renegade_crypto::fields::scalar_to_u128;
+
+use crate::TestContext;
+
+use super::{address_to_biguint, mint_dummy_erc20s, setup_external_match_token_approvals};
+
+/// The maximum amount in darkpool balances and match volumes
+const MAX_AMOUNT: Amount = 1u128 << 100;
+
+/// Generate the calldata for a malleable match
+pub async fn setup_malleable_match_test(
+    ctx: &TestContext,
+) -> Result<(U256, ProcessMalleableMatchSettleAtomicData)> {
+    let mut rng = thread_rng();
+    let merkle_root = ctx.get_root_scalar().await?;
+    let protocol_fee = ctx.get_protocol_fee().await?;
+
+    // Generate a random match result
+    let external_party_buy = rng.gen_bool(0.5);
+    let mut match_result = random_bounded_match_result(external_party_buy, ctx);
+    match_result.direction = external_party_buy;
+    let payload = generate_malleable_match_calldata(
+        &mut rng,
+        merkle_root,
+        protocol_fee,
+        match_result.clone(),
+    )?;
+
+    // Choose a base amount within the bounds
+    let base_amount = sample_base_amount(&match_result);
+    let quote_amount_fp = match_result.price * Scalar::from(base_amount);
+    let quote_amount = scalar_to_u128(&quote_amount_fp.floor());
+
+    // Setup ERC20 token balances
+    let exact_match_res = exact_match_result(&match_result, base_amount);
+    mint_dummy_erc20s(ctx.test_erc20_address1, U256::from(base_amount), ctx).await?;
+    mint_dummy_erc20s(ctx.test_erc20_address2, U256::from(quote_amount), ctx).await?;
+    setup_external_match_token_approvals(
+        external_party_buy,
+        false, // use_gas_sponsor
+        &exact_match_res,
+        ctx,
+    )
+    .await?;
+
+    Ok((U256::from(base_amount), payload))
+}
+
+/// Generate a random [`BoundedMatchResult`]
+fn random_bounded_match_result(external_party_buy: bool, ctx: &TestContext) -> BoundedMatchResult {
+    let mut rng = thread_rng();
+    let base = ctx.test_erc20_address1;
+    let quote = ctx.test_erc20_address2;
+    let min_base_amount = random_amount();
+    let max_base_amount = rng.gen_range(min_base_amount..MAX_AMOUNT);
+
+    BoundedMatchResult {
+        direction: external_party_buy,
+        quote_mint: address_to_biguint(quote),
+        base_mint: address_to_biguint(base),
+        price: random_price(),
+        min_base_amount,
+        max_base_amount,
+    }
+}
+
+/// Generate a random price for an external match
+fn random_price() -> FixedPoint {
+    let mut rng = thread_rng();
+    random_fixed_point(0.01, 1000., &mut rng)
+}
+
+/// Generate a random amount for a match
+fn random_amount() -> Amount {
+    let mut rng = thread_rng();
+    rng.gen_range(0..MAX_AMOUNT)
+}
+
+/// Choose a base amount
+fn sample_base_amount(match_result: &BoundedMatchResult) -> Amount {
+    let mut rng = thread_rng();
+    let min = match_result.min_base_amount;
+    let max = match_result.max_base_amount;
+    rng.gen_range(min..max)
+}
+
+/// Get the exact match result from a bounded match result and a base amount
+fn exact_match_result(
+    match_result: &BoundedMatchResult,
+    base_amount: Amount,
+) -> ExternalMatchResult {
+    let quote_amount_fp = match_result.price * Scalar::from(base_amount);
+    let quote_amount = scalar_to_u128(&quote_amount_fp.floor());
+
+    ExternalMatchResult {
+        quote_mint: match_result.quote_mint.clone(),
+        base_mint: match_result.base_mint.clone(),
+        quote_amount,
+        base_amount,
+        direction: match_result.direction,
+    }
+}

--- a/integration/src/utils/mod.rs
+++ b/integration/src/utils/mod.rs
@@ -3,11 +3,13 @@
 mod atomic_match;
 mod contract;
 mod conversion;
+mod malleable_match;
 mod sponsored_match;
 mod transfer;
 
 pub use atomic_match::*;
 pub use contract::*;
 pub use conversion::*;
+pub use malleable_match::*;
 pub use sponsored_match::*;
 pub use transfer::*;

--- a/integration/src/utils/transfer.rs
+++ b/integration/src/utils/transfer.rs
@@ -179,11 +179,13 @@ pub async fn setup_external_match_token_approvals(
     match_result: &ExternalMatchResult,
     test_args: &TestContext,
 ) -> Result<()> {
-    let mint = if buy_side { &match_result.quote_mint } else { &match_result.base_mint };
-
-    let mint = biguint_to_address(mint);
+    let mint_bigint = if buy_side { &match_result.quote_mint } else { &match_result.base_mint };
+    let mint = biguint_to_address(mint_bigint);
     let contract = DummyErc20Contract::new(mint, test_args.client.provider());
-    let amount = U256::from(TEST_FUNDING_AMOUNT);
+
+    // Approve the full balance of the sender
+    let sender_address = test_args.client.address();
+    let amount = contract.balanceOf(sender_address).call().await?._0;
 
     let spender = if use_gas_sponsor {
         test_args.gas_sponsor_proxy_address


### PR DESCRIPTION
### Purpose
This PR sets up the testing data and structure for malleable match integration tests. This includes generating calldata, setting up token approvals and balances, etc.

### Todo
- Add all test cases

### Testing
- [x] Added a basic test to check tx reverts