### PR TITLE
contracts-stylus: darkpool: Accept quote_amount in malleable matches

### DIFF
--- a/contracts-common/src/types/keys.rs
+++ b/contracts-common/src/types/keys.rs
@@ -7,6 +7,8 @@ use crate::serde_def_types::*;
 
 use super::ScalarField;
 
+/// A public signing key in the Renegade system
+///
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.
 /// Since the secp256k1 base field order is larger than that of Bn254's scalar
 /// field, it takes 2 Bn254 scalar field elements to represent each coordinate.

--- a/contracts-common/src/types/match.rs
+++ b/contracts-common/src/types/match.rs
@@ -10,6 +10,8 @@ use super::FixedPoint;
 
 /// The revert message when an invalid base amount is provided
 pub const ERROR_INVALID_BASE_AMT: &[u8] = b"invalid base amount";
+/// The revert message when an invalid quote amount is provided
+pub const ERROR_INVALID_QUOTE_AMT: &[u8] = b"invalid quote amount";
 
 /// The result of an external match
 /// The result of an atomic match
@@ -97,19 +99,10 @@ impl BoundedMatchResult {
     /// given a base amount
     pub fn to_external_match_result(
         &self,
+        quote_amount: U256,
         base_amount: U256,
     ) -> Result<ExternalMatchResult, Vec<u8>> {
-        // Validate the match amount
-        let amount_too_low = base_amount < self.min_base_amount;
-        let amount_too_high = base_amount > self.max_base_amount;
-        if amount_too_low || amount_too_high {
-            return Err(ERROR_INVALID_BASE_AMT.into());
-        }
-
-        // Compute the quote amount
-        let price = self.price;
-        let quote_amount = price.unsafe_fixed_point_mul(base_amount);
-
+        self.validate_amounts(quote_amount, base_amount)?;
         Ok(ExternalMatchResult {
             quote_mint: self.quote_mint,
             base_mint: self.base_mint,
@@ -117,5 +110,81 @@ impl BoundedMatchResult {
             base_amount,
             direction: self.direction,
         })
+    }
+
+    // --- Validation --- //
+
+    /// Validate the base and quote amount for a match
+    fn validate_amounts(&self, quote_amount: U256, base_amount: U256) -> Result<(), Vec<u8>> {
+        self.validate_base_amount(base_amount)?;
+        self.validate_quote_amount(quote_amount, base_amount)
+    }
+
+    /// Validate the base amount for a match
+    ///
+    /// This simply validates that the base amount lies in the range constructed
+    /// by the relayer. This range is validated in-circuit to be well
+    /// capitalized.
+    fn validate_base_amount(&self, base_amount: U256) -> Result<(), Vec<u8>> {
+        let amount_too_low = base_amount < self.min_base_amount;
+        let amount_too_high = base_amount > self.max_base_amount;
+        if amount_too_low || amount_too_high {
+            return Err(ERROR_INVALID_BASE_AMT.into());
+        }
+
+        Ok(())
+    }
+
+    /// Validate the quote amount for a match
+    ///
+    /// We allow an external user to specify a quote amount, but we need to
+    /// ensure that they have not given themselves an invalid amount or price
+    /// improvement at the expense of the internal party.
+    ///
+    /// This involves two checks:
+    /// 1. The quote amount must be within the range implied by the base amount
+    ///    range. Let `min_quote = floor(min_base * price)` and `max_quote =
+    ///    floor(max_base * price)`. The quote amount must lie in the range
+    ///    `[min_quote, max_quote]`.
+    /// 2. The quote amount must imply a price that improves upon the reference
+    ///    price in the match result *for the internal party*. Let
+    ///    `reference_quote = floor(base_amount * price)`. Then for an external
+    ///    sell order, we assert `quote_amount <= reference_quote`; i.e. the
+    ///    external party sells at a lower price. For an external buy order, we
+    ///    assert `quote_amount >= reference_quote`; i.e. the external party
+    ///    buys at a higher price.
+    ///
+    /// Note that we can combine these two checks by taking the intersection of
+    /// their respective intervals. For an external party buy order, this is the
+    /// interval:  `[ref_quote, inf) \cap [min_quote, max_quote] =
+    /// [ref_quote, max_quote]`
+    ///
+    /// For an external party sell order, this is the interval:
+    ///  `[0, ref_quote] \cap [min_quote, max_quote] = [min_quote, ref_quote]`
+    ///
+    /// So we check that the quote lies in the intersection interval
+    ///
+    /// SAFETY: All values below are constrained to be within 100 bits, and the
+    /// price is constrained to be within 127 bits, so wraparound is impossible
+    fn validate_quote_amount(&self, quote_amount: U256, base_amount: U256) -> Result<(), Vec<u8>> {
+        // Compute the quote amount bounds
+        let min_quote = self.price.unsafe_fixed_point_mul(self.min_base_amount);
+        let max_quote = self.price.unsafe_fixed_point_mul(self.max_base_amount);
+        let ref_quote = self.price.unsafe_fixed_point_mul(base_amount);
+
+        // Check that the quote amount lies in the intersection interval
+        let (range_min, range_max) = if self.is_external_party_sell() {
+            (min_quote, ref_quote)
+        } else {
+            (ref_quote, max_quote)
+        };
+
+        let quote_too_low = quote_amount < range_min;
+        let quote_too_high = quote_amount > range_max;
+        if quote_too_low || quote_too_high {
+            return Err(ERROR_INVALID_QUOTE_AMT.into());
+        }
+
+        Ok(())
     }
 }

--- a/contracts-common/src/types/match.rs
+++ b/contracts-common/src/types/match.rs
@@ -156,11 +156,11 @@ impl BoundedMatchResult {
     ///
     /// Note that we can combine these two checks by taking the intersection of
     /// their respective intervals. For an external party buy order, this is the
-    /// interval:  `[ref_quote, inf) \cap [min_quote, max_quote] =
-    /// [ref_quote, max_quote]`
+    /// interval:  
+    ///   [ref_quote, inf) \cap [min_quote, max_quote] = [ref_quote, max_quote]
     ///
     /// For an external party sell order, this is the interval:
-    ///  `[0, ref_quote] \cap [min_quote, max_quote] = [min_quote, ref_quote]`
+    ///   [0, ref_quote] \cap [min_quote, max_quote] = [min_quote, ref_quote]
     ///
     /// So we check that the quote lies in the intersection interval
     ///

--- a/contracts-common/src/types/transfers.rs
+++ b/contracts-common/src/types/transfers.rs
@@ -24,7 +24,9 @@ pub struct ExternalTransfer {
     pub is_withdrawal: bool,
 }
 
-/// Auxiliary data passed alongside an external transfer to verify its validity.
+/// Auxiliary authorization data for an external transfer
+///
+/// Passed alongside an external transfer to verify its validity.
 /// This includes a signature over the external transfer, and in the case of a
 /// deposit, the associated Permit2 data ([reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer))
 #[serde_as]

--- a/contracts-stylus/src/contracts/core/core_malleable_match_settle.rs
+++ b/contracts-stylus/src/contracts/core/core_malleable_match_settle.rs
@@ -171,6 +171,7 @@ impl CoreMalleableMatchSettleContract {
     #[payable]
     pub fn process_malleable_atomic_match_settle(
         &mut self,
+        quote_amount: U256,
         base_amount: U256,
         receiver: Address,
         internal_party_match_payload: Bytes,
@@ -220,7 +221,8 @@ impl CoreMalleableMatchSettleContract {
         });
 
         // Build an external match result given the base amount
-        let match_result = bounded_match_result.to_external_match_result(base_amount)?;
+        let match_result =
+            bounded_match_result.to_external_match_result(quote_amount, base_amount)?;
 
         // Apply the external match directly to the internal party's wallet
         let public_shares = statement.internal_party_public_shares;

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -870,6 +870,7 @@ impl DarkpoolContract {
     #[payable]
     pub fn process_malleable_atomic_match_settle<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
+        quote_amount: U256,
         base_amount: U256,
         internal_party_payload: Bytes,
         malleable_match_settle_atomic_statement: Bytes,
@@ -885,6 +886,7 @@ impl DarkpoolContract {
             storage,
             delegate,
             (
+                quote_amount,
                 base_amount,
                 receiver,
                 internal_party_payload.to_vec().into(),
@@ -902,6 +904,7 @@ impl DarkpoolContract {
         S: TopLevelStorage + BorrowMut<Self>,
     >(
         storage: &mut S,
+        quote_amount: U256,
         base_amount: U256,
         receiver: Address,
         internal_party_payload: Bytes,
@@ -917,6 +920,7 @@ impl DarkpoolContract {
             storage,
             delegate,
             (
+                quote_amount,
                 base_amount,
                 receiver,
                 internal_party_payload.to_vec().into(),

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -23,7 +23,7 @@ sol! {
     function processMatchSettleWithCommitments(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function processAtomicMatchSettle(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
     function processAtomicMatchSettleWithCommitments(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
-    function processMalleableAtomicMatchSettle(uint256 baseAmount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
+    function processMalleableAtomicMatchSettle(uint256 quoteAmount, uint256 baseAmount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
 
     // Merkle functions
     function init() external;


### PR DESCRIPTION
### Purpose
This PR accepts a `quote_amount` in the malleable match methods of the darkpool. This involves validating that the `quote_amount` lies in the specified bounds.

### Todo
- Update gas sponsorship
- Update integration test

### Testing
- Deferred until integration tests are updated