### PR TITLE
contracts-stylus: core_atomic_match_settle, gas_sponsor: return amount received

### DIFF
--- a/contracts-stylus/src/contracts/core/core_atomic_match_settle.rs
+++ b/contracts-stylus/src/contracts/core/core_atomic_match_settle.rs
@@ -19,7 +19,7 @@ use crate::{
             deserialize_from_calldata, get_weth_address, is_native_eth_address, postcard_serialize,
             serialize_atomic_match_statements_for_verification,
         },
-        solidity::{processAtomicMatchSettleVkeysCall, verifyAtomicMatchCall},
+        solidity::{processAtomicMatchSettleVkeysCall, verifyAtomicMatchCall, ExternalMatchOutput},
     },
     IMPL_ADDRESS_STORAGE_GAP1_SIZE, IMPL_ADDRESS_STORAGE_GAP2_SIZE,
     INVALID_TRANSACTION_VALUE_ERROR_MESSAGE,
@@ -173,6 +173,8 @@ impl CoreAtomicMatchSettleContract {
     /// [`contracts_common::types::ExternalMatchProofs`] struct, and the
     /// `match_linking_proofs` argument is the serialization of the
     /// [`contracts_common::types::ExternalMatchLinkingProofs`] struct
+    ///
+    /// Returns the amount received by the external party in the match
     #[payable]
     pub fn process_atomic_match_settle(
         &mut self,
@@ -181,7 +183,7 @@ impl CoreAtomicMatchSettleContract {
         valid_match_settle_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         let internal_party_match_payload: MatchPayload =
             deserialize_from_calldata(&internal_party_match_payload)?;
 
@@ -239,9 +241,17 @@ impl CoreAtomicMatchSettleContract {
         let fees = valid_match_settle_atomic_statement.external_party_fees;
         let match_result = valid_match_settle_atomic_statement.match_result;
         let relayer_fee_address = valid_match_settle_atomic_statement.relayer_fee_address;
-        execute_atomic_match_transfers(self, receiver, fees, match_result, relayer_fee_address)?;
+        let received_amount = execute_atomic_match_transfers(
+            self,
+            receiver,
+            fees,
+            match_result,
+            relayer_fee_address,
+        )?;
 
-        Ok(())
+        log(self.vm(), ExternalMatchOutput { received_amount });
+
+        Ok(received_amount)
     }
 }
 

--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -243,7 +243,9 @@ pub fn verify<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
 // --------------------
 
 /// Execute the transfers to/from the external party in an atomic match
-/// settlement
+/// settlement.
+///
+/// Returns the amount received by the external party, less of fees
 #[cfg(any(feature = "core-atomic-match-settle", feature = "core-malleable-match-settle"))]
 pub fn execute_atomic_match_transfers<
     C: CoreContractStorage,
@@ -254,7 +256,7 @@ pub fn execute_atomic_match_transfers<
     fees: FeeTake,
     match_result: ExternalMatchResult,
     relayer_fee_address: Address,
-) -> Result<(), Vec<u8>> {
+) -> Result<U256, Vec<u8>> {
     /// The number of transfers to execute in an atomic match settlement
     const N_TRANSFERS: usize = 4;
     let tx_sender = storage.vm().msg_sender();
@@ -282,12 +284,15 @@ pub fn execute_atomic_match_transfers<
     let trader_take = receive_amount
         .checked_sub(fees.total())
         .ok_or(TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE)?;
+
     transfers_batch.push(SimpleErc20Transfer::new_withdraw(receiver, receive_mint, trader_take));
 
     // The amount sent by the external party to the darkpool
     transfers_batch.push(SimpleErc20Transfer::new_deposit(tx_sender, send_mint, send_amount));
 
-    execute_simple_transfers(storage, transfers_batch)
+    execute_simple_transfers(storage, transfers_batch)?;
+
+    Ok(trader_take)
 }
 
 /// Executes a list of simple ERC20 transfers

--- a/contracts-stylus/src/contracts/core/core_malleable_match_settle.rs
+++ b/contracts-stylus/src/contracts/core/core_malleable_match_settle.rs
@@ -257,6 +257,7 @@ impl CoreMalleableMatchSettleContract {
             match_result,
             relayer_fee_address,
         )
+        .map(|_| ())
     }
 }
 

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -646,6 +646,8 @@ impl DarkpoolContract {
     /// Note that all sub-calls of `process_atomic_match_settle` must be marked
     /// as payable to allow for the darkpool to delegate call them. This can be
     /// seen in the merkle and transfer executor contracts.
+    ///
+    /// Returns the amount received by the external party in the match.
     #[payable]
     pub fn process_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -653,12 +655,13 @@ impl DarkpoolContract {
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
         let receiver = msg::sender();
         let delegate =
             Self::get_delegate_address(storage, CORE_ATOMIC_MATCH_SETTLEMENT_DELEGATE_SELECTOR);
+
         delegate_call_helper::<processAtomicMatchSettleCall>(
             storage,
             delegate,
@@ -670,10 +673,12 @@ impl DarkpoolContract {
                 match_linking_proofs.to_vec().into(),
             ),
         )
-        .map(|_| ())
+        .map(|ret| ret._0)
     }
 
-    /// Process an atomic match settle statement with a receiver specified
+    /// Process an atomic match settle statement with a receiver specified.
+    ///
+    /// Returns the amount received by the external party in the match.
     #[payable]
     pub fn process_atomic_match_settle_with_receiver<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -682,11 +687,12 @@ impl DarkpoolContract {
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         DarkpoolContract::_check_not_paused(storage)?;
 
         let delegate =
             Self::get_delegate_address(storage, CORE_ATOMIC_MATCH_SETTLEMENT_DELEGATE_SELECTOR);
+
         delegate_call_helper::<processAtomicMatchSettleCall>(
             storage,
             delegate,
@@ -698,7 +704,7 @@ impl DarkpoolContract {
                 match_linking_proofs.to_vec().into(),
             ),
         )
-        .map(|_| ())
+        .map(|ret| ret._0)
     }
 
     /// Process a malleable match settlement between two parties

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -1,10 +1,7 @@
 //! The gas sponsor contract, used to sponsor the gas costs of external (atomic)
 //! matches
 
-use contracts_common::{
-    constants::NUM_BYTES_U256,
-    types::{ExternalMatchResult, ValidMatchSettleAtomicStatement},
-};
+use contracts_common::{constants::NUM_BYTES_U256, types::ValidMatchSettleAtomicStatement};
 use contracts_core::crypto::ecdsa::ecdsa_verify;
 use stylus_sdk::{
     abi::Bytes,
@@ -23,7 +20,8 @@ use crate::{
         helpers::{check_address_not_zero, deserialize_from_calldata, is_native_eth_address},
         solidity::{
             GasSponsorPausedFallback, IDarkpool, IErc20, InsufficientSponsorBalance, NonceUsed,
-            OwnershipTransferred, Paused, SponsoredExternalMatch, Unpaused,
+            OwnershipTransferred, Paused, SponsoredExternalMatch, SponsoredExternalMatchOutput,
+            Unpaused,
         },
     },
     ECDSA_ERROR_MESSAGE, INVALID_ARR_LEN_ERROR_MESSAGE, INVALID_SIGNATURE_ERROR_MESSAGE,
@@ -182,6 +180,10 @@ impl GasSponsorContract {
     /// refund, refund amount).
     /// If the `receiver` is the zero address, we use `msg::sender()` as the
     /// receiver.
+    /// If the `refund_address` is the zero address, we use the receiver as the
+    /// refund address.
+    ///
+    /// Returns the amount received by the external party.
     #[payable]
     #[allow(clippy::too_many_arguments)]
     pub fn sponsor_atomic_match_settle_with_refund_options(
@@ -196,11 +198,11 @@ impl GasSponsorContract {
         refund_native_eth: bool,
         refund_amount: U256,
         signature: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         // Resolve the receiver to use
         let receiver = if receiver == Address::ZERO { self.vm().msg_sender() } else { receiver };
 
-        let match_result = self.sponsored_match_inner(
+        let (statement, received_in_match) = self.sponsored_match_inner(
             receiver,
             internal_party_match_payload,
             valid_match_settle_atomic_statement,
@@ -215,12 +217,17 @@ impl GasSponsorContract {
         // If gas sponsorship is paused, return early, no refunding will be done
         if self.is_paused()? {
             log(self.vm(), GasSponsorPausedFallback { nonce });
-            return Ok(());
+            log(
+                self.vm(),
+                SponsoredExternalMatchOutput { received_amount: received_in_match, nonce },
+            );
+
+            return Ok(received_in_match);
         }
 
         // Refund the gas costs
-        let (buy_token_addr, _) = match_result.external_party_buy_mint_amount();
-        self.refund_gas_cost(
+        let (buy_token_addr, _) = statement.match_result.external_party_buy_mint_amount();
+        let actual_refund_amount = self.refund_gas_cost(
             refund_native_eth,
             refund_address,
             buy_token_addr,
@@ -229,7 +236,20 @@ impl GasSponsorContract {
             nonce,
         )?;
 
-        Ok(())
+        // Calculate the total amount received by the external party, inclusive of
+        // sponsorship
+        let is_native_eth_buy = is_native_eth_address(buy_token_addr);
+        let received_amount = if is_native_eth_buy || !refund_native_eth {
+            // If the buy-side token is native ETH, or we are refunding in-kind,
+            // we account for the refund amount in the total output amount
+            received_in_match + actual_refund_amount
+        } else {
+            received_in_match
+        };
+
+        log(self.vm(), SponsoredExternalMatchOutput { received_amount, nonce });
+
+        Ok(received_amount)
     }
 }
 
@@ -301,6 +321,9 @@ impl GasSponsorContract {
     /// Invokes a sponsored atomic match settlement, returning the match result.
     /// This includes invoking the underlying atomic match settlement on the
     /// darkpool, and checking the sponsorship signature & nonce.
+    ///
+    /// Returns the deserialized statement for convenience, and the amount
+    /// received by the external party after the atomic match executes
     #[allow(clippy::too_many_arguments)]
     pub fn sponsored_match_inner(
         &mut self,
@@ -313,9 +336,9 @@ impl GasSponsorContract {
         nonce: U256,
         refund_amount: U256,
         signature: Bytes,
-    ) -> Result<ExternalMatchResult, Vec<u8>> {
+    ) -> Result<(ValidMatchSettleAtomicStatement, U256), Vec<u8>> {
         // Invoke the underlying atomic match settlement
-        let match_result = self.atomic_match_inner(
+        let (statement, received_in_match) = self.atomic_match_inner(
             receiver,
             internal_party_match_payload.clone(),
             valid_match_settle_atomic_statement.clone(),
@@ -329,13 +352,16 @@ impl GasSponsorContract {
         // Mark the nonce as used
         self.mark_nonce_used(nonce)?;
 
-        Ok(match_result)
+        Ok((statement, received_in_match))
     }
 
     /// Invokes the actual atomic match path on the darkpool contract,
     /// returning the match result.
     /// If the `receiver` is the zero address, we use `msg::sender()` as the
     /// receiver.
+    ///
+    /// Returns the deserialized statement for convenience, and the amount
+    /// received by the external party after the atomic match executes
     pub fn atomic_match_inner(
         &mut self,
         receiver: Address,
@@ -343,7 +369,7 @@ impl GasSponsorContract {
         valid_match_settle_atomic_statement: Bytes,
         match_proofs: Bytes,
         match_linking_proofs: Bytes,
-    ) -> Result<ExternalMatchResult, Vec<u8>> {
+    ) -> Result<(ValidMatchSettleAtomicStatement, U256), Vec<u8>> {
         let sender = self.vm().msg_sender();
         let sponsor = self.vm().contract_address();
         let darkpool_address = self.darkpool_address.get();
@@ -352,8 +378,7 @@ impl GasSponsorContract {
         let statement: ValidMatchSettleAtomicStatement =
             deserialize_from_calldata(&valid_match_settle_atomic_statement)?;
 
-        let match_result = statement.match_result;
-        let (send_mint, send_amount) = match_result.external_party_sell_mint_amount();
+        let (send_mint, send_amount) = statement.match_result.external_party_sell_mint_amount();
 
         // Only execute an ERC20 transfer if the input token is not the native asset
         if !is_native_eth_address(send_mint) {
@@ -369,7 +394,7 @@ impl GasSponsorContract {
         // method. We pass along the message value in case the input token is
         // the native asset
         let darkpool = IDarkpool::new(darkpool_address);
-        darkpool.process_atomic_match_settle_with_receiver(
+        let received_in_match = darkpool.process_atomic_match_settle_with_receiver(
             ctx,
             receiver,
             internal_party_match_payload.0.into(),
@@ -378,7 +403,7 @@ impl GasSponsorContract {
             match_linking_proofs.0.into(),
         )?;
 
-        Ok(match_result)
+        Ok((statement, received_in_match))
     }
 
     /// Resolves the refund address to use for the given arguments.
@@ -407,19 +432,21 @@ impl GasSponsorContract {
     }
 
     /// Refunds the user's gas costs through native ETH.
+    ///
+    /// Returns the actual amount of Ether refunded.
     fn refund_through_native_eth(
         &mut self,
         refund_address: Address,
         refund_amount: U256,
         nonce: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         // If the gas sponsor doesn't have enough Ether to refund the user,
         // emit an event but don't revert.
         let contract_address = self.vm().contract_address();
         let balance = self.vm().balance(contract_address);
         if balance < refund_amount {
             log(self.vm(), InsufficientSponsorBalance { nonce });
-            return Ok(());
+            return Ok(U256::ZERO);
         }
 
         let ctx = Call::new().value(refund_amount);
@@ -429,22 +456,21 @@ impl GasSponsorContract {
             &[], // calldata
         )?;
 
-        log(
-            self.vm(),
-            SponsoredExternalMatch { amount: refund_amount, token: Address::ZERO, nonce },
-        );
+        log(self.vm(), SponsoredExternalMatch { refund_amount, token: Address::ZERO, nonce });
 
-        Ok(())
+        Ok(refund_amount)
     }
 
     /// Refunds the user's gas costs through the buy-side token.
+    ///
+    /// Returns the actual amount of the buy-side token refunded.
     fn refund_through_buy_token(
         &mut self,
         refund_address: Address,
         buy_token_addr: Address,
         refund_amount: U256,
         nonce: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         let buy_token = IErc20::new(buy_token_addr);
 
         // If the gas sponsor doesn't have enough of the buy-side token to refund the
@@ -452,22 +478,22 @@ impl GasSponsorContract {
         let contract_address = self.vm().contract_address();
         if buy_token.balance_of(&mut (*self), contract_address)? < refund_amount {
             log(self.vm(), InsufficientSponsorBalance { nonce });
-            return Ok(());
+            return Ok(U256::ZERO);
         }
 
         // Refund the user's gas costs
         buy_token.transfer(&mut (*self), refund_address, refund_amount)?;
 
-        log(
-            self.vm(),
-            SponsoredExternalMatch { amount: refund_amount, token: buy_token_addr, nonce },
-        );
+        log(self.vm(), SponsoredExternalMatch { refund_amount, token: buy_token_addr, nonce });
 
-        Ok(())
+        Ok(refund_amount)
     }
 
     /// Refunds the user's gas costs, either through native ETH or the buy-side
     /// token.
+    ///
+    /// Returns the actual amount refunded, which can differ from the passed-in
+    /// value if e.g. the gas sponsor doesn't have enough of the refund token.
     fn refund_gas_cost(
         &mut self,
         refund_native_eth: bool,
@@ -476,7 +502,7 @@ impl GasSponsorContract {
         refund_amount: U256,
         receiver: Address,
         nonce: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<U256, Vec<u8>> {
         let refund_address =
             self.resolve_refund_address(refund_native_eth, refund_address, receiver);
 

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -20,7 +20,7 @@ sol! {
 
     // Core settlement functions
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function processAtomicMatchSettle(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processAtomicMatchSettle(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
     function processMalleableAtomicMatchSettle(uint256 baseAmount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
 
     // Merkle functions
@@ -77,6 +77,7 @@ sol! {
     event WalletUpdated(uint256 indexed wallet_blinder_share);
     event ExternalTransfer(address indexed account, address indexed mint, bool indexed is_withdrawal, uint256 amount);
     event NotePosted(uint256 indexed note_commitment);
+    event ExternalMatchOutput(uint256 indexed received_amount);
 
     // Darkpool controls events
     event FeeChanged(uint256 indexed new_fee);
@@ -100,12 +101,13 @@ sol! {
     event InsufficientSponsorBalance(uint256 indexed nonce);
     event NonceUsed(uint256 indexed nonce);
     event GasSponsorPausedFallback(uint256 indexed nonce);
-    event SponsoredExternalMatch(uint256 indexed amount, address indexed token, uint256 indexed nonce);
+    event SponsoredExternalMatch(uint256 indexed refund_amount, address indexed token, uint256 indexed nonce);
+    event SponsoredExternalMatchOutput(uint256 indexed received_amount, uint256 indexed nonce);
 }
 
 sol_interface! {
     interface IDarkpool {
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
     }
 
     interface IErc20 {


### PR DESCRIPTION
This PR updates the core atomic match settlement and gas sponsor contracts to return the exact amount received by the external party in the match.

Integration tests will come in a follow-up PR to mitigate the scope of review