### PR TITLE
integration: gas_sponsorship, atomic_settlement: add received amount tests

### DIFF
--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -142,6 +142,8 @@ sol!(
             bool memory refund_native_eth,
             uint256 memory refund_amount,
             bytes memory signature
-        ) external payable;
+        ) external payable returns (uint256);
+
+        event SponsoredExternalMatchOutput(uint256 indexed received_amount, uint256 indexed nonce);
     }
 );

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -48,6 +48,8 @@ sol!(
         function markNullifierSpent(uint256 memory nullifier) external;
         function isImplementationUpgraded(uint8 memory address_selector) external view returns (bool);
         function clearMerkle() external;
+
+        event ExternalMatchOutput(uint256 indexed received_amount);
     }
 );
 

--- a/integration/src/tests/atomic_settlement.rs
+++ b/integration/src/tests/atomic_settlement.rs
@@ -9,9 +9,10 @@ use scripts::utils::{call_helper, send_tx};
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
+    abis::DarkpoolTestContract::ExternalMatchOutput,
     utils::{
-        insert_shares_and_get_root, serialize_to_calldata, setup_atomic_match_settle_test,
-        setup_atomic_match_settle_test_native_eth, u256_to_scalar,
+        extract_first_event, insert_shares_and_get_root, serialize_to_calldata,
+        setup_atomic_match_settle_test, setup_atomic_match_settle_test_native_eth, u256_to_scalar,
     },
     TestContext,
 };
@@ -610,3 +611,132 @@ async fn test_atomic_match_settle__fee_override(ctx: TestContext) -> Result<()> 
     Ok(())
 }
 integration_test_async!(test_atomic_match_settle__fee_override);
+
+/// Test that the received_amount in the ExternalMatchOutput event is equal to
+/// the amount of the buy-side token received by the external party in a basic
+/// match
+#[allow(non_snake_case)]
+pub async fn test_atomic_settlement_output_received_amount__basic(ctx: TestContext) -> Result<()> {
+    let contract = ctx.darkpool_contract();
+    let data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
+
+    let (buy_token_addr, _) =
+        data.valid_match_settle_atomic_statement.match_result.external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Call process_atomic_match_settle
+    let call = contract.processAtomicMatchSettle(
+        serialize_to_calldata(&data.internal_party_match_payload)?,
+        serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
+        serialize_to_calldata(&data.match_atomic_proofs)?,
+        serialize_to_calldata(&data.match_atomic_linking_proofs)?,
+    );
+    let receipt = send_tx(call).await?;
+
+    // Extract the received_amount from the event
+    let expected_received_amount =
+        extract_first_event::<ExternalMatchOutput>(&receipt)?.received_amount;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_atomic_settlement_output_received_amount__basic);
+
+/// Test that the received_amount in the ExternalMatchOutput event is equal to
+/// the amount of the buy-side token received by the receiver in a match with a
+/// specified receiver
+#[allow(non_snake_case)]
+pub async fn test_atomic_settlement_output_received_amount__with_receiver(
+    ctx: TestContext,
+) -> Result<()> {
+    let contract = ctx.darkpool_contract();
+    let receiver = Address::random();
+    let data = setup_atomic_match_settle_test(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
+
+    let (buy_token_addr, _) =
+        data.valid_match_settle_atomic_statement.match_result.external_party_buy_mint_amount();
+
+    // Record initial balance of receiver
+    let initial_receiver_balance = ctx.get_erc20_balance_of(buy_token_addr, receiver).await?;
+
+    // Call process_atomic_match_settle_with_receiver
+    let call = contract.processAtomicMatchSettleWithReceiver(
+        receiver,
+        serialize_to_calldata(&data.internal_party_match_payload)?,
+        serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
+        serialize_to_calldata(&data.match_atomic_proofs)?,
+        serialize_to_calldata(&data.match_atomic_linking_proofs)?,
+    );
+    let receipt = send_tx(call).await?;
+
+    // Extract the received_amount from the event
+    let expected_received_amount =
+        extract_first_event::<ExternalMatchOutput>(&receipt)?.received_amount;
+
+    // Calculate the actual received amount from balance changes
+    let final_receiver_balance = ctx.get_erc20_balance_of(buy_token_addr, receiver).await?;
+    let actual_received_amount = final_receiver_balance - initial_receiver_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_atomic_settlement_output_received_amount__with_receiver);
+
+/// Test that the received_amount in the ExternalMatchOutput event is equal to
+/// the amount of native ETH received by the external party when buying ETH
+#[allow(non_snake_case)]
+pub async fn test_atomic_settlement_output_received_amount__native_eth_buy(
+    ctx: TestContext,
+) -> Result<()> {
+    let contract = ctx.darkpool_contract();
+    let data = setup_atomic_match_settle_test_native_eth(
+        true,  // buy_side
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
+
+    // Record initial ETH balance
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    // Call process_atomic_match_settle
+    let call = contract.processAtomicMatchSettle(
+        serialize_to_calldata(&data.internal_party_match_payload)?,
+        serialize_to_calldata(&data.valid_match_settle_atomic_statement)?,
+        serialize_to_calldata(&data.match_atomic_proofs)?,
+        serialize_to_calldata(&data.match_atomic_linking_proofs)?,
+    );
+    let receipt = send_tx(call).await?;
+
+    // Extract the received_amount from the event
+    let expected_received_amount =
+        extract_first_event::<ExternalMatchOutput>(&receipt)?.received_amount;
+
+    // Calculate the actual received amount from balance changes, accounting for gas
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+    let actual_received_amount = final_eth_balance + gas_cost - initial_eth_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_atomic_settlement_output_received_amount__native_eth_buy);

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -6,10 +6,11 @@ use scripts::utils::send_tx;
 use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
 
 use crate::{
+    abis::GasSponsorContract::SponsoredExternalMatchOutput,
     constants::REFUND_AMOUNT,
     utils::{
         amount_received_in_match, assert_native_eth_gas_refund, burn_gas_sponsor_token_balance,
-        extract_sponsored_output_event, setup_sponsored_match_test, sponsor_match_with_test_data,
+        extract_first_event, setup_sponsored_match_test, sponsor_match_with_test_data,
         SponsoredMatchTestOptions,
     },
     TestContext,
@@ -418,7 +419,8 @@ pub async fn test_sponsored_match_output_received_amount__in_kind(ctx: TestConte
     let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Extract the expected received_amount from the event
-    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+    let expected_received_amount =
+        extract_first_event::<SponsoredExternalMatchOutput>(&receipt)?.received_amount;
 
     // Calculate the actual received amount from balance changes
     let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
@@ -455,7 +457,8 @@ pub async fn test_sponsored_match_output_received_amount__native_eth(
     let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Extract the expected received_amount from the event
-    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+    let expected_received_amount =
+        extract_first_event::<SponsoredExternalMatchOutput>(&receipt)?.received_amount;
 
     // Calculate the actual received amount from balance changes
     let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
@@ -488,7 +491,8 @@ pub async fn test_sponsored_match_output_received_amount__native_eth_buy(
     let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Extract the expected received_amount from the event
-    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+    let expected_received_amount =
+        extract_first_event::<SponsoredExternalMatchOutput>(&receipt)?.received_amount;
 
     // Calculate the actual received amount from balance changes, accounting for gas
     let final_eth_balance = ctx.get_eth_balance().await?;
@@ -528,7 +532,8 @@ pub async fn test_sponsored_match_output_received_amount__paused(ctx: TestContex
     let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Extract the expected received_amount from the event
-    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+    let expected_received_amount =
+        extract_first_event::<SponsoredExternalMatchOutput>(&receipt)?.received_amount;
 
     // Calculate the actual received amount from balance changes
     let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
@@ -566,7 +571,8 @@ pub async fn test_sponsored_match_output_received_amount__underfunded_eth(
     let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Extract the expected received_amount from the event
-    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+    let expected_received_amount =
+        extract_first_event::<SponsoredExternalMatchOutput>(&receipt)?.received_amount;
 
     // Calculate the actual received amount from balance changes, accounting for gas
     let final_eth_balance = ctx.get_eth_balance().await?;
@@ -608,7 +614,8 @@ pub async fn test_sponsored_match_output_received_amount__underfunded_token(
     let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
 
     // Extract the expected received_amount from the event
-    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+    let expected_received_amount =
+        extract_first_event::<SponsoredExternalMatchOutput>(&receipt)?.received_amount;
 
     // Calculate the actual received amount from balance changes
     let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -8,8 +8,9 @@ use test_helpers::{assert_eq_result, assert_true_result, integration_test_async}
 use crate::{
     constants::REFUND_AMOUNT,
     utils::{
-        amount_received_in_match, assert_native_eth_gas_refund, setup_sponsored_match_test,
-        sponsor_match_with_test_data, SponsoredMatchTestOptions,
+        amount_received_in_match, assert_native_eth_gas_refund, burn_gas_sponsor_token_balance,
+        extract_sponsored_output_event, setup_sponsored_match_test, sponsor_match_with_test_data,
+        SponsoredMatchTestOptions,
     },
     TestContext,
 };
@@ -150,11 +151,11 @@ pub async fn test_sponsored_match__paused(ctx: TestContext) -> Result<()> {
 }
 integration_test_async!(test_sponsored_match__paused);
 
-/// Test a sponsored match when the gas sponsor is underfunded.
+/// Test a sponsored match when the gas sponsor lacks ETH for refunds.
 ///
 /// Asserts that the match succeeds but is not sponsored.
 #[allow(non_snake_case)]
-pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
+pub async fn test_sponsored_match__underfunded_eth(ctx: TestContext) -> Result<()> {
     let gas_sponsor_contract = ctx.gas_sponsor_contract();
     let options: SponsoredMatchTestOptions = Default::default();
     let data = setup_sponsored_match_test(options, &ctx).await?;
@@ -173,7 +174,45 @@ pub async fn test_sponsored_match__underfunded(ctx: TestContext) -> Result<()> {
 
     assert_eq_result!(initial_eth_balance - final_eth_balance, U256::from(gas_cost))
 }
-integration_test_async!(test_sponsored_match__underfunded);
+integration_test_async!(test_sponsored_match__underfunded_eth);
+
+/// Test a sponsored match when the gas sponsor lacks the buy-side token for
+/// in-kind refunds.
+///
+/// Asserts that the match succeeds but is not sponsored.
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match__underfunded_token(ctx: TestContext) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Get the amount received in the match (excluding any refund)
+    let received_in_match = amount_received_in_match(
+        &data.process_atomic_match_settle_data.valid_match_settle_atomic_statement,
+    );
+
+    // Burn the buy-side token balance of the gas sponsor
+    burn_gas_sponsor_token_balance(buy_token_addr, &ctx).await?;
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Calculate the final balance and verify no refund was added
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // The difference should be exactly the amount received in the match (no refund)
+    assert_eq_result!(final_balance - initial_balance, received_in_match)
+}
+integration_test_async!(test_sponsored_match__underfunded_token);
 
 /// Test a sponsored match through the gas sponsor with in-kind refunds.
 ///
@@ -356,3 +395,227 @@ pub async fn test_sponsored_match__refund_address__msg_sender(ctx: TestContext) 
     assert_eq_result!(post_refund_balance - initial_balance, REFUND_AMOUNT)
 }
 integration_test_async!(test_sponsored_match__refund_address__msg_sender);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is equal to the amount of the buy-side token received by the external party
+/// in a match with in-kind sponsorship
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__in_kind(ctx: TestContext) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__in_kind);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is equal to the amount of the buy-side token received by the external party
+/// in a match with native ETH sponsorship (not buying ETH)
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__native_eth(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    // Use default options (native ETH refund, not trading native ETH)
+    let options = SponsoredMatchTestOptions::default();
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__native_eth);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is equal to the amount of native ETH received by the external party
+/// in a match where they are buying ETH
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__native_eth_buy(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions {
+        trade_native_eth: true, // External party is buying ETH
+        ..Default::default()
+    };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    // Record initial ETH balance
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes, accounting for gas
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+
+    // The difference in balance plus gas cost equals the actual amount received
+    let actual_received_amount = final_eth_balance + gas_cost - initial_eth_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__native_eth_buy);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is correctly reported when the gas sponsor is paused
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__paused(ctx: TestContext) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    // Get the buy token address
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Pause the gas sponsor
+    send_tx(gas_sponsor_contract.pause()).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__paused);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is correctly reported when the gas sponsor lacks ETH for refunds
+/// in a match where the external party is buying native ETH
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__underfunded_eth(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions {
+        trade_native_eth: true, // External party is buying ETH
+        ..Default::default()
+    };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    // Withdraw all ETH from the gas sponsor
+    let balance = ctx.get_eth_balance_of(*gas_sponsor_contract.address()).await?;
+    let withdraw_tx = gas_sponsor_contract.withdrawEth(ctx.client.address(), balance);
+    send_tx(withdraw_tx).await?;
+
+    // Record initial ETH balance
+    let initial_eth_balance = ctx.get_eth_balance().await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes, accounting for gas
+    let final_eth_balance = ctx.get_eth_balance().await?;
+    let gas_cost = U256::from(receipt.gas_used as u128 * receipt.effective_gas_price);
+
+    // The difference in balance plus gas cost equals the actual amount received
+    let actual_received_amount = final_eth_balance + gas_cost - initial_eth_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__underfunded_eth);
+
+/// Test that the received_amount in the SponsoredExternalMatchOutput event
+/// is correctly reported when the gas sponsor lacks the buy-side token for
+/// in-kind refunds
+#[allow(non_snake_case)]
+pub async fn test_sponsored_match_output_received_amount__underfunded_token(
+    ctx: TestContext,
+) -> Result<()> {
+    let gas_sponsor_contract = ctx.gas_sponsor_contract();
+    let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
+    let data = setup_sponsored_match_test(options, &ctx).await?;
+
+    let (buy_token_addr, _) = data
+        .process_atomic_match_settle_data
+        .valid_match_settle_atomic_statement
+        .match_result
+        .external_party_buy_mint_amount();
+
+    // Burn the buy-side token balance of the gas sponsor
+    burn_gas_sponsor_token_balance(buy_token_addr, &ctx).await?;
+
+    // Record initial balance
+    let initial_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+
+    // Execute the sponsored match
+    let receipt = sponsor_match_with_test_data(&gas_sponsor_contract, data).await?;
+
+    // Extract the expected received_amount from the event
+    let expected_received_amount = extract_sponsored_output_event(&receipt)?;
+
+    // Calculate the actual received amount from balance changes
+    let final_balance = ctx.get_erc20_balance(buy_token_addr).await?;
+    let actual_received_amount = final_balance - initial_balance;
+
+    // Verify that the received_amount in the event matches the actual amount
+    // received
+    assert_eq_result!(expected_received_amount, actual_received_amount)
+}
+integration_test_async!(test_sponsored_match_output_received_amount__underfunded_token);

--- a/integration/src/utils/contract.rs
+++ b/integration/src/utils/contract.rs
@@ -1,8 +1,9 @@
 //! Integration testing utilities for contract interaction
 
-use alloy::signers::local::PrivateKeySigner;
+use alloy::{rpc::types::TransactionReceipt, signers::local::PrivateKeySigner};
 use alloy_contract::CallDecoder;
-use alloy_sol_types::SolCall;
+use alloy_primitives::Log;
+use alloy_sol_types::{SolCall, SolEvent};
 use ark_crypto_primitives::merkle_tree::MerkleTree as ArkMerkleTree;
 use circuit_types::elgamal::EncryptionKey;
 use constants::Scalar;
@@ -90,4 +91,22 @@ pub async fn assert_success<'a, C: CallDecoder + Unpin>(call: EthereumCall<'_, C
     let pending_res = call.send().await;
     assert!(pending_res.is_ok(), "Expected transaction to succeed, but it reverted");
     Ok(())
+}
+
+// -----------------
+// | Event Helpers |
+// -----------------
+
+/// Extracts the first matched event of the given type from a transaction
+/// receipt
+pub fn extract_first_event<E: SolEvent>(receipt: &TransactionReceipt) -> Result<Log<E>> {
+    // Get the first ExternalMatchOutput log from the receipt
+    receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            E::decode_log(&log.inner, false /* validate */).ok()
+        })
+        .ok_or(eyre::eyre!("Event not found in receipt"))
 }

--- a/integration/src/utils/sponsored_match.rs
+++ b/integration/src/utils/sponsored_match.rs
@@ -2,7 +2,6 @@
 
 use alloy::rpc::types::TransactionReceipt;
 use alloy_primitives::{utils::parse_ether, Address, Bytes, U256};
-use alloy_sol_types::SolEvent;
 use ark_std::UniformRand;
 use contracts_common::types::{ScalarField, ValidMatchSettleAtomicStatement};
 use contracts_utils::{
@@ -13,11 +12,7 @@ use rand::thread_rng;
 use scripts::utils::send_tx;
 use test_helpers::assert_eq_result;
 
-use crate::{
-    abis::{DummyErc20Contract, GasSponsorContract::SponsoredExternalMatchOutput},
-    constants::REFUND_AMOUNT,
-    GasSponsorInstance, TestContext,
-};
+use crate::{abis::DummyErc20Contract, constants::REFUND_AMOUNT, GasSponsorInstance, TestContext};
 
 use super::{
     native_eth_address, scalar_to_u256, serialize_to_calldata, setup_atomic_match_settle_test,
@@ -179,22 +174,6 @@ pub fn amount_received_in_match(statement: &ValidMatchSettleAtomicStatement) -> 
     let fee_total = statement.external_party_fees.total();
 
     base_amount - fee_total
-}
-
-/// Extracts the received_amount from a SponsoredExternalMatchOutput event in a
-/// transaction receipt
-pub fn extract_sponsored_output_event(receipt: &TransactionReceipt) -> Result<U256> {
-    // Get the first SponsoredExternalMatchOutput log from the receipt
-    let log = receipt
-        .inner
-        .logs()
-        .iter()
-        .find_map(|log| {
-            SponsoredExternalMatchOutput::decode_log(&log.inner, false /* validate */).ok()
-        })
-        .ok_or(eyre::eyre!("SponsoredExternalMatchOutput event not found in receipt"))?;
-
-    Ok(log.received_amount)
 }
 
 /// Burn the entirety of the gas sponsor's balance of the given token

--- a/integration/src/utils/sponsored_match.rs
+++ b/integration/src/utils/sponsored_match.rs
@@ -2,6 +2,7 @@
 
 use alloy::rpc::types::TransactionReceipt;
 use alloy_primitives::{utils::parse_ether, Address, Bytes, U256};
+use alloy_sol_types::SolEvent;
 use ark_std::UniformRand;
 use contracts_common::types::{ScalarField, ValidMatchSettleAtomicStatement};
 use contracts_utils::{
@@ -12,7 +13,11 @@ use rand::thread_rng;
 use scripts::utils::send_tx;
 use test_helpers::assert_eq_result;
 
-use crate::{abis::DummyErc20Contract, constants::REFUND_AMOUNT, GasSponsorInstance, TestContext};
+use crate::{
+    abis::{DummyErc20Contract, GasSponsorContract::SponsoredExternalMatchOutput},
+    constants::REFUND_AMOUNT,
+    GasSponsorInstance, TestContext,
+};
 
 use super::{
     native_eth_address, scalar_to_u256, serialize_to_calldata, setup_atomic_match_settle_test,
@@ -174,4 +179,31 @@ pub fn amount_received_in_match(statement: &ValidMatchSettleAtomicStatement) -> 
     let fee_total = statement.external_party_fees.total();
 
     base_amount - fee_total
+}
+
+/// Extracts the received_amount from a SponsoredExternalMatchOutput event in a
+/// transaction receipt
+pub fn extract_sponsored_output_event(receipt: &TransactionReceipt) -> Result<U256> {
+    // Get the first SponsoredExternalMatchOutput log from the receipt
+    let log = receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            SponsoredExternalMatchOutput::decode_log(&log.inner, false /* validate */).ok()
+        })
+        .ok_or(eyre::eyre!("SponsoredExternalMatchOutput event not found in receipt"))?;
+
+    Ok(log.received_amount)
+}
+
+/// Burn the entirety of the gas sponsor's balance of the given token
+pub async fn burn_gas_sponsor_token_balance(mint: Address, ctx: &TestContext) -> Result<()> {
+    let sponsor_token_balance =
+        ctx.get_erc20_balance_of(mint, ctx.gas_sponsor_proxy_address).await?;
+    let token_contract = DummyErc20Contract::new(mint, ctx.client.provider());
+    let burn_tx = token_contract.burn(ctx.gas_sponsor_proxy_address, sponsor_token_balance);
+    send_tx(burn_tx).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
This PR adds integration tests asserting the correctness of the calculated output amount for sponsored and unsponsored matches. This also adds a missing test case covering the situation where the gas sponsor lacks the necessary ERC20 balances to cover an in-kind refund.

All integration tests pass.