### PR TITLE
contracts-stylus: core-wallet-ops: Use full commitments in all methods

### DIFF
--- a/contracts-stylus/src/contracts/core/core_helpers.rs
+++ b/contracts-stylus/src/contracts/core/core_helpers.rs
@@ -15,8 +15,8 @@ use crate::{
         },
         solidity::{
             executeExternalTransferCall, executeTransferBatchCall, insertCommitmentCall,
-            insertSharesCommitmentCall, insertSharesWithSigCall, rootInHistoryCall, verifyCall,
-            NotePosted, NullifierSpent, WalletUpdated,
+            insertCommitmentWithSigCall, insertSharesCommitmentCall, insertSharesWithSigCall,
+            rootInHistoryCall, verifyCall, NotePosted, NullifierSpent, WalletUpdated,
         },
     },
     TRANSFER_ARITHMETIC_OVERFLOW_ERROR_MESSAGE, VKEYS_FETCH_ERROR_MESSAGE,
@@ -183,6 +183,30 @@ pub fn insert_commitment_into_tree<C: CoreContractStorage, S: TopLevelStorage + 
     Ok(())
 }
 
+/// Inserts a signed commitment into the Merkle tree
+pub fn insert_signed_commitment_into_tree<
+    C: CoreContractStorage,
+    S: TopLevelStorage + BorrowMut<C>,
+>(
+    s: &mut S,
+    commitment: ScalarField,
+    signature: Vec<u8>,
+    old_pk_root: PublicSigningKey,
+) -> Result<(), Vec<u8>> {
+    let storage = s.borrow_mut();
+    let merkle_address = storage.merkle_address();
+    let commitment_u256 = scalar_to_u256(commitment);
+    let old_pk_root_u256s =
+        pk_to_u256s(&old_pk_root).map_err(|_| INVALID_ARR_LEN_ERROR_MESSAGE.to_vec())?;
+
+    delegate_call_helper::<insertCommitmentWithSigCall>(
+        s,
+        merkle_address,
+        (commitment_u256, signature.into(), old_pk_root_u256s),
+    )?;
+    Ok(())
+}
+
 /// Prepares the wallet shares for insertion into the Merkle tree by converting
 /// them to a vector of [`U256`]
 pub fn prepare_wallet_shares_for_insertion(
@@ -199,7 +223,7 @@ pub fn prepare_wallet_shares_for_insertion(
 /// Prepares the private shares commitment & public wallet shares for insertion
 /// into the Merkle tree and delegate-calls the appropriate method on the Merkle
 /// contract
-pub fn insert_wallet_shares_into_tree<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
+pub fn insert_shares_into_tree<C: CoreContractStorage, S: TopLevelStorage + BorrowMut<C>>(
     s: &mut S,
     private_shares_commitment: ScalarField,
     public_wallet_shares: &[ScalarField],
@@ -234,7 +258,7 @@ pub fn insert_signed_shares_into_tree<C: CoreContractStorage, S: TopLevelStorage
     delegate_call_helper::<insertSharesWithSigCall>(
         s,
         merkle_address,
-        (total_wallet_shares, wallet_commitment_signature.to_vec().into(), old_pk_root_u256s),
+        (total_wallet_shares, wallet_commitment_signature.into(), old_pk_root_u256s),
     )
     .map(|_| ())
 }
@@ -363,16 +387,29 @@ pub fn rotate_wallet<C: CoreContractStorage, S: TopLevelStorage + HostAccess + B
     new_wallet_public_shares: &[ScalarField],
 ) -> Result<(), Vec<u8>> {
     check_wallet_rotation(s, old_wallet_nullifier, merkle_root, new_wallet_public_shares)?;
-    insert_wallet_shares_into_tree(
-        s,
-        new_wallet_private_shares_commitment,
-        new_wallet_public_shares,
-    )
+    insert_shares_into_tree(s, new_wallet_private_shares_commitment, new_wallet_public_shares)
 }
 
-/// Nullifies the old wallet and commits to the new wallet,
-/// verifying a signature over the commitment to the new wallet
-pub fn rotate_wallet_with_signature<
+/// Nullifies the old wallet and commits to the new wallet using a previously
+/// generated commitment directly, rather than the wallet's shares
+pub fn rotate_wallet_with_commitment<
+    C: CoreContractStorage,
+    S: TopLevelStorage + HostAccess + BorrowMut<C>,
+>(
+    s: &mut S,
+    old_wallet_nullifier: ScalarField,
+    merkle_root: ScalarField,
+    new_wallet_commitment: ScalarField,
+    new_wallet_public_shares: &[ScalarField],
+) -> Result<(), Vec<u8>> {
+    check_wallet_rotation(s, old_wallet_nullifier, merkle_root, new_wallet_public_shares)?;
+    insert_commitment_into_tree(s, new_wallet_commitment)?;
+    Ok(())
+}
+
+/// Nullifies the old wallet and commits to the new wallet, using a previously
+/// generated commitment directly, rather than the wallet's shares
+pub fn rotate_wallet_with_signed_shares<
     C: CoreContractStorage,
     S: TopLevelStorage + HostAccess + BorrowMut<C>,
 >(
@@ -391,6 +428,29 @@ pub fn rotate_wallet_with_signature<
         new_wallet_public_shares,
         new_wallet_commitment_signature,
         &old_pk_root,
+    )
+}
+
+/// Nullifies the old wallet and commits to the new wallet, using a previously
+/// generated commitment directly, rather than the wallet's shares
+pub fn rotate_wallet_with_signed_commitment<
+    C: CoreContractStorage,
+    S: TopLevelStorage + HostAccess + BorrowMut<C>,
+>(
+    s: &mut S,
+    old_wallet_nullifier: ScalarField,
+    merkle_root: ScalarField,
+    new_wallet_commitment: ScalarField,
+    new_wallet_commitment_signature: Vec<u8>,
+    new_wallet_public_shares: &[ScalarField],
+    old_pk_root: PublicSigningKey,
+) -> Result<(), Vec<u8>> {
+    check_wallet_rotation(s, old_wallet_nullifier, merkle_root, new_wallet_public_shares)?;
+    insert_signed_commitment_into_tree(
+        s,
+        new_wallet_commitment,
+        new_wallet_commitment_signature,
+        old_pk_root,
     )
 }
 

--- a/contracts-stylus/src/contracts/core/core_wallet_ops.rs
+++ b/contracts-stylus/src/contracts/core/core_wallet_ops.rs
@@ -9,7 +9,8 @@ use crate::{
     contracts::core::core_helpers::{
         check_root_and_nullify, commit_note, execute_external_transfer, fetch_vkeys,
         get_protocol_public_encryption_key, insert_commitment_into_tree, log_blinder_used,
-        rotate_wallet, rotate_wallet_with_signature, verify,
+        rotate_wallet, rotate_wallet_with_commitment, rotate_wallet_with_signed_commitment,
+        rotate_wallet_with_signed_shares, verify,
     },
     if_verifying,
     utils::{
@@ -222,14 +223,13 @@ impl CoreWalletOpsContract {
             )?;
         });
 
-        // TODO: Use full commitment here
-        rotate_wallet_with_signature(
+        rotate_wallet_with_signed_commitment(
             self,
             valid_wallet_update_statement.old_shares_nullifier,
             valid_wallet_update_statement.merkle_root,
             valid_wallet_update_statement.new_wallet_commitment,
-            &valid_wallet_update_statement.new_public_shares,
             wallet_commitment_signature.0,
+            &valid_wallet_update_statement.new_public_shares,
             valid_wallet_update_statement.old_pk_root,
         )?;
 
@@ -279,7 +279,7 @@ impl CoreWalletOpsContract {
             &valid_relayer_fee_settlement_statement.sender_updated_public_shares,
         )?;
 
-        rotate_wallet_with_signature(
+        rotate_wallet_with_signed_shares(
             self,
             valid_relayer_fee_settlement_statement.recipient_nullifier,
             valid_relayer_fee_settlement_statement.recipient_root,
@@ -321,7 +321,7 @@ impl CoreWalletOpsContract {
             )?;
         });
 
-        rotate_wallet(
+        rotate_wallet_with_commitment(
             self,
             valid_offline_fee_settlement_statement.nullifier,
             valid_offline_fee_settlement_statement.merkle_root,
@@ -357,13 +357,13 @@ impl CoreWalletOpsContract {
             )?;
         });
 
-        rotate_wallet_with_signature(
+        rotate_wallet_with_signed_commitment(
             self,
             valid_fee_redemption_statement.nullifier,
             valid_fee_redemption_statement.wallet_root,
             valid_fee_redemption_statement.new_shares_commitment,
-            &valid_fee_redemption_statement.new_wallet_public_shares,
             recipient_wallet_commitment_signature.0,
+            &valid_fee_redemption_statement.new_wallet_public_shares,
             valid_fee_redemption_statement.old_pk_root,
         )?;
 

--- a/contracts-utils/src/proof_system/test_data.rs
+++ b/contracts-utils/src/proof_system/test_data.rs
@@ -309,15 +309,7 @@ pub fn gen_update_wallet_data<R: CryptoRng + RngCore>(
 
     // Convert the statement & proof types to the ones expected by the contract
     let contract_statement = to_contract_valid_wallet_update_statement(&statement)?;
-
-    let shares_commitment = compute_poseidon_hash(
-        &[
-            vec![contract_statement.new_wallet_commitment],
-            contract_statement.new_public_shares.clone(),
-        ]
-        .concat(),
-    );
-
+    let shares_commitment = statement.new_wallet_commitment.inner();
     let wallet_commitment_signature = Bytes::from(
         hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).as_bytes(),
     );
@@ -410,15 +402,7 @@ pub fn gen_redeem_fee_data<R: CryptoRng + RngCore>(
     // Convert the statement & proof types to the ones expected by the contract
     let contract_statement: ContractValidFeeRedemptionStatement =
         to_contract_valid_fee_redemption_statement(&statement)?;
-
-    let shares_commitment = compute_poseidon_hash(
-        &[
-            vec![contract_statement.new_shares_commitment],
-            contract_statement.new_wallet_public_shares.clone(),
-        ]
-        .concat(),
-    );
-
+    let shares_commitment = statement.new_shares_commitment.inner();
     let wallet_commitment_signature = Bytes::from(
         hash_and_sign_message(&signing_key, &shares_commitment.serialize_to_bytes()).as_bytes(),
     );

--- a/integration/src/tests/basic_darkpool_interaction.rs
+++ b/integration/src/tests/basic_darkpool_interaction.rs
@@ -17,7 +17,10 @@ use scripts::utils::{call_helper, send_tx};
 use test_helpers::integration_test_async;
 
 use crate::{
-    utils::{insert_shares_and_get_root, serialize_to_calldata, u256_to_scalar},
+    utils::{
+        insert_commitment_and_get_root, insert_shares_and_get_root, serialize_to_calldata,
+        u256_to_scalar,
+    },
     TestContext,
 };
 
@@ -39,11 +42,10 @@ async fn test_new_wallet(ctx: TestContext) -> Result<()> {
     // Assert that Merkle root is correct
     let mut ark_merkle = new_ark_merkle_tree(TEST_MERKLE_HEIGHT);
 
-    let ark_root = insert_shares_and_get_root(
+    let ark_root = insert_commitment_and_get_root(
         &mut ark_merkle,
-        statement.private_shares_commitment,
-        &statement.public_wallet_shares,
         0, // index
+        statement.wallet_share_commitment,
     )?;
 
     let contract_root = ctx.get_root_scalar().await?;
@@ -82,11 +84,10 @@ async fn test_update_wallet(ctx: TestContext) -> Result<()> {
     assert!(nullifier_spent, "Nullifier not spent");
 
     // Assert that Merkle root is correct
-    let ark_root = insert_shares_and_get_root(
+    let ark_root = insert_commitment_and_get_root(
         &mut ark_merkle,
-        statement.new_private_shares_commitment,
-        &statement.new_public_shares,
         0, // index
+        statement.new_wallet_commitment,
     )
     .map_err(|e| eyre!("{}", e))?;
 

--- a/integration/src/tests/fees.rs
+++ b/integration/src/tests/fees.rs
@@ -16,7 +16,10 @@ use scripts::utils::send_tx;
 use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
 
 use crate::{
-    utils::{get_protocol_pubkey, insert_shares_and_get_root, serialize_to_calldata},
+    utils::{
+        get_protocol_pubkey, insert_commitment_and_get_root, insert_shares_and_get_root,
+        serialize_to_calldata,
+    },
     TestContext,
 };
 
@@ -98,11 +101,10 @@ async fn test_settle_offline_fee(ctx: TestContext) -> Result<()> {
     assert_true_result!(nullifier_spent)?;
 
     // Assert that Merkle root is correct
-    insert_shares_and_get_root(
+    insert_commitment_and_get_root(
         &mut ark_merkle,
-        statement.updated_wallet_commitment,
-        &statement.updated_wallet_public_shares,
         0, // index
+        statement.new_wallet_commitment,
     )
     .map_err(|e| eyre!("{}", e))?;
 
@@ -170,11 +172,10 @@ async fn test_redeem_fee(ctx: TestContext) -> Result<()> {
     assert_true_result!(nullifier_spent)?;
 
     // Assert that Merkle root is correct
-    let ark_root = insert_shares_and_get_root(
+    let ark_root = insert_commitment_and_get_root(
         &mut ark_merkle,
-        statement.new_wallet_commitment,
-        &statement.new_wallet_public_shares,
         0, // index
+        statement.new_shares_commitment,
     )
     .map_err(|e| eyre!("{}", e))?;
 

--- a/integration/src/utils/contract.rs
+++ b/integration/src/utils/contract.rs
@@ -50,6 +50,16 @@ pub(crate) fn insert_shares_and_get_root(
     let mut shares = vec![private_shares_commitment];
     shares.extend(public_shares);
     let commitment = compute_poseidon_hash(&shares);
+    insert_commitment_and_get_root(ark_merkle, index, commitment)
+}
+
+/// Inserts a commitment to the given wallet shares into the Arkworks Merkle
+/// tree and returns the new root
+pub(crate) fn insert_commitment_and_get_root(
+    ark_merkle: &mut ArkMerkleTree<MerkleConfig>,
+    index: usize,
+    commitment: ScalarField,
+) -> Result<Scalar> {
     ark_merkle
         .update(index, &commitment)
         .map_err(|_| eyre!("Failed to update Arkworks Merkle tree"))?;


### PR DESCRIPTION
### Purpose
This PR updates all `core-wallet-ops` methods to use full commitments in their Merkle insertions. I also updated the Merkle tests to expect full commitments inserted from the statement.

### Testing
- [x] All integration tests pass