### PR TITLE
contracts-stylus: gas_sponsor: return exact output amount

### DIFF
--- a/contracts-common/src/types/fees.rs
+++ b/contracts-common/src/types/fees.rs
@@ -19,7 +19,7 @@ pub struct FeeTake {
     pub protocol_fee: U256,
 }
 
-#[cfg(any(feature = "core-settlement", feature = "test-helpers"))]
+#[cfg(any(feature = "core-settlement", feature = "gas-sponsor", feature = "test-helpers"))]
 impl FeeTake {
     /// Get the total fee taken
     pub fn total(&self) -> U256 {

--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -19,7 +19,7 @@ use crate::{
             NotePosted, NullifierSpent, WalletUpdated,
         },
     },
-    TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE, VKEYS_FETCH_ERROR_MESSAGE,
+    ARITHMETIC_OVERFLOW_ERROR_MESSAGE, VKEYS_FETCH_ERROR_MESSAGE,
 };
 use alloc::{vec, vec::Vec};
 use alloy_sol_types::{SolCall, SolType};
@@ -279,9 +279,8 @@ pub fn execute_atomic_match_transfers<
     ));
 
     // The amount received by the external party after deducting the fees
-    let trader_take = receive_amount
-        .checked_sub(fees.total())
-        .ok_or(TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE)?;
+    let trader_take =
+        receive_amount.checked_sub(fees.total()).ok_or(ARITHMETIC_OVERFLOW_ERROR_MESSAGE)?;
     transfers_batch.push(SimpleErc20Transfer::new_withdraw(receiver, receive_mint, trader_take));
 
     // The amount sent by the external party to the darkpool

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -1,10 +1,7 @@
 //! The gas sponsor contract, used to sponsor the gas costs of external (atomic)
 //! matches
 
-use contracts_common::{
-    constants::NUM_BYTES_U256,
-    types::{ExternalMatchResult, ValidMatchSettleAtomicStatement},
-};
+use contracts_common::{constants::NUM_BYTES_U256, types::ValidMatchSettleAtomicStatement};
 use contracts_core::crypto::ecdsa::ecdsa_verify;
 use stylus_sdk::{
     abi::Bytes,
@@ -23,11 +20,12 @@ use crate::{
         helpers::{check_address_not_zero, deserialize_from_calldata, is_native_eth_address},
         solidity::{
             GasSponsorPausedFallback, IDarkpool, IErc20, InsufficientSponsorBalance, NonceUsed,
-            OwnershipTransferred, Paused, SponsoredExternalMatch, Unpaused,
+            OwnershipTransferred, Paused, SponsoredExternalMatch, SponsoredExternalMatchOutput,
+            Unpaused,
         },
     },
-    ECDSA_ERROR_MESSAGE, INVALID_ARR_LEN_ERROR_MESSAGE, INVALID_SIGNATURE_ERROR_MESSAGE,
-    INVALID_VERSION_ERROR_MESSAGE, NOT_OWNER_ERROR_MESSAGE,
+    ARITHMETIC_OVERFLOW_ERROR_MESSAGE, ECDSA_ERROR_MESSAGE, INVALID_ARR_LEN_ERROR_MESSAGE,
+    INVALID_SIGNATURE_ERROR_MESSAGE, INVALID_VERSION_ERROR_MESSAGE, NOT_OWNER_ERROR_MESSAGE,
 };
 
 // ------------------
@@ -182,6 +180,10 @@ impl GasSponsorContract {
     /// refund, refund amount).
     /// If the `receiver` is the zero address, we use `msg::sender()` as the
     /// receiver.
+    /// If the `refund_address` is the zero address, we use the receiver as the
+    /// refund address.
+    ///
+    /// Returns the amount received by the external party.
     #[payable]
     #[allow(clippy::too_many_arguments)]
     pub fn sponsor_atomic_match_settle_with_refund_options(
@@ -196,11 +198,11 @@ impl GasSponsorContract {
         refund_native_eth: bool,
         refund_amount: U256,
         signature: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         // Resolve the receiver to use
         let receiver = if receiver == Address::ZERO { self.vm().msg_sender() } else { receiver };
 
-        let match_result = self.sponsored_match_inner(
+        let statement = self.sponsored_match_inner(
             receiver,
             internal_party_match_payload,
             valid_match_settle_atomic_statement,
@@ -212,14 +214,20 @@ impl GasSponsorContract {
             signature,
         )?;
 
+        // Calculate the output amount received by the external party, before
+        // sponsorship
+        let (buy_token_addr, buy_amount) = statement.match_result.external_party_buy_mint_amount();
+        let fee_total = statement.external_party_fees.total();
+        let received_excl_refund =
+            buy_amount.checked_sub(fee_total).ok_or(ARITHMETIC_OVERFLOW_ERROR_MESSAGE)?;
+
         // If gas sponsorship is paused, return early, no refunding will be done
         if self.is_paused()? {
             log(self.vm(), GasSponsorPausedFallback { nonce });
-            return Ok(());
+            return Ok(received_excl_refund);
         }
 
         // Refund the gas costs
-        let (buy_token_addr, _) = match_result.external_party_buy_mint_amount();
         self.refund_gas_cost(
             refund_native_eth,
             refund_address,
@@ -229,7 +237,20 @@ impl GasSponsorContract {
             nonce,
         )?;
 
-        Ok(())
+        // Calculate the total amount received by the external party, inclusive of
+        // sponsorship
+        let is_native_eth_buy = is_native_eth_address(buy_token_addr);
+        let received_amount = if is_native_eth_buy || !refund_native_eth {
+            // If the buy-side token is native ETH, or we are refunding in-kind,
+            // we account for the refund amount in the total output amount
+            received_excl_refund + refund_amount
+        } else {
+            received_excl_refund
+        };
+
+        log(self.vm(), SponsoredExternalMatchOutput { received_amount, nonce });
+
+        Ok(received_amount)
     }
 }
 
@@ -313,9 +334,9 @@ impl GasSponsorContract {
         nonce: U256,
         refund_amount: U256,
         signature: Bytes,
-    ) -> Result<ExternalMatchResult, Vec<u8>> {
+    ) -> Result<ValidMatchSettleAtomicStatement, Vec<u8>> {
         // Invoke the underlying atomic match settlement
-        let match_result = self.atomic_match_inner(
+        let statement = self.atomic_match_inner(
             receiver,
             internal_party_match_payload.clone(),
             valid_match_settle_atomic_statement.clone(),
@@ -329,7 +350,7 @@ impl GasSponsorContract {
         // Mark the nonce as used
         self.mark_nonce_used(nonce)?;
 
-        Ok(match_result)
+        Ok(statement)
     }
 
     /// Invokes the actual atomic match path on the darkpool contract,
@@ -343,7 +364,7 @@ impl GasSponsorContract {
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
-    ) -> Result<ExternalMatchResult, Vec<u8>> {
+    ) -> Result<ValidMatchSettleAtomicStatement, Vec<u8>> {
         let sender = self.vm().msg_sender();
         let sponsor = self.vm().contract_address();
         let darkpool_address = self.darkpool_address.get();
@@ -352,8 +373,7 @@ impl GasSponsorContract {
         let statement: ValidMatchSettleAtomicStatement =
             deserialize_from_calldata(&valid_match_settle_atomic_statement)?;
 
-        let match_result = statement.match_result;
-        let (send_mint, send_amount) = match_result.external_party_sell_mint_amount();
+        let (send_mint, send_amount) = statement.match_result.external_party_sell_mint_amount();
 
         // Only execute an ERC20 transfer if the input token is not the native asset
         if !is_native_eth_address(send_mint) {
@@ -378,7 +398,7 @@ impl GasSponsorContract {
             match_linking_proofs.0.into(),
         )?;
 
-        Ok(match_result)
+        Ok(statement)
     }
 
     /// Resolves the refund address to use for the given arguments.
@@ -429,10 +449,7 @@ impl GasSponsorContract {
             &[], // calldata
         )?;
 
-        log(
-            self.vm(),
-            SponsoredExternalMatch { amount: refund_amount, token: Address::ZERO, nonce },
-        );
+        log(self.vm(), SponsoredExternalMatch { refund_amount, token: Address::ZERO, nonce });
 
         Ok(())
     }
@@ -458,10 +475,7 @@ impl GasSponsorContract {
         // Refund the user's gas costs
         buy_token.transfer(&mut (*self), refund_address, refund_amount)?;
 
-        log(
-            self.vm(),
-            SponsoredExternalMatch { amount: refund_amount, token: buy_token_addr, nonce },
-        );
+        log(self.vm(), SponsoredExternalMatch { refund_amount, token: buy_token_addr, nonce });
 
         Ok(())
     }

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -224,11 +224,17 @@ impl GasSponsorContract {
         // If gas sponsorship is paused, return early, no refunding will be done
         if self.is_paused()? {
             log(self.vm(), GasSponsorPausedFallback { nonce });
+
+            log(
+                self.vm(),
+                SponsoredExternalMatchOutput { received_amount: received_excl_refund, nonce },
+            );
+
             return Ok(received_excl_refund);
         }
 
         // Refund the gas costs
-        self.refund_gas_cost(
+        let actual_refund_amount = self.refund_gas_cost(
             refund_native_eth,
             refund_address,
             buy_token_addr,
@@ -243,7 +249,7 @@ impl GasSponsorContract {
         let received_amount = if is_native_eth_buy || !refund_native_eth {
             // If the buy-side token is native ETH, or we are refunding in-kind,
             // we account for the refund amount in the total output amount
-            received_excl_refund + refund_amount
+            received_excl_refund + actual_refund_amount
         } else {
             received_excl_refund
         };
@@ -427,19 +433,21 @@ impl GasSponsorContract {
     }
 
     /// Refunds the user's gas costs through native ETH.
+    ///
+    /// Returns the actual amount of Ether refunded.
     fn refund_through_native_eth(
         &mut self,
         refund_address: Address,
         refund_amount: U256,
         nonce: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         // If the gas sponsor doesn't have enough Ether to refund the user,
         // emit an event but don't revert.
         let contract_address = self.vm().contract_address();
         let balance = self.vm().balance(contract_address);
         if balance < refund_amount {
             log(self.vm(), InsufficientSponsorBalance { nonce });
-            return Ok(());
+            return Ok(U256::ZERO);
         }
 
         let ctx = Call::new().value(refund_amount);
@@ -451,17 +459,19 @@ impl GasSponsorContract {
 
         log(self.vm(), SponsoredExternalMatch { refund_amount, token: Address::ZERO, nonce });
 
-        Ok(())
+        Ok(refund_amount)
     }
 
     /// Refunds the user's gas costs through the buy-side token.
+    ///
+    /// Returns the actual amount of the buy-side token refunded.
     fn refund_through_buy_token(
         &mut self,
         refund_address: Address,
         buy_token_addr: Address,
         refund_amount: U256,
         nonce: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         let buy_token = IErc20::new(buy_token_addr);
 
         // If the gas sponsor doesn't have enough of the buy-side token to refund the
@@ -469,7 +479,7 @@ impl GasSponsorContract {
         let contract_address = self.vm().contract_address();
         if buy_token.balance_of(&mut (*self), contract_address)? < refund_amount {
             log(self.vm(), InsufficientSponsorBalance { nonce });
-            return Ok(());
+            return Ok(U256::ZERO);
         }
 
         // Refund the user's gas costs
@@ -477,11 +487,14 @@ impl GasSponsorContract {
 
         log(self.vm(), SponsoredExternalMatch { refund_amount, token: buy_token_addr, nonce });
 
-        Ok(())
+        Ok(refund_amount)
     }
 
     /// Refunds the user's gas costs, either through native ETH or the buy-side
     /// token.
+    ///
+    /// Returns the actual amount refunded, which can differ from the passed-in
+    /// value if e.g. the gas sponsor doesn't have enough of the refund token.
     fn refund_gas_cost(
         &mut self,
         refund_native_eth: bool,
@@ -490,7 +503,7 @@ impl GasSponsorContract {
         refund_amount: U256,
         receiver: Address,
         nonce: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         let refund_address =
             self.resolve_refund_address(refund_native_eth, refund_address, receiver);
 

--- a/contracts-stylus/src/utils/constants.rs
+++ b/contracts-stylus/src/utils/constants.rs
@@ -68,9 +68,9 @@ pub const PUBLIC_BLINDER_USED_ERROR_MESSAGE: &[u8] = b"public blinder already us
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
 pub const ROOT_NOT_IN_HISTORY_ERROR_MESSAGE: &[u8] = b"root not in history";
 
-/// The revert message when a transfer arithmetic operation overflows
-#[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]
-pub const TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE: &[u8] = b"transfer arithmetic overflow";
+/// The revert message when an arithmetic operation overflows
+#[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract", feature = "gas-sponsor"))]
+pub const ARITHMETIC_OVERFLOW_ERROR_MESSAGE: &[u8] = b"arithmetic overflow";
 
 /// The revert message when a transaction value should be zero
 #[cfg(any(feature = "darkpool-core", feature = "darkpool-test-contract"))]

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -100,7 +100,8 @@ sol! {
     event InsufficientSponsorBalance(uint256 indexed nonce);
     event NonceUsed(uint256 indexed nonce);
     event GasSponsorPausedFallback(uint256 indexed nonce);
-    event SponsoredExternalMatch(uint256 indexed amount, address indexed token, uint256 indexed nonce);
+    event SponsoredExternalMatch(uint256 indexed refund_amount, address indexed token, uint256 indexed nonce);
+    event SponsoredExternalMatchOutput(uint256 indexed received_amount, uint256 indexed nonce);
 }
 
 sol_interface! {

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -142,6 +142,6 @@ sol!(
             bool memory refund_native_eth,
             uint256 memory refund_amount,
             bytes memory signature
-        ) external payable;
+        ) external payable returns (uint256);
     }
 );

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -143,5 +143,7 @@ sol!(
             uint256 memory refund_amount,
             bytes memory signature
         ) external payable returns (uint256);
+
+        event SponsoredExternalMatchOutput(uint256 indexed received_amount, uint256 indexed nonce);
     }
 );

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -8,8 +8,9 @@ use test_helpers::{assert_eq_result, assert_true_result, integration_test_async}
 use crate::{
     constants::REFUND_AMOUNT,
     utils::{
-        amount_received_in_match, assert_native_eth_gas_refund, setup_sponsored_match_test,
-        sponsor_match_with_test_data, SponsoredMatchTestOptions,
+        amount_received_in_match, assert_native_eth_gas_refund, burn_gas_sponsor_token_balance,
+        extract_sponsored_output_event, setup_sponsored_match_test, sponsor_match_with_test_data,
+        SponsoredMatchTestOptions,
     },
     TestContext,
 };
@@ -150,11 +151,11 @@ pub async fn test_sponsored_match__paused(ctx: TestContext) -> Result<()> {
 }
 integration_test_async!(test_sponsored_match__paused);
 
-/// Test a sponsored match when the gas sponsor is underfunded.
+/// Test a sponsored match when the gas sponsor lacks ETH for refunds.
 ///
 /// Asserts that the match succeeds but is not sponsored.
 #[allow(non_snake_case)]
-pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
+pub async fn test_sponsored_match__underfunded_eth(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
     let options: SponsoredMatchTestOptions = Default::default();
     let data = setup_sponsored_match_test(options, &ctx).await?;
@@ -173,7 +174,45 @@ pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
 
     assert_eq_result!(initial_eth_balance - final_eth_balance, U256::from(gas_cost))
 }
-integration_test_async!(test_sponsored_match__underfunded);
+integration_test_async!(test_sponsored_match__underfunded_eth);
+
+/// Test a sponsored match when the gas sponsor lacks the buy-side token for
+/// in-kind refunds.
+///
+/// Asserts that the match succeeds but is not sponsored.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__underfunded_token(ctx: TestContext) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Get the amount received in the match (excluding any refund)
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
+
+    // Burn the buy-side token balance of the gas sponsor
+    burn_gas_sponsor_token_balance(buy_token_addr, &ctx).await?;
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Calculate the final balance and verify no refund was added
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // The difference should be exactly the amount received in the match (no refund)
+    assert_eq_result!(final_balance - initial_balance, received_in_match)
+}
+integration_test_async!(test_sponsored_match__underfunded_token);
 
 /// Test a sponsored match through the gas sponsor with in-kind refunds.
 ///
@@ -356,3 +395,227 @@ pub async fn test_sponsored_match__refund_address__msg_sender(ctx: TestContext) 
     assert_eq_result!(post_refund_balance - initial_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__refund_address__msg_sender);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is equal to the amount of the buy-side token received by the external party
+/// in a match with in-kind sponsorship
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__in_kind(ctx: TestContext) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__in_kind);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is equal to the amount of the buy-side token received by the external party
+/// in a match with native ETH sponsorship (not buying ETH)
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__native_eth(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    // Use default options (native ETH refund, not trading native ETH)
+    let options = SponsoredMatchTestOptions::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__native_eth);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is equal to the amount of native ETH received by the external party
+/// in a match where they are buying ETH
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__native_eth_buy(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions {
+        trade_native_eth: true, // External party is buying ETH
+        ..Default::default()
+    };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    // Record initial ETH balance
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes, accounting for gas
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+
+    // The difference in balance plus gas cost equals the actual amount received
+    let actual_received_amount = final_eth_balance + gas_cost - initial_eth_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__native_eth_buy);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is correctly reported when the gas sponsor is paused
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__paused(ctx: TestContext) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    // Get the buy token address
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Pause the gas sponsor
+    send_tx(gas_sponsor_contract.pause()).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__paused);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is correctly reported when the gas sponsor lacks ETH for refunds
+/// in a match where the external party is buying native ETH
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__underfunded_eth(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions {
+        trade_native_eth: true, // External party is buying ETH
+        ..Default::default()
+    };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    // Withdraw all ETH from the gas sponsor
+    let balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
+    let withdraw_tx = gas_sponsor_contract.withdrawEth(ctx.client.address(), balance);
+    send_tx(withdraw_tx).await?;
+
+    // Record initial ETH balance
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes, accounting for gas
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+
+    // The difference in balance plus gas cost equals the actual amount received
+    let actual_received_amount = final_eth_balance + gas_cost - initial_eth_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__underfunded_eth);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is correctly reported when the gas sponsor lacks the buy-side token for
+/// in-kind refunds
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__underfunded_token(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Burn the buy-side token balance of the gas sponsor
+    burn_gas_sponsor_token_balance(buy_token_addr, &ctx).await?;
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__underfunded_token);

--- a/integration/src/utils/sponsored_match.rs
+++ b/integration/src/utils/sponsored_match.rs
@@ -2,6 +2,7 @@
 
 use alloy::rpc::types::TransactionReceipt;
 use alloy_primitives::{utils::parse_ether, Address, Bytes, U256};
+use alloy_sol_types::SolEvent;
 use ark_std::UniformRand;
 use contracts_common::types::{ScalarField, ValidMatchSettleAtomicStatement};
 use contracts_utils::{
@@ -12,7 +13,11 @@ use rand::thread_rng;
 use scripts::utils::send_tx;
 use test_helpers::assert_eq_result;
 
-use crate::{abis::DummyErc20Contract, constants::REFUND_AMOUNT, GasSponsorInstance, TestContext};
+use crate::{
+    abis::{DummyErc20Contract, GasSponsorContract::SponsoredExternalMatchOutput},
+    constants::REFUND_AMOUNT,
+    GasSponsorInstance, TestContext,
+};
 
 use super::{
     native_eth_address, scalar_to_u256, serialize_to_calldata, setup_atomic_match_settle_test,
@@ -174,4 +179,31 @@ pub fn amount_received_in_match(statement: &ValidMatchSettleAtomicStatement) -> 
     let fee_total = statement.external_party_fees.total();
 
     base_amount - fee_total
+}
+
+/// Extracts the received_amount from a SponsoredExternalMatchOutput event in a
+/// transaction receipt
+pub fn extract_sponsored_output_event(receipt: &TransactionReceipt) -> Result<U256> {
+    // Get the first SponsoredExternalMatchOutput log from the receipt
+    let log = receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            SponsoredExternalMatchOutput::decode_log(&log.inner, false /* validate */).ok()
+        })
+        .ok_or(eyre::eyre!("SponsoredExternalMatchOutput event not found in receipt"))?;
+
+    Ok(log.received_amount)
+}
+
+/// Burn the entirety of the gas sponsor's balance of the given token
+pub async fn burn_gas_sponsor_token_balance(mint: Address, ctx: &TestContext) -> Result<()> {
+    let sponsor_token_balance =
+        ctx.get_erc20_balance_of(mint, ctx.gas_sponsor_proxy_address).await?;
+    let token_contract = DummyErc20Contract::new(mint, ctx.client.provider());
+    let burn_tx = token_contract.burn(ctx.gas_sponsor_proxy_address, sponsor_token_balance);
+    send_tx(burn_tx).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
This PR updates the gas sponsor contract's `sponsor_atomic_match_settle_with_refund_options` method to return the exact output amount received by the external party. We also emit a new log, `SponsoredExternalMatchOutput`, containing this value. This log is necessary to view the output amount outside of the EVM.

### Testing
We add a new set of integration tests asserting that the output amount is correctly calculated, all of which pass. We also add a test case asserting that a match succeeds, but no refund is issued, for in-kind refunds when the gas sponsor lacks the requisite token balance.