### PR TITLE
integration: Updates malleable match tests with quote amounts

### DIFF
--- a/contracts-common/src/types/match.rs
+++ b/contracts-common/src/types/match.rs
@@ -12,6 +12,8 @@ use super::FixedPoint;
 pub const ERROR_INVALID_BASE_AMT: &[u8] = b"invalid base amount";
 /// The revert message when an invalid quote amount is provided
 pub const ERROR_INVALID_QUOTE_AMT: &[u8] = b"invalid quote amount";
+/// The revert message when a zero base or quote amount is provided
+pub const ERROR_ZERO_BASE_OR_QUOTE_AMT: &[u8] = b"zero base or quote amount";
 
 /// The result of an external match
 /// The result of an atomic match
@@ -116,6 +118,10 @@ impl BoundedMatchResult {
 
     /// Validate the base and quote amount for a match
     fn validate_amounts(&self, quote_amount: U256, base_amount: U256) -> Result<(), Vec<u8>> {
+        if quote_amount.is_zero() || base_amount.is_zero() {
+            return Err(ERROR_ZERO_BASE_OR_QUOTE_AMT.into());
+        }
+
         self.validate_base_amount(base_amount)?;
         self.validate_quote_amount(quote_amount, base_amount)
     }

--- a/contracts-stylus/src/contracts/darkpool.rs
+++ b/contracts-stylus/src/contracts/darkpool.rs
@@ -900,6 +900,7 @@ impl DarkpoolContract {
 
     /// Process a malleable match settlement with a receiver specified
     #[payable]
+    #[allow(clippy::too_many_arguments)]
     pub fn process_malleable_atomic_match_settle_with_receiver<
         S: TopLevelStorage + BorrowMut<Self>,
     >(

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -454,6 +454,7 @@ impl GasSponsorContract {
         let darkpool = IDarkpool::new(self.darkpool_address.get());
         let received_in_match = darkpool.process_malleable_atomic_match_settle_with_receiver(
             ctx,
+            quote_amount,
             base_amount,
             receiver,
             internal_party_match_payload.0.into(),

--- a/contracts-stylus/src/contracts/gas_sponsor.rs
+++ b/contracts-stylus/src/contracts/gas_sponsor.rs
@@ -253,6 +253,7 @@ impl GasSponsorContract {
     #[allow(clippy::too_many_arguments)]
     pub fn sponsor_malleable_atomic_match_settle_with_refund_options(
         &mut self,
+        quote_amount: U256,
         base_amount: U256,
         receiver: Address,
         internal_party_match_payload: Bytes,
@@ -271,6 +272,7 @@ impl GasSponsorContract {
 
         // Execute the malleable match on the darkpool
         let (match_res, received_in_match) = self.do_malleable_match(
+            quote_amount,
             base_amount,
             receiver,
             internal_party_match_payload,
@@ -429,6 +431,7 @@ impl GasSponsorContract {
     /// `process_malleable_match_settle_with_receiver` method as sender
     pub fn do_malleable_match(
         &mut self,
+        quote_amount: U256,
         base_amount: U256,
         receiver: Address,
         internal_party_match_payload: Bytes,
@@ -439,7 +442,8 @@ impl GasSponsorContract {
         // Take custody of the trader's input tokens to proxy the match
         let statement: ValidMalleableMatchSettleAtomicStatement =
             deserialize_from_calldata(&malleable_match_settle_statement)?;
-        let external_match = statement.match_result.to_external_match_result(base_amount)?;
+        let external_match =
+            statement.match_result.to_external_match_result(quote_amount, base_amount)?;
         self.custody_send_tokens(&external_match)?;
 
         // Call the darkpool contract's `process_malleable_match_settle_with_receiver`

--- a/contracts-stylus/src/utils/solidity.rs
+++ b/contracts-stylus/src/utils/solidity.rs
@@ -113,7 +113,7 @@ sol! {
 sol_interface! {
     interface IDarkpool {
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable returns (uint256);
-        function processMalleableAtomicMatchSettleWithReceiver(uint256 memory base_amount, address receiver, bytes memory internal_party_match_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable returns (uint256);
+        function processMalleableAtomicMatchSettleWithReceiver(uint256 quote_amount, uint256 base_amount, address receiver, bytes memory internal_party_match_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable returns (uint256);
     }
 
     interface IErc20 {

--- a/integration/src/abis.rs
+++ b/integration/src/abis.rs
@@ -43,7 +43,7 @@ sol!(
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
         function processAtomicMatchSettleWithCommitments(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_with_commitments_statement, bytes memory match_atomic_proofs, bytes memory match_atomic_linking_proofs) external payable;
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external payable;
-        function processMalleableAtomicMatchSettle(uint256 memory base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable;
+        function processMalleableAtomicMatchSettleWithReceiver(uint256 quote_amount, uint256 base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable;
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
@@ -149,7 +149,8 @@ sol!(
             bytes memory signature
         ) external payable returns (uint256);
         function sponsorMalleableAtomicMatchSettleWithRefundOptions(
-            uint256 memory base_amount,
+            uint256 quote_amount,
+            uint256 base_amount,
             address receiver,
             bytes memory internal_party_payload,
             bytes memory malleable_match_settle_atomic_statement,

--- a/integration/src/tests/gas_sponsorship.rs
+++ b/integration/src/tests/gas_sponsorship.rs
@@ -652,6 +652,7 @@ pub async fn test_sponsored_malleable_match__in_kind(ctx: TestContext) -> Result
     let options = SponsoredMatchTestOptions { in_kind_refund: true, ..Default::default() };
     let data = setup_sponsored_malleable_match_test(options, &ctx).await?;
 
+    let quote_amount = data.quote_amount;
     let base_amount = data.base_amount;
     let statement = &data
         .process_malleable_match_settle_atomic_data
@@ -659,7 +660,7 @@ pub async fn test_sponsored_malleable_match__in_kind(ctx: TestContext) -> Result
     let match_res = statement.match_result.clone();
     let fee_rates = statement.external_fee_rates;
 
-    let external_match = match_res.to_external_match_result(base_amount).unwrap();
+    let external_match = match_res.to_external_match_result(quote_amount, base_amount).unwrap();
     let (buy_token_addr, buy_amount) = external_match.external_party_buy_mint_amount();
     let external_part_fees = fee_rates.get_fee_take(buy_amount);
     let net_recv = buy_amount - external_part_fees.total();

--- a/integration/src/tests/malleable_atomic_settlement.rs
+++ b/integration/src/tests/malleable_atomic_settlement.rs
@@ -222,6 +222,97 @@ async fn test_malleable_match__incorrect_protocol_fee_rate(ctx: TestContext) -> 
 }
 integration_test_async!(test_malleable_match__incorrect_protocol_fee_rate);
 
+/// Tests a malleable match in which the quote amount is set outside of the
+/// quote bounds
+#[allow(non_snake_case)]
+async fn test_malleable_match__quote_amount_outside_bounds(ctx: TestContext) -> Result<()> {
+    let darkpool = ctx.darkpool_contract();
+    let (_, base_amount, payload) = setup_malleable_match_test(
+        false, // is_native
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
+
+    // Choose a quote amount outside the quote bounds
+    // To isolate the min and max bounds, we choose one that gives price improvement
+    // to the internal user, and defer the price improvement constraint to another
+    // test
+    let statement = &payload.valid_malleable_match_settle_atomic_statement;
+    let match_res = &statement.match_result;
+    let is_sell = statement.match_result.is_external_party_sell();
+    let quote_amount = if is_sell {
+        // If the external party is selling, try a quote amount lower than the minimum
+        // base amount's implied quote
+        let min_quote = match_res.price.unsafe_fixed_point_mul(match_res.min_base_amount);
+        min_quote - U256::from(1)
+    } else {
+        // If the external party is buying, try a quote amount greater than the
+        // maximum base amount's implied quote
+        let max_quote = match_res.price.unsafe_fixed_point_mul(match_res.max_base_amount);
+        max_quote + U256::from(1)
+    };
+
+    // Try submitting the match, should fail
+    let receiver = ctx.client.address();
+    let tx = darkpool.processMalleableAtomicMatchSettleWithReceiver(
+        quote_amount,
+        base_amount,
+        receiver,
+        serialize_to_calldata(&payload.internal_party_match_payload)?,
+        serialize_to_calldata(&statement)?,
+        serialize_to_calldata(&payload.match_atomic_proofs)?,
+        serialize_to_calldata(&payload.match_atomic_linking_proofs)?,
+    );
+    let is_err = send_tx(tx).await.is_err();
+    assert_true_result!(is_err)
+}
+integration_test_async!(test_malleable_match__quote_amount_outside_bounds);
+
+/// Test a malleable match in which the quote amount attempts to give price
+/// improvement to the external user. This is invalid, all price improvement
+/// over the reference price goes to the internal user
+#[allow(non_snake_case)]
+async fn test_malleable_match__invalid_price_improvement(ctx: TestContext) -> Result<()> {
+    let darkpool = ctx.darkpool_contract();
+    let (_, base_amount, payload) = setup_malleable_match_test(
+        false, // is_native
+        false, // use_gas_sponsor
+        &ctx,
+    )
+    .await?;
+
+    // Modify the quote amount to give price improvement to the external user
+    let statement = &payload.valid_malleable_match_settle_atomic_statement;
+    let match_res = &statement.match_result;
+    let is_sell = statement.match_result.is_external_party_sell();
+    let ref_quote_amount = match_res.price.unsafe_fixed_point_mul(base_amount);
+    let quote_amount = if is_sell {
+        // If the external party is selling, try a quote amount higher than the
+        // reference quote amount => higher price
+        ref_quote_amount + U256::from(1)
+    } else {
+        // If the external party is buying, try a quote amount lower than the
+        // reference quote amount => lower price
+        ref_quote_amount - U256::from(1)
+    };
+
+    // Try submitting the match, should fail
+    let receiver = ctx.client.address();
+    let tx = darkpool.processMalleableAtomicMatchSettleWithReceiver(
+        quote_amount,
+        base_amount,
+        receiver,
+        serialize_to_calldata(&payload.internal_party_match_payload)?,
+        serialize_to_calldata(&statement)?,
+        serialize_to_calldata(&payload.match_atomic_proofs)?,
+        serialize_to_calldata(&payload.match_atomic_linking_proofs)?,
+    );
+    let is_err = send_tx(tx).await.is_err();
+    assert_true_result!(is_err)
+}
+integration_test_async!(test_malleable_match__invalid_price_improvement);
+
 // -----------
 // | Helpers |
 // -----------

--- a/integration/src/tests/malleable_atomic_settlement.rs
+++ b/integration/src/tests/malleable_atomic_settlement.rs
@@ -25,7 +25,7 @@ use crate::{
 /// Test a basic malleable match
 #[allow(non_snake_case)]
 async fn test_malleable_match__basic(ctx: TestContext) -> Result<()> {
-    let (base_amount, payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, payload) = setup_malleable_match_test(
         false, // is_native
         false, // use_gas_sponsor
         &ctx,
@@ -34,6 +34,7 @@ async fn test_malleable_match__basic(ctx: TestContext) -> Result<()> {
     let receiver = ctx.client.address();
     submit_and_validate_malleable_match(
         receiver,
+        quote_amount,
         base_amount,
         payload.internal_party_match_payload,
         payload.valid_malleable_match_settle_atomic_statement,
@@ -50,7 +51,7 @@ integration_test_async!(test_malleable_match__basic);
 /// Test a malleable match on the native asset
 #[allow(non_snake_case)]
 async fn test_malleable_match__native(ctx: TestContext) -> Result<()> {
-    let (base_amount, payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, payload) = setup_malleable_match_test(
         true,  // is_native
         false, // use_gas_sponsor
         &ctx,
@@ -59,6 +60,7 @@ async fn test_malleable_match__native(ctx: TestContext) -> Result<()> {
     let receiver = ctx.client.address();
     submit_and_validate_malleable_match(
         receiver,
+        quote_amount,
         base_amount,
         payload.internal_party_match_payload,
         payload.valid_malleable_match_settle_atomic_statement,
@@ -75,7 +77,7 @@ integration_test_async!(test_malleable_match__native);
 /// Test a malleable match with a non-sender as the receiver
 #[allow(non_snake_case)]
 async fn test_malleable_match__non_sender_receiver(ctx: TestContext) -> Result<()> {
-    let (base_amount, payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, payload) = setup_malleable_match_test(
         false, // is_native
         false, // use_gas_sponsor
         &ctx,
@@ -84,6 +86,7 @@ async fn test_malleable_match__non_sender_receiver(ctx: TestContext) -> Result<(
     let receiver = Address::random();
     submit_and_validate_malleable_match(
         receiver,
+        quote_amount,
         base_amount,
         payload.internal_party_match_payload,
         payload.valid_malleable_match_settle_atomic_statement,
@@ -100,7 +103,7 @@ integration_test_async!(test_malleable_match__non_sender_receiver);
 /// Test a malleable match with a non-sender as the receiver on the native asset
 #[allow(non_snake_case)]
 async fn test_malleable_match__non_sender_receiver_native(ctx: TestContext) -> Result<()> {
-    let (base_amount, payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, payload) = setup_malleable_match_test(
         true,  // is_native
         false, // use_gas_sponsor
         &ctx,
@@ -109,6 +112,7 @@ async fn test_malleable_match__non_sender_receiver_native(ctx: TestContext) -> R
     let receiver = Address::random();
     submit_and_validate_malleable_match(
         receiver,
+        quote_amount,
         base_amount,
         payload.internal_party_match_payload,
         payload.valid_malleable_match_settle_atomic_statement,
@@ -129,14 +133,16 @@ integration_test_async!(test_malleable_match__non_sender_receiver_native);
 #[allow(non_snake_case)]
 async fn test_malleable_match__non_native_invalid_value(ctx: TestContext) -> Result<()> {
     let darkpool = ctx.darkpool_contract();
-    let (base_amount, payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, payload) = setup_malleable_match_test(
         false, // is_native
         true,  // use_gas_sponsor
         &ctx,
     )
     .await?;
+    let receiver = ctx.client.address();
     let tx = darkpool
-        .processMalleableAtomicMatchSettle(
+        .processMalleableAtomicMatchSettleWithReceiver(
+            quote_amount,
             base_amount,
             receiver,
             serialize_to_calldata(&payload.internal_party_match_payload)?,
@@ -154,7 +160,7 @@ integration_test_async!(test_malleable_match__non_native_invalid_value);
 #[allow(non_snake_case)]
 async fn test_malleable_match__native_value_too_small(ctx: TestContext) -> Result<()> {
     let darkpool = ctx.darkpool_contract();
-    let (base_amount, mut payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, mut payload) = setup_malleable_match_test(
         true,  // is_native
         false, // use_gas_sponsor
         &ctx,
@@ -165,7 +171,8 @@ async fn test_malleable_match__native_value_too_small(ctx: TestContext) -> Resul
     let receiver = ctx.client.address();
     let invalid_value = base_amount - U256::from(1);
     let tx = darkpool
-        .processMalleableAtomicMatchSettle(
+        .processMalleableAtomicMatchSettleWithReceiver(
+            quote_amount,
             base_amount,
             receiver,
             serialize_to_calldata(&payload.internal_party_match_payload)?,
@@ -184,7 +191,7 @@ integration_test_async!(test_malleable_match__native_value_too_small);
 async fn test_malleable_match__incorrect_protocol_fee_rate(ctx: TestContext) -> Result<()> {
     let mut rng = thread_rng();
     let darkpool = ctx.darkpool_contract();
-    let (base_amount, mut payload) = setup_malleable_match_test(
+    let (quote_amount, base_amount, mut payload) = setup_malleable_match_test(
         false, // is_native
         false, // use_gas_sponsor
         &ctx,
@@ -201,7 +208,8 @@ async fn test_malleable_match__incorrect_protocol_fee_rate(ctx: TestContext) -> 
     fee_rate.protocol_fee_rate.repr -= ScalarField::from(1);
     let receiver = ctx.client.address();
 
-    let tx = darkpool.processMalleableAtomicMatchSettle(
+    let tx = darkpool.processMalleableAtomicMatchSettleWithReceiver(
+        quote_amount,
         base_amount,
         receiver,
         serialize_to_calldata(&payload.internal_party_match_payload)?,
@@ -220,8 +228,10 @@ integration_test_async!(test_malleable_match__incorrect_protocol_fee_rate);
 
 /// Submit a malleable match, and validate the balances of all parties before
 /// and after
+#[allow(clippy::too_many_arguments)]
 async fn submit_and_validate_malleable_match(
     receiver: Address,
+    quote_amount: U256,
     base_amount: U256,
     internal_party_payload: MatchPayload,
     statement: ValidMalleableMatchSettleAtomicStatement,
@@ -242,7 +252,8 @@ async fn submit_and_validate_malleable_match(
     let value = if native_sell { base_amount } else { U256::ZERO };
 
     let tx = darkpool
-        .processMalleableAtomicMatchSettle(
+        .processMalleableAtomicMatchSettleWithReceiver(
+            quote_amount,
             base_amount,
             receiver,
             serialize_to_calldata(&internal_party_payload)?,

--- a/integration/src/utils/malleable_match.rs
+++ b/integration/src/utils/malleable_match.rs
@@ -27,11 +27,13 @@ use super::{
 const MAX_TRADE_SIZE: Amount = 1u128 << 15;
 
 /// Generate the calldata for a malleable match
+///
+/// Returns the quote amount, base amount, and the payload
 pub async fn setup_malleable_match_test(
     is_native: bool,
     use_gas_sponsor: bool,
     ctx: &TestContext,
-) -> Result<(U256, ProcessMalleableMatchSettleAtomicData)> {
+) -> Result<(U256, U256, ProcessMalleableMatchSettleAtomicData)> {
     let mut rng = thread_rng();
     let merkle_root = ctx.get_root_scalar().await?;
     let protocol_fee = ctx.get_protocol_fee().await?;
@@ -70,7 +72,7 @@ pub async fn setup_malleable_match_test(
         payload.valid_malleable_match_settle_atomic_statement.match_result.base_mint =
             native_eth_address();
     }
-    Ok((U256::from(base_amount), payload))
+    Ok((U256::from(quote_amount), U256::from(base_amount), payload))
 }
 
 /// Generate a random [`BoundedMatchResult`]

--- a/integration/src/utils/sponsored_match.rs
+++ b/integration/src/utils/sponsored_match.rs
@@ -67,6 +67,8 @@ pub struct SponsoredMalleableMatchSettleAtomicData {
     pub refund_address: Address,
     /// The base amount swapped
     pub base_amount: U256,
+    /// The quote amount swapped
+    pub quote_amount: U256,
     /// The address to receive the tokens
     pub receiver: Address,
     /// The sponsorship nonce
@@ -167,7 +169,7 @@ pub async fn setup_sponsored_malleable_match_test(
     send_tx(ctx.gas_sponsor_contract().unpause()).await?;
 
     // Setup malleable match test data
-    let (base_amount, process_malleable_match_settle_atomic_data) =
+    let (quote_amount, base_amount, process_malleable_match_settle_atomic_data) =
         setup_malleable_match_test(options.trade_native_eth, true /* use_gas_sponsor */, ctx)
             .await?;
 
@@ -206,6 +208,7 @@ pub async fn setup_sponsored_malleable_match_test(
         refund_native_eth: !options.in_kind_refund,
         refund_amount: REFUND_AMOUNT,
         base_amount,
+        quote_amount,
     })
 }
 
@@ -304,6 +307,7 @@ pub async fn sponsor_malleable_match_with_test_data(
         process_malleable_match_settle_atomic_data: test_data,
         refund_address,
         base_amount,
+        quote_amount,
         receiver,
         nonce,
         refund_native_eth,
@@ -327,6 +331,7 @@ pub async fn sponsor_malleable_match_with_test_data(
     // Prepare the transaction
     let settle_tx = gas_sponsor
         .sponsorMalleableAtomicMatchSettleWithRefundOptions(
+            quote_amount,
             base_amount,
             receiver,
             internal_party_payload,

--- a/scripts/src/utils.rs
+++ b/scripts/src/utils.rs
@@ -396,9 +396,9 @@ pub fn get_rustflags_for_contract(contract: &StylusContract) -> String {
 /// given contract
 pub fn get_wasm_opt_flags_for_contract(contract: &StylusContract) -> &'static str {
     match contract {
-        StylusContract::DarkpoolTestContract | StylusContract::GasSponsor => {
-            AGGRESSIVE_SIZE_OPTIMIZATION_FLAG
-        },
+        StylusContract::DarkpoolTestContract
+        | StylusContract::GasSponsor
+        | StylusContract::CoreMalleableMatchSettle => AGGRESSIVE_SIZE_OPTIMIZATION_FLAG,
         _ => AGGRESSIVE_OPTIMIZATION_FLAG,
     }
 }


### PR DESCRIPTION
### Purpose
This PR updates the rest of the repo to ingest the changes from #334. Specifically:
- Updates the gas sponsorship contract to use `quote_amount` in the malleable match path
- Updates integration tests to use `quote_amount` in malleable match tests
- Adds new integration tests for invalid quote amounts in a malleable match

### Testing
- [x] Integration tests pass 